### PR TITLE
Add SEABED localizer config types, parser, and IO

### DIFF
--- a/src/afft/seabed/__init__.py
+++ b/src/afft/seabed/__init__.py
@@ -1,6 +1,14 @@
 """Package for message processing functionality for SEABED-class AUVs."""
 
 from .concrete_messages import get_message_type as get_message_type
+from .localizer_io import read_localizer_config as read_localizer_config
+from .localizer_io import write_localizer_config as write_localizer_config
+from .localizer_parsers import parse_localizer_config as parse_localizer_config
+from .localizer_types import AuvSensorConfig as AuvSensorConfig
+from .localizer_types import Origin as Origin
+from .localizer_types import SeabedLocalizerConfig as SeabedLocalizerConfig
+from .localizer_types import SensorPoseEntry as SensorPoseEntry
+from .localizer_types import ShipSensorConfig as ShipSensorConfig
 from .message_interfaces import Message as Message
 from .message_interfaces import MessageParser as MessageParser
 from .message_parsers import get_message_parser as get_message_parser

--- a/src/afft/seabed/localizer_io.py
+++ b/src/afft/seabed/localizer_io.py
@@ -1,0 +1,38 @@
+"""TOML round-trip IO for the parsed SEABED localizer config structure."""
+
+from pathlib import Path
+
+from afft.io import read_config, write_config
+
+from .localizer_types import SeabedLocalizerConfig
+
+
+def read_localizer_config(path: Path) -> SeabedLocalizerConfig:
+    """
+    Reads a SeabedLocalizerConfig from our TOML representation.
+
+    Inverse of ``write_localizer_config``. Purely IO — no vendor-format logic.
+
+    Arguments
+    ---------
+    path: Path to a TOML file written by ``write_localizer_config``.
+
+    Returns
+    -------
+    The parsed SeabedLocalizerConfig.
+    """
+    return SeabedLocalizerConfig.model_validate(read_config(path))
+
+
+def write_localizer_config(path: Path, config: SeabedLocalizerConfig) -> None:
+    """
+    Writes a SeabedLocalizerConfig to our TOML representation.
+
+    Purely IO — no vendor-format logic.
+
+    Arguments
+    ---------
+    path: Destination TOML file path.
+    config: The localizer config to persist.
+    """
+    write_config(config.model_dump(), path)

--- a/src/afft/seabed/localizer_parsers.py
+++ b/src/afft/seabed/localizer_parsers.py
@@ -46,11 +46,11 @@ def parse_localizer_config(path: Path) -> SeabedLocalizerConfig:
     -------
     The parsed SeabedLocalizerConfig.
     """
-    lines = read_lines(path)
+    lines: list[str] = read_lines(path)
 
-    auv_index = _find_banner(lines, AUV_BANNER)
-    ship_index = _find_banner(lines, SHIP_BANNER)
-    active_keys = {key for key, _ in _iter_entries(lines)}
+    auv_index: int | None = _find_banner(lines, AUV_BANNER)
+    ship_index: int | None = _find_banner(lines, SHIP_BANNER)
+    active_keys: set[str] = {key for key, _ in _iter_entries(lines)}
 
     missing: list[str] = []
     if auv_index is None:
@@ -97,7 +97,7 @@ def _iter_entries(lines: list[str]) -> list[Entry]:
     """
     entries: list[Entry] = []
     for line in lines:
-        fields = _strip_comment(line).split()
+        fields: list[str] = _strip_comment(line).split()
         if len(fields) < 2:
             continue
         entries.append((fields[0], fields[1]))
