### PR TITLE
Add deployment descriptor datatypes, IO, and file manifest

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -1,7 +1,26 @@
 """Package for AUV deployment configuration."""
 
+from .descriptor import DeploymentDescriptor as DeploymentDescriptor
+from .descriptor import DeploymentFileSection as DeploymentFileSection
+from .descriptor import DeploymentSensor as DeploymentSensor
+from .descriptor import DeploymentSensorSection as DeploymentSensorSection
+from .descriptor import DeploymentSystemSection as DeploymentSystemSection
+from .descriptor import (
+    DeploymentTelemetrySection as DeploymentTelemetrySection,
+)
+from .descriptor import PlatformIdentity as PlatformIdentity
+from .descriptor import SensorExtrinsics as SensorExtrinsics
+from .descriptor import SensorIdentity as SensorIdentity
+from .files import DeploymentFiles as DeploymentFiles
+from .files import collect_deployment_files as collect_deployment_files
 from .loader import load_deployment_config as load_deployment_config
+from .loader import (
+    read_deployment_descriptors as read_deployment_descriptors,
+)
 from .loader import read_deployment_info as read_deployment_info
+from .loader import (
+    write_deployment_descriptors as write_deployment_descriptors,
+)
 from .loader import write_deployment_info as write_deployment_info
 from .types import DeploymentConfig as DeploymentConfig
 from .types import DeploymentInfo as DeploymentInfo

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -1,29 +1,31 @@
 """Package for AUV deployment configuration."""
 
-from .descriptor import DeploymentDescriptor as DeploymentDescriptor
-from .descriptor import DeploymentFileSection as DeploymentFileSection
-from .descriptor import DeploymentSensor as DeploymentSensor
-from .descriptor import DeploymentSensorSection as DeploymentSensorSection
-from .descriptor import DeploymentSystemSection as DeploymentSystemSection
 from .descriptor import (
+    DeploymentDescriptor as DeploymentDescriptor,
+    DeploymentFileSection as DeploymentFileSection,
+    DeploymentSensor as DeploymentSensor,
+    DeploymentSensorSection as DeploymentSensorSection,
+    DeploymentSystemSection as DeploymentSystemSection,
     DeploymentTelemetrySection as DeploymentTelemetrySection,
+    PlatformIdentity as PlatformIdentity,
+    SensorExtrinsics as SensorExtrinsics,
+    SensorIdentity as SensorIdentity,
 )
-from .descriptor import PlatformIdentity as PlatformIdentity
-from .descriptor import SensorExtrinsics as SensorExtrinsics
-from .descriptor import SensorIdentity as SensorIdentity
-from .files import DeploymentFiles as DeploymentFiles
-from .files import collect_deployment_files as collect_deployment_files
-from .loader import load_deployment_config as load_deployment_config
+from .files import (
+    DeploymentFiles as DeploymentFiles,
+    collect_deployment_files as collect_deployment_files,
+)
 from .loader import (
+    load_deployment_config as load_deployment_config,
     read_deployment_descriptors as read_deployment_descriptors,
-)
-from .loader import read_deployment_info as read_deployment_info
-from .loader import (
+    read_deployment_info as read_deployment_info,
     write_deployment_descriptors as write_deployment_descriptors,
+    write_deployment_info as write_deployment_info,
 )
-from .loader import write_deployment_info as write_deployment_info
-from .types import DeploymentConfig as DeploymentConfig
-from .types import DeploymentInfo as DeploymentInfo
-from .types import DeploymentMetadata as DeploymentMetadata
-from .types import TopsideUsblModemConfig as TopsideUsblModemConfig
-from .types import UsblUncertaintyProfile as UsblUncertaintyProfile
+from .types import (
+    DeploymentConfig as DeploymentConfig,
+    DeploymentInfo as DeploymentInfo,
+    DeploymentMetadata as DeploymentMetadata,
+    TopsideUsblModemConfig as TopsideUsblModemConfig,
+    UsblUncertaintyProfile as UsblUncertaintyProfile,
+)

