### PR TITLE
Convert deployment datatypes to frozen Pydantic models

### DIFF
--- a/src/afft/deployment/loader.py
+++ b/src/afft/deployment/loader.py
@@ -2,7 +2,6 @@
 
 import msgspec
 
-from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +10,6 @@ from afft.io.config_io import read_config
 from .types import (
     DeploymentConfig,
     DeploymentInfo,
-    DeploymentMetadata,
     TopsideUsblModemConfig,
     UsblUncertaintyProfile,
 )
@@ -67,27 +65,8 @@ def load_deployment_config(
     extrinsics_entry: dict[str, Any] = topside_extrinsics[extrinsics_label]
     uncertainty_entry: dict[str, Any] = uncertainty_profiles[uncertainty_label]
 
-    usbl_modem = TopsideUsblModemConfig(
-        locx=extrinsics_entry["locx"],
-        locy=extrinsics_entry["locy"],
-        locz=extrinsics_entry["locz"],
-        rotx=extrinsics_entry["rotx"],
-        roty=extrinsics_entry["roty"],
-        rotz=extrinsics_entry["rotz"],
-        comment=extrinsics_entry.get("comment", ""),
-    )
-
-    usbl_uncertainty = UsblUncertaintyProfile(
-        horizontal_position_std=uncertainty_entry["horizontal_position_std"],
-        slant_range_std=uncertainty_entry["slant_range_std"],
-        bearing_std=uncertainty_entry["bearing_std"],
-        ship_x_std=uncertainty_entry["ship_x_std"],
-        ship_y_std=uncertainty_entry["ship_y_std"],
-        ship_z_std=uncertainty_entry["ship_z_std"],
-        ship_heading_std=uncertainty_entry["ship_heading_std"],
-        ship_roll_std=uncertainty_entry["ship_roll_std"],
-        ship_pitch_std=uncertainty_entry["ship_pitch_std"],
-    )
+    usbl_modem = TopsideUsblModemConfig.model_validate(extrinsics_entry)
+    usbl_uncertainty = UsblUncertaintyProfile.model_validate(uncertainty_entry)
 
     return DeploymentConfig(
         label=deployment_label,
@@ -115,24 +94,36 @@ def read_deployment_info(path: Path) -> list[DeploymentInfo]:
     deployments: list[DeploymentInfo] = []
     for entry in raw.get("deployments", []):
         metadata: dict[str, Any] = entry.get("metadata", {})
+        # Fill defaults for missing / legacy fields so older deployment TOML
+        # files that predate some fields still load, then validate.
         deployments.append(
-            DeploymentInfo(
-                deployment_label=entry["deployment_label"],
-                deployment_datetime=entry["deployment_datetime"],
-                deployment_platform=entry.get("deployment_platform", ""),
-                metadata=DeploymentMetadata(
-                    acfr_deployment_label=metadata["acfr_deployment_label"],
-                    acfr_campaign_label=metadata["acfr_campaign_label"],
-                    acfr_platform_label=metadata.get("acfr_platform_label", ""),
-                    origin_latitude=metadata.get("origin_latitude", 0.0),
-                    origin_longitude=metadata.get("origin_longitude", 0.0),
-                    magnetic_variation=metadata.get("magnetic_variation", 0.0),
-                    message_topics=metadata.get("message_topics", []),
-                    renav_labels=metadata.get("renav_labels", []),
-                    camera_calibration_files=metadata.get(
-                        "camera_calibration_files", []
-                    ),
-                ),
+            DeploymentInfo.model_validate(
+                {
+                    "deployment_label": entry["deployment_label"],
+                    "deployment_datetime": entry["deployment_datetime"],
+                    "deployment_platform": entry.get("deployment_platform", ""),
+                    "metadata": {
+                        "acfr_deployment_label": metadata[
+                            "acfr_deployment_label"
+                        ],
+                        "acfr_campaign_label": metadata["acfr_campaign_label"],
+                        "acfr_platform_label": metadata.get(
+                            "acfr_platform_label", ""
+                        ),
+                        "origin_latitude": metadata.get("origin_latitude", 0.0),
+                        "origin_longitude": metadata.get(
+                            "origin_longitude", 0.0
+                        ),
+                        "magnetic_variation": metadata.get(
+                            "magnetic_variation", 0.0
+                        ),
+                        "message_topics": metadata.get("message_topics", []),
+                        "renav_labels": metadata.get("renav_labels", []),
+                        "camera_calibration_files": metadata.get(
+                            "camera_calibration_files", []
+                        ),
+                    },
+                }
             )
         )
     return deployments
@@ -151,5 +142,12 @@ def write_deployment_info(
     deployments: Deployment info objects to serialize.
     """
     path.write_bytes(
-        msgspec.toml.encode({"deployments": [asdict(d) for d in deployments]})
+        msgspec.toml.encode(
+            {
+                "deployments": [
+                    deployment.model_dump(mode="python")
+                    for deployment in deployments
+                ]
+            }
+        )
     )

--- a/src/afft/deployment/types.py
+++ b/src/afft/deployment/types.py
@@ -1,11 +1,11 @@
 """Data types for AUV deployment configuration and metadata."""
 
-from dataclasses import dataclass
 from datetime import datetime
 
+from pydantic import BaseModel, ConfigDict
 
-@dataclass(slots=True, frozen=True)
-class UsblUncertaintyProfile:
+
+class UsblUncertaintyProfile(BaseModel):
     """
     Deployment-calibrated USBL uncertainty profile (1σ standard deviations).
 
@@ -22,6 +22,8 @@ class UsblUncertaintyProfile:
     ship_pitch_std: Ship pitch uncertainty in radians.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     horizontal_position_std: float
     slant_range_std: float
     bearing_std: float
@@ -33,8 +35,7 @@ class UsblUncertaintyProfile:
     ship_pitch_std: float
 
 
-@dataclass(slots=True, frozen=True)
-class TopsideUsblModemConfig:
+class TopsideUsblModemConfig(BaseModel):
     """
     Position and orientation of the USBL transceiver in the ship reference frame.
 
@@ -49,6 +50,8 @@ class TopsideUsblModemConfig:
     comment: Optional note about the calibration.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     locx: float
     locy: float
     locz: float
@@ -58,8 +61,7 @@ class TopsideUsblModemConfig:
     comment: str = ""
 
 
-@dataclass(slots=True, frozen=True)
-class DeploymentConfig:
+class DeploymentConfig(BaseModel):
     """
     Configuration for a single AUV deployment.
 
@@ -73,6 +75,8 @@ class DeploymentConfig:
     sensor_keys: Identifiers for sensors active during this deployment.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     label: str
     ship_name: str
     date: str
@@ -81,8 +85,7 @@ class DeploymentConfig:
     sensor_keys: tuple[str, ...] = ()
 
 
-@dataclass(slots=True, frozen=True)
-class DeploymentMetadata:
+class DeploymentMetadata(BaseModel):
     """
     Collected metadata for a single AUV deployment.
 
@@ -99,6 +102,8 @@ class DeploymentMetadata:
     camera_calibration_files: Sorted unique camera calibration filenames.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     acfr_deployment_label: str
     acfr_campaign_label: str
     acfr_platform_label: str
@@ -110,8 +115,7 @@ class DeploymentMetadata:
     camera_calibration_files: list[str]
 
 
-@dataclass(slots=True, frozen=True)
-class DeploymentInfo:
+class DeploymentInfo(BaseModel):
     """
     Core identity fields for a single AUV deployment.
 
@@ -122,6 +126,8 @@ class DeploymentInfo:
     deployment_platform: Squidle+ platform name for this deployment.
     metadata: Collected deployment metadata.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     deployment_label: str
     deployment_datetime: datetime


### PR DESCRIPTION
Closes #165.

Convert the datatypes in `deployment/types.py` from frozen dataclasses to frozen Pydantic v2 models (`ConfigDict(frozen=True)`) and migrate their IO, unifying the `deployment/` datatype surface on Pydantic ahead of #159. This is a behaviour-preserving refactor: field names, types, and the on-disk TOML shape are unchanged, so existing `config/acfr_deployments*.toml` and `deployment_configs*.toml` consumers are unaffected.

## Changes

`deployment/types.py`:
- `DeploymentConfig`, `DeploymentMetadata`, `UsblUncertaintyProfile`, `TopsideUsblModemConfig`, `DeploymentInfo` are now frozen Pydantic v2 models. Field names, types, defaults, and the `Attributes` docstring style are unchanged.
- `message_topics` is left without a model-level default (it is promoted to `telemetry.topics` in #159).

`deployment/loader.py`:
- `read_deployment_info` builds via `model_validate`, keeping the explicit dict->model mapping that fills lenient defaults for missing / legacy metadata fields, so older `acfr_deployments*.toml` files still load.
- `write_deployment_info` serializes via `model_dump(mode="python")` + the existing msgspec TOML encoder, keeping `deployment_datetime` a native TOML datetime.
- `load_deployment_config` builds the USBL modem and uncertainty profiles via `model_validate`.

## Verification

- Round-trips `config/acfr_deployments.toml` (52 deployments) with `read == write == read`; `deployment_datetime` preserved as a timezone-aware datetime; frozen enforced.
- Lenient read confirmed against a legacy metadata dict missing most fields.
- `load_deployment_config` returns behaviourally-equal configs.
- `ruff check`, `ruff format`, `mypy`, and `pytest` (80 passed) all pass for the touched module.

Prerequisite for #159.