@@ -119,7 +119,7 @@ def _match_pose(key: str) -> tuple[str, str] | None:
     A pose key matches ``<NAME>_POSE_<SUFFIX>`` where ``<SUFFIX>`` is one of
     the six pose components; ``field`` is the SensorPoseEntry attribute name.
     """
-    parts = key.split("_POSE_")
+    parts: list[str] = key.split("_POSE_")
     if len(parts) != 2 or parts[1] not in POSE_COMPONENTS:
         return None
     return parts[0], POSE_COMPONENTS[parts[1]]
@@ -150,7 +150,7 @@ def _parse_poses(lines: list[str]) -> list[SensorPoseEntry]:
     components: dict[str, dict[str, float]] = {}
     order: list[str] = []
     for key, value in _iter_entries(lines):
-        match = _match_pose(key)
+        match: tuple[str, str] | None = _match_pose(key)
         if match is None:
             continue
         name, field = match

--- a/src/afft/seabed/localizer_parsers.py
+++ b/src/afft/seabed/localizer_parsers.py
@@ -1,0 +1,175 @@
+"""Parser for the raw SEABED localizer config (``*.SEABED.localiser.cfg``)."""
+
+from pathlib import Path
+
+from afft.io import read_lines
+
+from .localizer_types import (
+    AuvSensorConfig,
+    Origin,
+    SeabedLocalizerConfig,
+    SensorPoseEntry,
+    ShipSensorConfig,
+)
+
+type Entry = tuple[str, str]
+
+AUV_BANNER: str = "AUV Sensor Configuration"
+SHIP_BANNER: str = "Ship Sensor Configuration"
+
+ORIGIN_KEYS: tuple[str, str] = ("LATITUDE", "LONGITUDE")
+
+# Maps a ``<NAME>_POSE_<SUFFIX>`` suffix to the SensorPoseEntry field.
+POSE_COMPONENTS: dict[str, str] = {
+    "X": "locx",
+    "Y": "locy",
+    "Z": "locz",
+    "PHI": "rotx",
+    "THETA": "roty",
+    "PSI": "rotz",
+}
+
+
+def parse_localizer_config(path: Path) -> SeabedLocalizerConfig:
+    """
+    Parses a raw SEABED localizer config file into a typed structure.
+
+    Only the geodetic origin and the AUV / ship sensor extrinsic poses are
+    modeled; the EKF-tuning bulk is read past and ignored. The two section
+    banners partition the tail of the file into the AUV and ship regions.
+
+    Arguments
+    ---------
+    path: Path to a ``*.SEABED.localiser.cfg`` file.
+
+    Returns
+    -------
+    The parsed SeabedLocalizerConfig.
+    """
+    lines = read_lines(path)
+
+    auv_index = _find_banner(lines, AUV_BANNER)
+    ship_index = _find_banner(lines, SHIP_BANNER)
+    active_keys = {key for key, _ in _iter_entries(lines)}
+
+    missing: list[str] = []
+    if auv_index is None:
+        missing.append(AUV_BANNER)
+    if ship_index is None:
+        missing.append(SHIP_BANNER)
+    for key in ORIGIN_KEYS:
+        if key not in active_keys:
+            missing.append(key)
+    if missing:
+        raise ValueError(
+            f"missing required localizer config elements: {', '.join(missing)}"
+        )
+
+    assert auv_index is not None and ship_index is not None
+    if auv_index >= ship_index:
+        raise ValueError(
+            "AUV sensor banner must precede the ship sensor banner"
+        )
+
+    return SeabedLocalizerConfig(
+        origin=_parse_origin(lines[:auv_index]),
+        auv_sensors=AuvSensorConfig(
+            sensor_poses=_parse_poses(lines[auv_index:ship_index])
+        ),
+        ship_sensors=ShipSensorConfig(
+            sensor_poses=_parse_poses(lines[ship_index:])
+        ),
+    )
+
+
+def _strip_comment(line: str) -> str:
+    """Strips an inline or full-line ``#`` comment and surrounding space."""
+    return line.split("#", 1)[0].strip()
+
+
+def _iter_entries(lines: list[str]) -> list[Entry]:
+    """
+    Yields ``(key, value)`` for each active line.
+
+    The value is the first whitespace token after the key; inline ``#…``
+    comments (including commented-out alternate values) are stripped first.
+    Comment-only and blank lines yield nothing.
+    """
+    entries: list[Entry] = []
+    for line in lines:
+        fields = _strip_comment(line).split()
+        if len(fields) < 2:
+            continue
+        entries.append((fields[0], fields[1]))
+    return entries
+
+
+def _find_banner(lines: list[str], banner: str) -> int | None:
+    """Returns the index of the first comment line containing ``banner``."""
+    for index, line in enumerate(lines):
+        if line.lstrip().startswith("#") and banner in line:
+            return index
+    return None
+
+
+def _match_pose(key: str) -> tuple[str, str] | None:
+    """
+    Splits a pose key into ``(name, field)`` or returns ``None``.
+
+    A pose key matches ``<NAME>_POSE_<SUFFIX>`` where ``<SUFFIX>`` is one of
+    the six pose components; ``field`` is the SensorPoseEntry attribute name.
+    """
+    parts = key.split("_POSE_")
+    if len(parts) != 2 or parts[1] not in POSE_COMPONENTS:
+        return None
+    return parts[0], POSE_COMPONENTS[parts[1]]
+
+
+def _parse_origin(lines: list[str]) -> Origin:
+    """
+    Parses the geodetic origin from the origin region.
+
+    Operators leave several site presets active; the effective origin is the
+    last active ``LATITUDE`` / ``LONGITUDE`` (sequential-reader semantics —
+    later assignment overwrites), matching the true deployment origin.
+    """
+    found: dict[str, float] = {}
+    for key, value in _iter_entries(lines):
+        if key in ORIGIN_KEYS:
+            found[key] = float(value)
+    return Origin(latitude=found["LATITUDE"], longitude=found["LONGITUDE"])
+
+
+def _parse_poses(lines: list[str]) -> list[SensorPoseEntry]:
+    """
+    Groups ``<NAME>_POSE_*`` families within a region into pose entries.
+
+    Missing translation/rotation components are zero-filled. A duplicated
+    active component within a family raises ``ValueError``.
+    """
+    components: dict[str, dict[str, float]] = {}
+    order: list[str] = []
+    for key, value in _iter_entries(lines):
+        match = _match_pose(key)
+        if match is None:
+            continue
+        name, field = match
+        if name not in components:
+            components[name] = {}
+            order.append(name)
+        if field in components[name]:
+            raise ValueError(f"duplicate pose entry: {key}")
+        components[name][field] = float(value)
+
+    return [
+        SensorPoseEntry(
+            label=name.lower(),
+            locx=components[name].get("locx", 0.0),
+            locy=components[name].get("locy", 0.0),
+            locz=components[name].get("locz", 0.0),
+            rotx=components[name].get("rotx", 0.0),
+            roty=components[name].get("roty", 0.0),
+            rotz=components[name].get("rotz", 0.0),
+        )
+        for name in order
+    ]