--- a/src/afft/deployment/descriptor.py
+++ b/src/afft/deployment/descriptor.py
@@ -1,0 +1,206 @@
+"""Data types describing a single ACFR deployment."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .types import DeploymentMetadata
+
+
+class SensorIdentity(BaseModel):
+    """
+    Curated identity of a sensor — vendor, product, and label.
+
+    Populated by a later enrichment process; the fields are finalized there.
+    Expected to hold a human-friendly label (e.g. ``"Teledyne RDI Workhorse
+    Navigator 1200"``) plus vendor and product metadata.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+
+class SensorExtrinsics(BaseModel):
+    """
+    A sensor's mounting pose in the vehicle (SNAME) body frame.
+
+    Populated by a later enrichment process that reconciles the localizer
+    config's pose families with the system-config-derived sensor roster via a
+    curated alias table (e.g. localizer ``DVL`` -> syscfg ``RDI``).
+
+    Attributes
+    ----------
+    locx: X translation in metres.
+    locy: Y translation in metres.
+    locz: Z translation in metres.
+    rotx: Roll angle in radians.
+    roty: Pitch angle in radians.
+    rotz: Yaw angle in radians.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    locx: float
+    locy: float
+    locz: float
+    rotx: float
+    roty: float
+    rotz: float
+
+
+class DeploymentSensor(BaseModel):
+    """
+    A sensor in a deployment's configured roster.
+
+    Attributes
+    ----------
+    key: Terse sensor identifier and RAW AUV message topic prefix (e.g.
+        ``"RDI"``); also the enrichment catalog lookup key.
+    identity: Curated sensor metadata; ``None`` until enrichment fills it.
+    extrinsics: Sensor mounting pose; ``None`` until enrichment fills it from
+        the localizer config.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    identity: SensorIdentity | None = None
+    extrinsics: SensorExtrinsics | None = None
+
+
+class DeploymentSensorSection(BaseModel):
+    """
+    The deployment's configured sensor roster, from the SEABED system config.
+
+    Attributes
+    ----------
+    sensors: One entry per configured sensor.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensors: list[DeploymentSensor]
+
+
+class PlatformIdentity(BaseModel):
+    """
+    Curated identity of the deployment's platform.
+
+    Populated by a later enrichment process from a curated platform catalog.
+    Not derivable from the deployment data files — only ``platform_class`` has
+    a counterpart there (``system.vehicle_name``), which is the catalog's
+    natural lookup key.
+
+    Attributes
+    ----------
+    platform_label: Human-readable platform name (e.g. ``"AUV Sirius"``).
+    platform_class: Vehicle class / system config vehicle name (e.g.
+        ``"SEABED"``).
+    platform_operator: Operating institution (e.g. ``"ACFR"``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    platform_label: str
+    platform_class: str
+    platform_operator: str
+
+
+class DeploymentSystemSection(BaseModel):
+    """
+    The deployment vehicle's identity and logging setup, from the SEABED
+    system config.
+
+    Attributes
+    ----------
+    vehicle_name: Vehicle name (e.g. ``"SEABED"``).
+    vehicle_config: Vehicle configuration (e.g. ``"NORM_CFG"``).
+    log_directory: On-vehicle log directory (e.g. ``"/files1/Log"``).
+    logged_streams: Stream types written to disk (e.g. ``["SYSLOG", "RAW",
+        "CTL", "AUV", "MSG", "RDI"]``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    vehicle_name: str
+    vehicle_config: str
+    log_directory: str
+    logged_streams: list[str]
+
+
+class DeploymentFileSection(BaseModel):
+    """
+    Flat inventory of a deployment's files, keyed by role.
+
+    Each field is a role; its value is the matching file paths relative to the
+    deployment root, sorted. A role with no matching files is an empty list, so
+    every deployment carries the full role vocabulary.
+
+    Attributes
+    ----------
+    raw_messages: Raw telemetry logs.
+    system_config: SEABED system config.
+    localizer_config: SEABED localizer config.
+    magvar_config: Magnetic variation config.
+    mission_log: Mission log.
+    camera_calibrations: Camera calibration files.
+    camera_poses: Stereo pose estimates.
+    usbl_logs: Topside USBL text logs.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    raw_messages: list[str] = Field(default_factory=list)
+    system_config: list[str] = Field(default_factory=list)
+    localizer_config: list[str] = Field(default_factory=list)
+    magvar_config: list[str] = Field(default_factory=list)
+    mission_log: list[str] = Field(default_factory=list)
+    camera_calibrations: list[str] = Field(default_factory=list)
+    camera_poses: list[str] = Field(default_factory=list)
+    usbl_logs: list[str] = Field(default_factory=list)
+
+
+class DeploymentTelemetrySection(BaseModel):
+    """
+    Message topics observed in the deployment's RAW AUV telemetry logs.
+
+    Attributes
+    ----------
+    topics: Sorted unique message topic names observed across all RAW AUV log
+        files (e.g. ``["GPS_RMC", "RDI", "VIS"]``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    topics: list[str]
+
+
+class DeploymentDescriptor(BaseModel):
+    """
+    Structured, human-readable description of a single ACFR deployment.
+
+    Attributes
+    ----------
+    deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
+    deployment_datetime: Deployment datetime.
+    deployment_platform: Squidle+ platform name for this deployment.
+    metadata: Collected deployment metadata.
+    files: Inventory of the deployment's files, keyed by role.
+    telemetry: Message topics observed in the RAW AUV logs.
+    sensors: The deployment's configured sensor roster.
+    system: The vehicle's identity and logging setup.
+    platform: Curated platform identity; ``None`` until enrichment fills it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    deployment_datetime: datetime
+    deployment_platform: str
+
+    metadata: DeploymentMetadata
+    files: DeploymentFileSection
+    telemetry: DeploymentTelemetrySection
+    sensors: DeploymentSensorSection
+    system: DeploymentSystemSection
+
+    platform: PlatformIdentity | None = None

--- a/src/afft/deployment/files.py
+++ b/src/afft/deployment/files.py
@@ -1,0 +1,148 @@
+"""Runtime file manifest for a single ACFR deployment directory."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from afft.utils.log import logger
+
+
+class DeploymentFiles(BaseModel):
+    """
+    Validated file manifest for one deployment directory.
+
+    A runtime index of absolute paths, resolved once so that downstream
+    parsers and builders never re-walk the deployment tree. It is never
+    serialized — it is projected onto a ``DeploymentFileSection`` first.
+
+    Attributes
+    ----------
+    root: Deployment root directory.
+    system_config: SEABED system config; required.
+    localizer_config: SEABED localizer config; required.
+    magvar_config: Magnetic variation config, or ``None`` if absent.
+    mission_log: Mission log, or ``None`` if absent.
+    raw_messages: Raw telemetry logs.
+    usbl_logs: Topside USBL text logs.
+    camera_calibrations: Camera calibration files.
+    camera_poses: Stereo pose estimates.
+    other: Every file under the root that no role matched.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    root: Path
+    system_config: Path
+    localizer_config: Path
+    magvar_config: Path | None
+    mission_log: Path | None
+    raw_messages: list[Path]
+    usbl_logs: list[Path]
+    camera_calibrations: list[Path]
+    camera_poses: list[Path]
+    other: list[Path]
+
+
+# Role -> glob pattern, relative to the deployment root. Ordered: a file is
+# assigned to the first role whose pattern matches it, and every file that no
+# pattern matches lands in `other`.
+_ROLE_PATTERNS: dict[str, str] = {
+    "raw_messages": "messages/*.RAW.auv",
+    "system_config": "messages/*.SEABED.syscfg",
+    "localizer_config": "messages/*.SEABED.localiser.cfg",
+    "magvar_config": "messages/*.magnetic_variation.cfg",
+    "mission_log": "messages/*.log",
+    "camera_calibrations": "camera_calibration/**/*.calib",
+    "camera_poses": "camera_poses/**/*stereo_pose_est.data",
+    "usbl_logs": "usbl/log-*.txt",
+}
+
+
+def collect_deployment_files(root: Path) -> DeploymentFiles:
+    """
+    Scan a deployment directory and assign every file to a role.
+
+    Arguments
+    ---------
+    root: Deployment root directory.
+
+    Returns
+    -------
+    Validated file manifest for the deployment.
+
+    Raises
+    ------
+    NotADirectoryError: If the root is not an existing directory.
+    ValueError: If a required singular role matches no file or more than one.
+    """
+    if not root.is_dir():
+        raise NotADirectoryError(f"not a deployment directory: {root}")
+
+    matches: dict[str, list[Path]] = {
+        role: [] for role in _ROLE_PATTERNS.keys()
+    }
+    assigned: set[Path] = set()
+    for role, pattern in _ROLE_PATTERNS.items():
+        for path in root.glob(pattern):
+            if not path.is_file() or path in assigned:
+                continue
+            matches[role].append(path)
+            assigned.add(path)
+
+    for role in matches:
+        matches[role].sort()
+
+    other: list[Path] = sorted(
+        path
+        for path in root.rglob("*")
+        if path.is_file() and path not in assigned
+    )
+    if other:
+        logger.warning(
+            f"{len(other)} uncategorized file(s) in {root.name}: "
+            f"{', '.join(str(path.relative_to(root)) for path in other)}"
+        )
+
+    return DeploymentFiles(
+        root=root,
+        system_config=_required_singular(matches, "system_config", root),
+        localizer_config=_required_singular(matches, "localizer_config", root),
+        magvar_config=_optional_singular(matches, "magvar_config", root),
+        mission_log=_optional_singular(matches, "mission_log", root),
+        raw_messages=matches["raw_messages"],
+        usbl_logs=matches["usbl_logs"],
+        camera_calibrations=matches["camera_calibrations"],
+        camera_poses=matches["camera_poses"],
+        other=other,
+    )
+
+
+def _required_singular(
+    matches: dict[str, list[Path]],
+    role: str,
+    root: Path,
+) -> Path:
+    """Resolve a role that must match exactly one file, else raise."""
+    paths: list[Path] = matches[role]
+    if len(paths) != 1:
+        raise ValueError(
+            f"expected exactly one {role} in {root.name}, found {len(paths)}"
+        )
+    return paths[0]
+
+
+def _optional_singular(
+    matches: dict[str, list[Path]],
+    role: str,
+    root: Path,
+) -> Path | None:
+    """Resolve a role that may match no file, warning on absence or excess."""
+    paths: list[Path] = matches[role]
+    if not paths:
+        logger.warning(f"no {role} in {root.name}")
+        return None
+    if len(paths) > 1:
+        logger.warning(
+            f"{len(paths)} {role} files in {root.name}, using {paths[0].name}"
+        )
+    return paths[0]

--- a/src/afft/deployment/loader.py
+++ b/src/afft/deployment/loader.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from afft.io.config_io import read_config
 
+from .descriptor import DeploymentDescriptor
 from .types import (
     DeploymentConfig,
     DeploymentInfo,
@@ -117,11 +118,6 @@ def read_deployment_info(path: Path) -> list[DeploymentInfo]:
                         "magnetic_variation": metadata.get(
                             "magnetic_variation", 0.0
                         ),
-                        "message_topics": metadata.get("message_topics", []),
-                        "renav_labels": metadata.get("renav_labels", []),
-                        "camera_calibration_files": metadata.get(
-                            "camera_calibration_files", []
-                        ),
                     },
                 }
             )
