### PR TITLE
Restructure deployment descriptor into platform and vessel sections

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -3,13 +3,16 @@
 from .descriptor import (
     DeploymentDescriptor as DeploymentDescriptor,
     DeploymentFileSection as DeploymentFileSection,
-    DeploymentSensor as DeploymentSensor,
-    DeploymentSensorSection as DeploymentSensorSection,
+    DeploymentPlatformSection as DeploymentPlatformSection,
     DeploymentSystemSection as DeploymentSystemSection,
     DeploymentTelemetrySection as DeploymentTelemetrySection,
+    DeploymentVesselSection as DeploymentVesselSection,
     PlatformIdentity as PlatformIdentity,
+    PlatformSensor as PlatformSensor,
     SensorExtrinsics as SensorExtrinsics,
     SensorIdentity as SensorIdentity,
+    VesselIdentity as VesselIdentity,
+    VesselSensor as VesselSensor,
 )
 from .files import (
     DeploymentFiles as DeploymentFiles,

--- a/src/afft/deployment/descriptor.py
+++ b/src/afft/deployment/descriptor.py
@@ -21,7 +21,8 @@ class SensorIdentity(BaseModel):
 
 class SensorExtrinsics(BaseModel):
     """
-    A sensor's mounting pose in the vehicle (SNAME) body frame.
+    A sensor's mounting pose, in the reference frame of the body it is mounted
+    on — stated by the descriptor section the sensor lives in.
 
     Populated by a later enrichment process that reconciles the localizer
     config's pose families with the system-config-derived sensor roster via a
@@ -47,17 +48,17 @@ class SensorExtrinsics(BaseModel):
     rotz: float
 
 
-class DeploymentSensor(BaseModel):
+class PlatformSensor(BaseModel):
     """
-    A sensor in a deployment's configured roster.
+    A sensor mounted on the deployment's platform.
 
     Attributes
     ----------
     key: Terse sensor identifier and RAW AUV message topic prefix (e.g.
         ``"RDI"``); also the enrichment catalog lookup key.
     identity: Curated sensor metadata; ``None`` until enrichment fills it.
-    extrinsics: Sensor mounting pose; ``None`` until enrichment fills it from
-        the localizer config.
+    extrinsics: Sensor mounting pose in the vehicle (SNAME) body frame;
+        ``None`` until enrichment fills it from the localizer config.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -67,18 +68,27 @@ class DeploymentSensor(BaseModel):
     extrinsics: SensorExtrinsics | None = None
 
 
-class DeploymentSensorSection(BaseModel):
+class VesselSensor(BaseModel):
     """
-    The deployment's configured sensor roster, from the SEABED system config.
+    A sensor mounted on the deployment's support vessel.
+
+    Distinct from ``PlatformSensor`` because its ``extrinsics`` are expressed
+    in the ship reference frame rather than the vehicle (SNAME) body frame.
 
     Attributes
     ----------
-    sensors: One entry per configured sensor.
+    key: Terse sensor identifier (e.g. ``"USBL"``); also the enrichment catalog
+        lookup key.
+    identity: Curated sensor metadata; ``None`` until enrichment fills it.
+    extrinsics: Sensor mounting pose in the ship reference frame; ``None``
+        until enrichment fills it from the curated USBL extrinsics catalog.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    sensors: list[DeploymentSensor]
+    key: str
+    identity: SensorIdentity | None = None
+    extrinsics: SensorExtrinsics | None = None
 
 
 class PlatformIdentity(BaseModel):
@@ -103,6 +113,64 @@ class PlatformIdentity(BaseModel):
     platform_label: str
     platform_class: str
     platform_operator: str
+
+
+class VesselIdentity(BaseModel):
+    """
+    Curated identity of the deployment's support vessel.
+
+    Attributes
+    ----------
+    vessel_name: Support vessel name (e.g. ``"RV Linnaeus"``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    vessel_name: str
+
+
+class DeploymentPlatformSection(BaseModel):
+    """
+    The deployment platform's curated identity and its sensor roster.
+
+    The roster is derived from the SEABED system config at describe time;
+    ``identity`` and the sensors' curated slots are filled by enrichment.
+
+    Sensor extrinsics in this section are expressed in the vehicle (SNAME)
+    body frame, unlike ``DeploymentVesselSection``, whose poses are in the
+    ship reference frame.
+
+    Attributes
+    ----------
+    identity: Curated platform identity; ``None`` until enrichment fills it.
+    sensors: One entry per configured platform sensor.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    identity: PlatformIdentity | None = None
+    sensors: list[PlatformSensor] = Field(default_factory=list)
+
+
+class DeploymentVesselSection(BaseModel):
+    """
+    The support vessel's curated identity and its sensor roster.
+
+    Populated by a later enrichment process from the curated USBL extrinsics
+    catalog. Not derivable from the deployment data files: the support vessel
+    is topside, and nothing in the system config names it.
+
+    Attributes
+    ----------
+    identity: Curated vessel identity; ``None`` until enrichment fills it.
+    sensors: One entry per curated vessel sensor (USBL transceiver, ship GPS,
+        ship attitude sensor); empty until enrichment fills it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    identity: VesselIdentity | None = None
+    sensors: list[VesselSensor] = Field(default_factory=list)
 
 
 class DeploymentSystemSection(BaseModel):
@@ -182,25 +250,24 @@ class DeploymentDescriptor(BaseModel):
     ----------
     deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
     deployment_datetime: Deployment datetime.
-    deployment_platform: Squidle+ platform name for this deployment.
     metadata: Collected deployment metadata.
     files: Inventory of the deployment's files, keyed by role.
     telemetry: Message topics observed in the RAW AUV logs.
-    sensors: The deployment's configured sensor roster.
+    platform: The platform's curated identity and its sensor roster.
     system: The vehicle's identity and logging setup.
-    platform: Curated platform identity; ``None`` until enrichment fills it.
+    vessel: The support vessel's curated identity and its sensor roster;
+        ``None`` until enrichment fills it.
     """
 
     model_config = ConfigDict(frozen=True)
 
     deployment_label: str
     deployment_datetime: datetime
-    deployment_platform: str
 
     metadata: DeploymentMetadata
     files: DeploymentFileSection
     telemetry: DeploymentTelemetrySection
-    sensors: DeploymentSensorSection
+    platform: DeploymentPlatformSection
     system: DeploymentSystemSection
 
-    platform: PlatformIdentity | None = None
+    vessel: DeploymentVesselSection | None = None

--- a/src/afft/tasks/deployment_descriptor/__init__.py
+++ b/src/afft/tasks/deployment_descriptor/__init__.py
@@ -3,7 +3,7 @@
 from .builders import (
     build_deployment_file_section as build_deployment_file_section,
     build_deployment_metadata as build_deployment_metadata,
-    build_sensor_section as build_sensor_section,
+    build_platform_section as build_platform_section,
     build_system_section as build_system_section,
     build_telemetry_section as build_telemetry_section,
 )

--- a/src/afft/tasks/deployment_descriptor/builders.py
+++ b/src/afft/tasks/deployment_descriptor/builders.py
@@ -8,10 +8,10 @@ from afft.deployment import (
     DeploymentFiles,
     DeploymentFileSection,
     DeploymentMetadata,
-    DeploymentSensor,
-    DeploymentSensorSection,
+    DeploymentPlatformSection,
     DeploymentSystemSection,
     DeploymentTelemetrySection,
+    PlatformSensor,
 )
 from afft.seabed import SeabedSystemConfig
 
@@ -80,14 +80,15 @@ def build_system_section(
     )
 
 
-def build_sensor_section(
+def build_platform_section(
     system_config: SeabedSystemConfig,
-) -> DeploymentSensorSection:
+) -> DeploymentPlatformSection:
     """
-    Map a parsed SEABED system config onto the descriptor's sensor section.
+    Map a parsed SEABED system config onto the descriptor's platform section.
 
-    The curated ``identity`` and ``extrinsics`` slots are left unfilled; an
-    enrichment process populates them later.
+    The section's curated ``identity`` slot and the sensors' ``identity`` and
+    ``extrinsics`` slots are left unfilled; an enrichment process populates
+    them later.
 
     Arguments
     ---------
@@ -95,11 +96,11 @@ def build_sensor_section(
 
     Returns
     -------
-    The deployment's configured sensor roster, keys only.
+    The platform's configured sensor roster, keys only.
     """
-    return DeploymentSensorSection(
+    return DeploymentPlatformSection(
         sensors=[
-            DeploymentSensor(key=entry.name)
+            PlatformSensor(key=entry.name)
             for entry in system_config.sensors.entries
         ]
     )

--- a/src/afft/tasks/deployment_descriptor/runner.py
+++ b/src/afft/tasks/deployment_descriptor/runner.py
@@ -22,7 +22,7 @@ from afft.utils.log import logger
 from .builders import (
     build_deployment_file_section,
     build_deployment_metadata,
-    build_sensor_section,
+    build_platform_section,
     build_system_section,
     build_telemetry_section,
 )
@@ -158,8 +158,8 @@ def describe_deployment(
     system_config: SeabedSystemConfig = parse_system_config(files.system_config)
     parse_localizer_config(files.localizer_config)
 
-    sensors = build_sensor_section(system_config)
-    if not sensors.sensors:
+    platform = build_platform_section(system_config)
+    if not platform.sensors:
         diagnostics.warning(
             deployment_label, "empty sensor roster in the system config"
         )
@@ -167,13 +167,12 @@ def describe_deployment(
     return DeploymentDescriptor(
         deployment_label=deployment_label,
         deployment_datetime=deployment_datetime,
-        deployment_platform="",
         metadata=build_deployment_metadata(
             files, deployment_label, diagnostics
         ),
         files=build_deployment_file_section(files),
         telemetry=build_telemetry_section(files, deployment_label, diagnostics),
-        sensors=sensors,
+        platform=platform,
         system=build_system_section(system_config),
     )
 

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -9,12 +9,15 @@ from afft.deployment import (
     DeploymentDescriptor,
     DeploymentFileSection,
     DeploymentMetadata,
-    DeploymentSensor,
-    DeploymentSensorSection,
+    DeploymentPlatformSection,
     DeploymentSystemSection,
     DeploymentTelemetrySection,
+    DeploymentVesselSection,
     PlatformIdentity,
+    PlatformSensor,
     SensorExtrinsics,
+    VesselIdentity,
+    VesselSensor,
     collect_deployment_files,
     read_deployment_descriptors,
     write_deployment_descriptors,
@@ -56,7 +59,6 @@ def _build_descriptor() -> DeploymentDescriptor:
         deployment_datetime=datetime(
             2017, 5, 25, 23, 46, 0, tzinfo=timezone.utc
         ),
-        deployment_platform="",
         metadata=DeploymentMetadata(
             acfr_deployment_label="SS11_snapperbank",
             acfr_campaign_label="WA201705",
@@ -70,8 +72,8 @@ def _build_descriptor() -> DeploymentDescriptor:
             system_config=["messages/20170525_2346.SEABED.syscfg"],
         ),
         telemetry=DeploymentTelemetrySection(topics=["RDI", "VIS"]),
-        sensors=DeploymentSensorSection(
-            sensors=[DeploymentSensor(key="RDI"), DeploymentSensor(key="VIS")]
+        platform=DeploymentPlatformSection(
+            sensors=[PlatformSensor(key="RDI"), PlatformSensor(key="VIS")]
         ),
         system=DeploymentSystemSection(
             vehicle_name="SEABED",
@@ -109,27 +111,29 @@ def test_unfilled_curated_slots_are_omitted(tmp_path: Path) -> None:
     write_deployment_descriptors(path, [_build_descriptor()])
 
     entry = read_config(path)["deployments"][0]
-    assert "platform" not in entry
-    assert "identity" not in entry["sensors"]["sensors"][0]
-    assert "extrinsics" not in entry["sensors"]["sensors"][0]
+    assert "vessel" not in entry
+    assert "identity" not in entry["platform"]
+    assert "identity" not in entry["platform"]["sensors"][0]
+    assert "extrinsics" not in entry["platform"]["sensors"][0]
 
     descriptors = read_deployment_descriptors(path)
-    assert descriptors[0].platform is None
-    assert descriptors[0].sensors.sensors[0].identity is None
-    assert descriptors[0].sensors.sensors[0].extrinsics is None
+    assert descriptors[0].vessel is None
+    assert descriptors[0].platform.identity is None
+    assert descriptors[0].platform.sensors[0].identity is None
+    assert descriptors[0].platform.sensors[0].extrinsics is None
 
 
 def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
     descriptor = _build_descriptor().model_copy(
         update={
-            "platform": PlatformIdentity(
-                platform_label="AUV Sirius",
-                platform_class="SEABED",
-                platform_operator="ACFR",
-            ),
-            "sensors": DeploymentSensorSection(
+            "platform": DeploymentPlatformSection(
+                identity=PlatformIdentity(
+                    platform_label="AUV Sirius",
+                    platform_class="SEABED",
+                    platform_operator="ACFR",
+                ),
                 sensors=[
-                    DeploymentSensor(
+                    PlatformSensor(
                         key="RDI",
                         extrinsics=SensorExtrinsics(
                             locx=0.1,
@@ -140,7 +144,35 @@ def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
                             rotz=3.14,
                         ),
                     )
-                ]
+                ],
+            ),
+        }
+    )
+    path = tmp_path / "deployments.toml"
+
+    write_deployment_descriptors(path, [descriptor])
+
+    assert read_deployment_descriptors(path) == [descriptor]
+
+
+def test_filled_vessel_section_round_trip(tmp_path: Path) -> None:
+    descriptor = _build_descriptor().model_copy(
+        update={
+            "vessel": DeploymentVesselSection(
+                identity=VesselIdentity(vessel_name="RV Linnaeus"),
+                sensors=[
+                    VesselSensor(
+                        key="USBL",
+                        extrinsics=SensorExtrinsics(
+                            locx=1.0,
+                            locy=-0.5,
+                            locz=2.5,
+                            rotx=0.0,
+                            roty=0.0,
+                            rotz=1.57,
+                        ),
+                    )
+                ],
             ),
         }
     )

--- a/tests/test_describe_deployment.py
+++ b/tests/test_describe_deployment.py
@@ -17,7 +17,7 @@ from afft.tasks.deployment_descriptor import (
     DescribeDeploymentDiagnostics,
     build_deployment_file_section,
     build_deployment_metadata,
-    build_sensor_section,
+    build_platform_section,
     build_system_section,
     build_telemetry_section,
     run_describe_deployment,
@@ -147,21 +147,22 @@ def test_build_file_section_empties_absent_optional_roles(
     assert section.magvar_config == []
 
 
-def test_build_system_and_sensor_sections(tmp_path: Path) -> None:
+def test_build_system_and_platform_sections(tmp_path: Path) -> None:
     directory = _build_deployment(tmp_path, DEPLOYMENT_CONTENTS)
     files = collect_deployment_files(directory)
     system_config = parse_system_config(files.system_config)
 
     system = build_system_section(system_config)
-    sensors = build_sensor_section(system_config)
+    platform = build_platform_section(system_config)
 
     assert system.vehicle_name == "SEABED"
     assert system.vehicle_config == "NORM_CFG"
     assert system.log_directory == "/files1/Log"
     assert system.logged_streams == ["SYSLOG", "RAW", "CTL"]
-    assert [sensor.key for sensor in sensors.sensors] == ["RDI", "VIS"]
-    assert all(sensor.identity is None for sensor in sensors.sensors)
-    assert all(sensor.extrinsics is None for sensor in sensors.sensors)
+    assert platform.identity is None
+    assert [sensor.key for sensor in platform.sensors] == ["RDI", "VIS"]
+    assert all(sensor.identity is None for sensor in platform.sensors)
+    assert all(sensor.extrinsics is None for sensor in platform.sensors)
 
 
 def test_build_telemetry_section_collects_topics(
@@ -294,7 +295,7 @@ def test_run_writes_descriptor_toml(tmp_path: Path) -> None:
         "2017-05-25T23:46:00+00:00"
     )
     assert descriptor.telemetry.topics == ["GPS_RMC", "RDI", "VIS"]
-    assert [sensor.key for sensor in descriptor.sensors.sensors] == [
+    assert [sensor.key for sensor in descriptor.platform.sensors] == [
         "RDI",
         "VIS",
     ]
@@ -315,7 +316,8 @@ def test_run_leaves_curated_slots_absent(tmp_path: Path) -> None:
     )
 
     contents = output_file.read_text()
-    assert "[deployments.platform]" not in contents
+    assert "[deployments.platform]" in contents
+    assert "[deployments.vessel]" not in contents
     assert "identity" not in contents
     assert "extrinsics" not in contents
 


### PR DESCRIPTION
Closes #178.

Schema-only change following the slot-then-enrich pattern from #159: this adds the slots, #171 fills them.

## What changed

`DeploymentDescriptor` described the vehicle side of a deployment but carried nothing about the support vessel, so the USBL transceiver's mounting pose and the ship's identity were unrecoverable from the descriptor. Adding a vessel section also exposed a modelling gap on the vehicle side, where `platform` and `sensors` sat beside each other as unrelated top-level slots. The descriptor now has one consistent rule: **a body section carries its identity and its sensors, and the owning body determines the reference frame of those sensors' extrinsics.**

- `DeploymentSensor` renamed to `PlatformSensor`; `DeploymentSensorSection` renamed to `DeploymentPlatformSection`, now carrying `identity: PlatformIdentity | None` alongside `sensors`.
- New `VesselSensor`, `VesselIdentity`, and `DeploymentVesselSection`, with extrinsics in the ship reference frame.
- On `DeploymentDescriptor`, the single `platform` section replaces the former top-level `sensors` and `platform` slots, and `vessel: DeploymentVesselSection | None = None` is added.
- `deployment_platform` removed — `platform.identity.platform_label` fills the same role, and `describe` wrote it as `\"\"` for all 17 deployments. `DeploymentInfo` keeps its own copy, so the Squidle+ matcher is unaffected.
- Both sections default `sensors` to an empty list; `describe` already warns on an empty roster.
- `SensorExtrinsics` is reused by both sensor types, so its docstring no longer names the vehicle frame — the section states the frame instead.

## Lifecycle: the sections match in shape, not in lifecycle

`platform` is not a pure enrichment slot: its roster is derivable from the system config, so `describe` emits the section with `sensors` populated and `identity` still `None`, and the section is required. The vessel section is the opposite — nothing in it is derivable from a deployment's data files, so it stays `None` until enrichment.

The platform label consequently sits behind two `None`s until enrichment has run. That costs nothing today, but a future consumer reading it from the descriptor gains an ordering dependency on #171.

## Serialized shape

Descriptors now always carry a `[deployments.platform]` header holding the roster; previously `platform` was omitted entirely and the roster lived under `[deployments.sensors]`, with the `sensors.sensors` stutter. Reads of existing descriptor files are unaffected — the models set only `frozen=True`, so pydantic's default `extra=\"ignore\"` applies to the removed fields.

## Verification

- `ruff format`, `ruff check`, `mypy --strict`, and `pytest` all clean (141 passed).
- New `test_filled_vessel_section_round_trip` mirrors `test_filled_curated_slots_round_trip`, confirming `exclude_none` omits the unfilled curated slots and that a filled vessel section round-trips.
- Descriptors regenerated with `deployment describe` over the 17-deployment ACFR data root, and the output shape verified: `deployment_platform` gone, roster under `[deployments.platform]`, no `[deployments.vessel]`.

## Follow-ups

- #171's references to `DeploymentSensor.identity`, `DeploymentSensor.key`, and `DeploymentDescriptor.platform` as a `PlatformIdentity` slot go stale with this change, and its catalog-lookup half now covers three slots rather than two.
- Retiring the parallel `DeploymentConfig` / `load_deployment_config` path, the `comment` field on `TopsideUsblModemConfig`, and `metadata.acfr_platform_label` belong to the CLI-facing migration after #171.