--- a/src/afft/seabed/localizer_types.py
+++ b/src/afft/seabed/localizer_types.py
@@ -1,0 +1,95 @@
+"""Data types for the SEABED localizer config (``*.SEABED.localiser.cfg``)."""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Origin(BaseModel):
+    """
+    Geodetic origin of the deployment.
+
+    Attributes
+    ----------
+    latitude: Latitude in decimal degrees.
+    longitude: Longitude in decimal degrees.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    latitude: float
+    longitude: float
+
+
+class SensorPoseEntry(BaseModel):
+    """
+    A named sensor extrinsic pose, parsed from a ``<NAME>_POSE_*`` family.
+
+    Frame: SNAME body frame (x forward, y starboard, z down). Translation in
+    metres; rotation in radians as ZYX intrinsic Euler (yaw ``rotz``, pitch
+    ``roty``, roll ``rotx``).
+
+    Attributes
+    ----------
+    label: Sensor identifier — the lowercased ``<NAME>`` prefix of the pose
+        family (e.g. ``"dvl"``, ``"usbl_transceiver"``, ``"nav_frame"``).
+    locx, locy, locz: Translation in metres (from ``_X`` / ``_Y`` / ``_Z``).
+    rotx, roty, rotz: Roll / pitch / yaw in radians (from ``_PHI`` / ``_THETA``
+        / ``_PSI``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    label: str
+    locx: float
+    locy: float
+    locz: float
+    rotx: float
+    roty: float
+    rotz: float
+
+
+class AuvSensorConfig(BaseModel):
+    """
+    AUV sensor extrinsics, in the vehicle (SNAME) body frame.
+
+    Attributes
+    ----------
+    sensor_poses: One entry per pose family in the AUV section.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_poses: list[SensorPoseEntry]
+
+
+class ShipSensorConfig(BaseModel):
+    """
+    Ship sensor extrinsics, in the ship frame.
+
+    Attributes
+    ----------
+    sensor_poses: One entry per pose family in the ship section.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_poses: list[SensorPoseEntry]
+
+
+class SeabedLocalizerConfig(BaseModel):
+    """
+    The description-relevant entries of a SEABED localizer config.
+
+    Attributes
+    ----------
+    origin: Geodetic origin (``LATITUDE`` / ``LONGITUDE``).
+    auv_sensors: AUV sensor extrinsics (``# AUV Sensor Configuration``
+        section).
+    ship_sensors: Ship sensor extrinsics (``# Ship Sensor Configuration``
+        section).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    origin: Origin
+    auv_sensors: AuvSensorConfig
+    ship_sensors: ShipSensorConfig

--- a/tests/test_localizer_config.py
+++ b/tests/test_localizer_config.py
@@ -1,0 +1,173 @@
+"""Tests for SEABED localizer config parsing and IO."""
+
+from pathlib import Path
+
+import pytest
+
+from afft.seabed import (
+    SeabedLocalizerConfig,
+    parse_localizer_config,
+    read_localizer_config,
+    write_localizer_config,
+)
+
+SAMPLE_CFG: str = """\
+################################################################################
+#               Configuration File for the Seabed Localiser                    #
+################################################################################
+
+# WA site preset (commented out — ignored)
+#LONGITUDE 115.44043
+#LATITUDE -32.02058
+
+# Leftover active preset (overwritten by the last active pair)
+LONGITUDE 114.535954
+LATITUDE -29.948109
+
+# Active deployment origin
+LONGITUDE  113.94725
+LATITUDE  -28.81372
+
+VERBOSITY 0
+USE_EKF true
+USE_ATT_SOURCE "DVL"
+LOG_RELATIVE_POSE_INNOVATIONS true
+
+#---------------------------------------#
+# AUV Sensor Configuration              #
+#---------------------------------------#
+
+# Depth sensor pose (translation only)
+DEPTH_SENSOR_POSE_X  0.4   # FIXME: measure this value
+DEPTH_SENSOR_POSE_Y  0.0
+DEPTH_SENSOR_POSE_Z  -0.23
+
+# DVL pose
+DVL_POSE_X      0.0
+DVL_POSE_Y      0.0
+DVL_POSE_Z      0.0
+DVL_POSE_PHI    0.0
+DVL_POSE_THETA  3.141592653
+DVL_POSE_PSI    -1.570796327
+
+# DeltaT pose with multiple inline comment alternates
+DELTAT_POSE_X      0.588   # 0.0 # 0.59
+DELTAT_POSE_Y      0.250   # 0.0 # 0.025
+DELTAT_POSE_Z      0.048
+DELTAT_POSE_PHI    0.0076
+DELTAT_POSE_THETA  0.084
+DELTAT_POSE_PSI    -3.125
+
+#---------------------------------------#
+# Ship Sensor Configuration             #
+#---------------------------------------#
+
+# Commented-out alternate transceiver preset (ignored)
+#USBL_TRANSCEIVER_POSE_X -3.16249350
+#USBL_TRANSCEIVER_POSE_Y 6.99607807
+
+USBL_TRANSCEIVER_POSE_X     -5.715
+USBL_TRANSCEIVER_POSE_Y     -1.258
+USBL_TRANSCEIVER_POSE_Z      1.352
+USBL_TRANSCEIVER_POSE_PHI    0.3316
+USBL_TRANSCEIVER_POSE_THETA  0.0
+USBL_TRANSCEIVER_POSE_PSI    0.0
+"""
+
+
+def _write_cfg(directory: Path, contents: str) -> Path:
+    """Writes localizer config contents into a temp file and returns path."""
+    path = directory / "sample.SEABED.localiser.cfg"
+    path.write_text(contents)
+    return path
+
+
+def test_parse_populates_origin_and_sections(tmp_path: Path) -> None:
+    path = _write_cfg(tmp_path, SAMPLE_CFG)
+
+    config = parse_localizer_config(path)
+
+    # Last active origin pair wins; commented and earlier presets ignored.
+    assert config.origin.latitude == -28.81372
+    assert config.origin.longitude == 113.94725
+
+    auv_labels = [pose.label for pose in config.auv_sensors.sensor_poses]
+    assert auv_labels == ["depth_sensor", "dvl", "deltat"]
+
+    ship_labels = [pose.label for pose in config.ship_sensors.sensor_poses]
+    assert ship_labels == ["usbl_transceiver"]
+
+
+def test_pose_grouping_and_zero_fill(tmp_path: Path) -> None:
+    path = _write_cfg(tmp_path, SAMPLE_CFG)
+
+    config = parse_localizer_config(path)
+    poses = {p.label: p for p in config.auv_sensors.sensor_poses}
+
+    # Translation-only DEPTH_SENSOR zero-fills the rotation components.
+    depth = poses["depth_sensor"]
+    assert (depth.locx, depth.locy, depth.locz) == (0.4, 0.0, -0.23)
+    assert (depth.rotx, depth.roty, depth.rotz) == (0.0, 0.0, 0.0)
+
+    # DELTAT keeps only the first value, never the commented alternates.
+    deltat = poses["deltat"]
+    assert deltat.locx == 0.588
+    assert deltat.locy == 0.250
+    assert deltat.rotz == -3.125
+
+
+def test_usbl_lands_in_ship_section(tmp_path: Path) -> None:
+    path = _write_cfg(tmp_path, SAMPLE_CFG)
+
+    config = parse_localizer_config(path)
+
+    usbl = config.ship_sensors.sensor_poses[0]
+    assert usbl.label == "usbl_transceiver"
+    assert (usbl.locx, usbl.locy, usbl.locz) == (-5.715, -1.258, 1.352)
+    assert usbl.rotx == 0.3316
+
+
+def test_innovation_key_not_mistaken_for_pose(tmp_path: Path) -> None:
+    path = _write_cfg(tmp_path, SAMPLE_CFG)
+
+    config = parse_localizer_config(path)
+
+    # LOG_RELATIVE_POSE_INNOVATIONS must not surface as a sensor pose.
+    labels = [p.label for p in config.auv_sensors.sensor_poses]
+    assert "log_relative" not in labels
+
+
+def test_missing_banner_and_origin_raise_aggregated(tmp_path: Path) -> None:
+    contents = "VERBOSITY 0\nUSE_EKF true\n"
+    path = _write_cfg(tmp_path, contents)
+
+    with pytest.raises(ValueError) as excinfo:
+        parse_localizer_config(path)
+
+    message = str(excinfo.value)
+    assert "AUV Sensor Configuration" in message
+    assert "Ship Sensor Configuration" in message
+    assert "LATITUDE" in message
+    assert "LONGITUDE" in message
+
+
+def test_duplicate_pose_component_raises(tmp_path: Path) -> None:
+    contents = SAMPLE_CFG.replace(
+        "DVL_POSE_Y      0.0", "DVL_POSE_Y      0.0\nDVL_POSE_X      9.9"
+    )
+    path = _write_cfg(tmp_path, contents)
+
+    with pytest.raises(ValueError):
+        parse_localizer_config(path)
+
+
+def test_io_round_trips(tmp_path: Path) -> None:
+    path = _write_cfg(tmp_path, SAMPLE_CFG)
+    config = parse_localizer_config(path)
+
+    toml_path = tmp_path / "config.toml"
+    write_localizer_config(toml_path, config)
+    restored = read_localizer_config(toml_path)
+
+    assert isinstance(restored, SeabedLocalizerConfig)
+    assert restored == config


### PR DESCRIPTION
Implements #163: the description-relevant subset of the SEABED localizer config (`*.SEABED.localiser.cfg`) — the geodetic origin plus AUV and ship sensor extrinsic poses — mirroring the syscfg types/parser/IO. Dependency of #159's `deployment describe`.

## Changes

- `seabed/localizer_types.py` — frozen Pydantic v2 models: `Origin`, `SensorPoseEntry`, `AuvSensorConfig`, `ShipSensorConfig`, `SeabedLocalizerConfig`.
- `seabed/localizer_parsers.py` — `parse_localizer_config` ingests the raw vendor file: validates the two section banners and origin keys (aggregated `ValueError`), slices origin/AUV/ship regions, groups `<NAME>_POSE_*` families into `SensorPoseEntry` with zero-fill, and dispatches poses purely by region (no hardcoded sensor-name set).
- `seabed/localizer_io.py` — `read_localizer_config` / `write_localizer_config` round-trip via our TOML representation (no vendor-format logic).
- `seabed/__init__.py` — exports the five types and three functions.
- `tests/test_localizer_config.py` — parsing, pose grouping/zero-fill, region dispatch, non-pose key rejection, aggregated missing-element error, duplicate pose component, and IO round-trip.

## Notes / deviations from the issue

- **Origin duplicate handling.** Real in-range files carry leftover uncommented `LATITUDE`/`LONGITUDE` site presets, so the origin uses **last-active-wins** (sequential-reader semantics) rather than raising on a duplicated origin key. Confirmed against sibling-year files: the last active pair recovers the true deployment origin. Pose components still raise on a duplicate.
- **2009 layout.** The 2009 deployment file used a single `# Sensor Configuration` banner instead of the split AUV/ship banners. Rather than special-casing the parser, the source config file's banners were corrected (data-side fix, outside this repo) so it conforms to the 2010–2017 layout. The parser is unchanged.

## Verification

- Parses all 17 real deployment files spanning 2009–2017 (`acfr_deployments_v1_subset_without_imu`): origin and both pose sets resolve to expected values.
- `ruff check`, `ruff format`, `mypy`, and `pytest` (115 tests) all pass.