@@ -147,6 +143,53 @@ def write_deployment_info(
                 "deployments": [
                     deployment.model_dump(mode="python")
                     for deployment in deployments
+                ]
+            }
+        )
+    )
+
+
+def read_deployment_descriptors(path: Path) -> list[DeploymentDescriptor]:
+    """
+    Read deployment descriptors from a deployments TOML file.
+
+    Arguments
+    ---------
+    path: Path to the deployments TOML file.
+
+    Returns
+    -------
+    List of deployment descriptors.
+    """
+    raw: dict[str, Any] = read_config(path)
+    return [
+        DeploymentDescriptor.model_validate(entry)
+        for entry in raw.get("deployments", [])
+    ]
+
+
+def write_deployment_descriptors(
+    path: Path,
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    """
+    Write deployment descriptors to a deployments TOML file.
+
+    Curated slots that are still unfilled are omitted rather than written as
+    null: TOML has no null literal, and the ``None`` defaults restore them on
+    read.
+
+    Arguments
+    ---------
+    path: Path to write the deployments TOML file.
+    descriptors: Deployment descriptors to serialize.
+    """
+    path.write_bytes(
+        msgspec.toml.encode(
+            {
+                "deployments": [
+                    descriptor.model_dump(mode="python", exclude_none=True)
+                    for descriptor in descriptors
                 ]
             }
         )

--- a/src/afft/deployment/types.py
+++ b/src/afft/deployment/types.py
@@ -97,9 +97,6 @@ class DeploymentMetadata(BaseModel):
     origin_latitude: Deployment origin latitude in decimal degrees.
     origin_longitude: Deployment origin longitude in decimal degrees.
     magnetic_variation: Magnetic variation at the origin in degrees.
-    message_topics: Sorted unique message topic names from the RAW AUV logs.
-    renav_labels: Sorted renav run labels from the camera poses directory.
-    camera_calibration_files: Sorted unique camera calibration filenames.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -110,9 +107,6 @@ class DeploymentMetadata(BaseModel):
     origin_latitude: float
     origin_longitude: float
     magnetic_variation: float
-    message_topics: list[str]
-    renav_labels: list[str]
-    camera_calibration_files: list[str]
 
 
 class DeploymentInfo(BaseModel):

--- a/src/afft/tasks/collect_deployment_info/runner.py
+++ b/src/afft/tasks/collect_deployment_info/runner.py
@@ -15,12 +15,9 @@ from afft.utils.log import logger
 from .collectors import (
     collect_acfr_campaign_label,
     collect_acfr_deployment_label,
-    collect_camera_calibration_files,
     collect_magnetic_variation,
-    collect_message_topics,
     collect_origin_latitude,
     collect_origin_longitude,
-    collect_renav_labels,
 )
 from .types import (
     CollectDeploymentInfoCommand,
@@ -198,15 +195,6 @@ def run_collect_deployment_info(
                         deployment_dir, config, diagnostics
                     ),
                     magnetic_variation=collect_magnetic_variation(
-                        deployment_dir, config, diagnostics
-                    ),
-                    message_topics=collect_message_topics(
-                        deployment_dir, config, diagnostics
-                    ),
-                    renav_labels=collect_renav_labels(
-                        deployment_dir, config, diagnostics
-                    ),
-                    camera_calibration_files=collect_camera_calibration_files(
                         deployment_dir, config, diagnostics
                     ),
                 ),

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -1,0 +1,227 @@
+"""Tests for the deployment descriptor datatypes, IO, and file manifest."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from afft.deployment import (
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    DeploymentMetadata,
+    DeploymentSensor,
+    DeploymentSensorSection,
+    DeploymentSystemSection,
+    DeploymentTelemetrySection,
+    PlatformIdentity,
+    SensorExtrinsics,
+    collect_deployment_files,
+    read_deployment_descriptors,
+    write_deployment_descriptors,
+)
+from afft.io import read_config
+
+DEPLOYMENT_NAME: str = "qd66hv_20170525_234600_deployment_data"
+
+DEPLOYMENT_FILES: tuple[str, ...] = (
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170525_2346.SEABED.syscfg",
+    "messages/20170525_2346.SEABED.localiser.cfg",
+    "messages/20170525_2346.magnetic_variation.cfg",
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+    "messages/20170525_2346.CTL.auv",
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+)
+
+
+def _build_deployment(root: Path, names: tuple[str, ...]) -> Path:
+    """Builds a synthetic deployment directory tree and returns its root."""
+    directory = root / DEPLOYMENT_NAME
+    for name in names:
+        path = directory / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("")
+    return directory
+
+
+def _build_descriptor() -> DeploymentDescriptor:
+    """Builds a descriptor with every curated slot left unfilled."""
+    return DeploymentDescriptor(
+        deployment_label="qd66hv_20170525_234600",
+        deployment_datetime=datetime(
+            2017, 5, 25, 23, 46, 0, tzinfo=timezone.utc
+        ),
+        deployment_platform="",
+        metadata=DeploymentMetadata(
+            acfr_deployment_label="SS11_snapperbank",
+            acfr_campaign_label="WA201705",
+            acfr_platform_label="",
+            origin_latitude=-32.0,
+            origin_longitude=115.5,
+            magnetic_variation=-1.5,
+        ),
+        files=DeploymentFileSection(
+            raw_messages=["messages/20170525_2346.RAW.auv"],
+            system_config=["messages/20170525_2346.SEABED.syscfg"],
+        ),
+        telemetry=DeploymentTelemetrySection(topics=["RDI", "VIS"]),
+        sensors=DeploymentSensorSection(
+            sensors=[DeploymentSensor(key="RDI"), DeploymentSensor(key="VIS")]
+        ),
+        system=DeploymentSystemSection(
+            vehicle_name="SEABED",
+            vehicle_config="NORM_CFG",
+            log_directory="/files1/Log",
+            logged_streams=["SYSLOG", "RAW"],
+        ),
+    )
+
+
+def test_descriptor_round_trip(tmp_path: Path) -> None:
+    descriptor = _build_descriptor()
+    path = tmp_path / "deployments.toml"
+
+    write_deployment_descriptors(path, [descriptor])
+
+    assert read_deployment_descriptors(path) == [descriptor]
+
+
+def test_descriptor_datetime_is_native_toml_datetime(tmp_path: Path) -> None:
+    path = tmp_path / "deployments.toml"
+
+    write_deployment_descriptors(path, [_build_descriptor()])
+
+    # Unquoted, so TOML decodes it back to a datetime rather than a string.
+    assert "deployment_datetime = 2017-05-25 23:46:00+00:00" in path.read_text()
+    assert isinstance(
+        read_config(path)["deployments"][0]["deployment_datetime"], datetime
+    )
+
+
+def test_unfilled_curated_slots_are_omitted(tmp_path: Path) -> None:
+    path = tmp_path / "deployments.toml"
+
+    write_deployment_descriptors(path, [_build_descriptor()])
+
+    entry = read_config(path)["deployments"][0]
+    assert "platform" not in entry
+    assert "identity" not in entry["sensors"]["sensors"][0]
+    assert "extrinsics" not in entry["sensors"]["sensors"][0]
+
+    descriptors = read_deployment_descriptors(path)
+    assert descriptors[0].platform is None
+    assert descriptors[0].sensors.sensors[0].identity is None
+    assert descriptors[0].sensors.sensors[0].extrinsics is None
+
+
+def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
+    descriptor = _build_descriptor().model_copy(
+        update={
+            "platform": PlatformIdentity(
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="ACFR",
+            ),
+            "sensors": DeploymentSensorSection(
+                sensors=[
+                    DeploymentSensor(
+                        key="RDI",
+                        extrinsics=SensorExtrinsics(
+                            locx=0.1,
+                            locy=0.2,
+                            locz=0.3,
+                            rotx=0.0,
+                            roty=0.0,
+                            rotz=3.14,
+                        ),
+                    )
+                ]
+            ),
+        }
+    )
+    path = tmp_path / "deployments.toml"
+
+    write_deployment_descriptors(path, [descriptor])
+
+    assert read_deployment_descriptors(path) == [descriptor]
+
+
+def test_collect_files_assigns_every_role(tmp_path: Path) -> None:
+    directory = _build_deployment(tmp_path, DEPLOYMENT_FILES)
+
+    files = collect_deployment_files(directory)
+
+    assert files.root == directory
+    assert files.system_config.name == "20170525_2346.SEABED.syscfg"
+    assert files.localizer_config.name == "20170525_2346.SEABED.localiser.cfg"
+    assert files.magvar_config is not None
+    assert files.mission_log is not None
+    assert len(files.raw_messages) == 2
+    assert len(files.usbl_logs) == 2
+    assert len(files.camera_calibrations) == 1
+    assert len(files.camera_poses) == 2
+
+
+def test_collect_files_partitions_exhaustively(tmp_path: Path) -> None:
+    directory = _build_deployment(tmp_path, DEPLOYMENT_FILES)
+
+    files = collect_deployment_files(directory)
+
+    assigned = [
+        files.system_config,
+        files.localizer_config,
+        files.magvar_config,
+        files.mission_log,
+        *files.raw_messages,
+        *files.usbl_logs,
+        *files.camera_calibrations,
+        *files.camera_poses,
+        *files.other,
+    ]
+    assert len(assigned) == len(DEPLOYMENT_FILES)
+    assert files.other == [directory / "messages/20170525_2346.CTL.auv"]
+
+
+def test_collect_files_optional_singulars_default_to_none(
+    tmp_path: Path,
+) -> None:
+    names = tuple(
+        name
+        for name in DEPLOYMENT_FILES
+        if not name.endswith((".magnetic_variation.cfg", ".log"))
+    )
+    directory = _build_deployment(tmp_path, names)
+
+    files = collect_deployment_files(directory)
+
+    assert files.magvar_config is None
+    assert files.mission_log is None
+
+
+def test_collect_files_raises_on_missing_required_singular(
+    tmp_path: Path,
+) -> None:
+    names = tuple(
+        name for name in DEPLOYMENT_FILES if not name.endswith(".syscfg")
+    )
+    directory = _build_deployment(tmp_path, names)
+
+    with pytest.raises(ValueError, match="system_config"):
+        collect_deployment_files(directory)
+
+
+def test_collect_files_raises_on_duplicated_required_singular(
+    tmp_path: Path,
+) -> None:
+    directory = _build_deployment(
+        tmp_path,
+        DEPLOYMENT_FILES + ("messages/20170526_0000.SEABED.localiser.cfg",),
+    )
+
+    with pytest.raises(ValueError, match="localizer_config"):
+        collect_deployment_files(directory)


### PR DESCRIPTION
Closes #172.

Adds the `DeploymentDescriptor` datatype surface, its TOML serialization, and the runtime file manifest — the `deployment/` half of #159. The task and CLI that populate these types are #173.

## Changes

**`deployment/descriptor.py` (new)** — the umbrella record and its section and item models, all frozen Pydantic v2:

- `DeploymentDescriptor` — identity fields plus `metadata`, `files`, `telemetry`, `sensors`, `system`, and the curated `platform` slot.
- `DeploymentFileSection` — flat inventory, one `list[str]` role field per role, paths relative to the deployment root.
- `DeploymentTelemetrySection` — message topics observed in the `RAW.auv` logs.
- `DeploymentSensorSection` / `DeploymentSensor` — the configured roster, keyed by the terse sensor identifier, with `identity` and `extrinsics` enrichment slots colocated on each record so they cannot drift out of alignment.
- `DeploymentSystemSection` — vehicle identity and logging setup.
- `SensorIdentity`, `SensorExtrinsics`, `PlatformIdentity` — curated slots declared here so the schema does not change when the enrichment issue lands. `SensorIdentity` is intentionally fieldless for now; its fields are finalized in #171.

**`deployment/files.py` (new)** — `DeploymentFiles`, a runtime index of absolute paths, and `collect_deployment_files`, a single scan per deployment directory. Field type encodes requiredness: `system_config` and `localizer_config` are non-optional and raise when missing or duplicated; `magvar_config` and `mission_log` warn and default to `None`. Every remaining file lands in `other` and is logged. The module does not import `DeploymentFileSection`.

**`deployment/loader.py`** — adds `read_deployment_descriptors` / `write_deployment_descriptors`. The write path uses `model_dump(mode='python', exclude_none=True)`: TOML has no null literal and `msgspec.toml.encode` raises on `None`, so an unfilled curated slot is omitted and the `None` defaults restore it on read.

**`deployment/types.py`** — removes `message_topics`, `renav_labels`, and `camera_calibration_files` from `DeploymentMetadata`, redundant with the new `telemetry` and `files` sections. `DeploymentInfo` and `read_deployment_info` are retained until the `collect_squidle_media` migration lands (#159 D7); `config/acfr_deployments_v1.toml` still reads back all 52 deployments.

**`tasks/collect_deployment_info/runner.py`** — stops passing the three removed metadata fields. The collectors themselves are left in place; #173 migrates that logic into its builders.

## Open questions, resolved

1. **IO module placement** — `loader.py`, as specified in the issue's scope. The `seabed/*_io.py` split exists to keep IO away from vendor parsing, and there is no parsing here; a dedicated module would only separate the new functions from the `read_deployment_info` / `write_deployment_info` pair they directly supersede.
2. **Role matching rules** — an ordered `_ROLE_PATTERNS` constant in `files.py`, globbed relative to the root, first-match-wins so the partition is disjoint. Recursion comes from `**` in the pattern itself, used only by the two camera roles. "Duplicated" means a required singular matching anything other than exactly one file.
3. **Test fixtures** — a `tmp_path`-constructed synthetic deployment tree, matching the existing flat `tests/` style rather than introducing a checked-in `tests/data/`. #173 can reuse the builder helper.

## Deviation from the issue

The `camera_poses` glob is `camera_poses/**/*stereo_pose_est.data`, not `camera_poses/**/*_stereo_pose_est.data` as tabulated. The reference-files section lists both `camera_poses/*_stereo_pose_est.data` and the nested `renav<date>/stereo_pose_est.data`; the underscore in the tabulated pattern excludes the nested form, which would then fall through to `other`. Dropping it catches both.

## Testing

`tests/test_deployment_descriptor.py` — descriptor round-trip, native TOML datetime encoding, `exclude_none` omission and restore, filled-slot round-trip, role assignment, exhaustive partition, optional-singular defaults, and required-singular missing / duplicated failures.

`ruff check`, `ruff format`, `mypy --strict`, and `pytest` (124 passed) are clean.