### PR TITLE
Add curated deployment catalog and catalog scaffolding task

### DIFF
--- a/config/deployment_catalog_v1.toml
+++ b/config/deployment_catalog_v1.toml
@@ -1,0 +1,671 @@
+# Curated records that deployment descriptor enrichment resolves against.
+#
+# Translations are in metres and rotations in radians, matching the localizer
+# config and the SensorExtrinsics model. Rotation entries carry their degree
+# equivalents as a trailing comment.
+#
+# Platform profiles are curated at one per calendar year, from the AUV pose
+# families of the 17 deployments whose localizer configs are on disk; no year
+# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
+# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
+# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
+# excluded as an unmeasured placeholder for a device nothing consumes, and
+# nav_frame is not a sensor. PAROSCI carries its pose as written, including the
+# locx the localizer config flags for measurement.
+#
+# Vessel profiles are reshaped from usbl_extrinsics_profiles in
+# config/deployment_configs_all.toml and cover all 52 deployments; the platform
+# side covers the 17 on disk, and the rest follow when the archive does.
+#
+# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
+# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
+# Roster keys with no entry here are simply left unenriched.
+
+[[sensors]]
+key = "camera_prosilica"
+label = "AVT Prosilica GC1380 stereo camera"
+vendor = "AVT"
+product = "Prosilica GC1380"
+type = "stereo_camera"
+
+[[sensors]]
+key = "dvl_teledyne"
+label = "Teledyne RDI Work Horse Navigator DVL"
+vendor = "Teledyne RDI"
+product = "Work Horse Navigator"
+type = "dvl"
+
+[[sensors]]
+key = "pressure_parosci"
+label = "Paroscientific Digiquartz pressure sensor"
+vendor = "Paroscientific"
+product = "Digiquartz"
+type = "pressure"
+
+[[sensors]]
+key = "ctd_seabird"
+label = "Seabird SBE 37-SIP CTD"
+vendor = "Seabird"
+product = "SBE 37-SIP"
+type = "ctd"
+
+[[sensors]]
+key = "ecopuck_wetlabs"
+label = "WET Labs ECO Puck Triplet sensor"
+vendor = "WET Labs"
+product = "ECO Puck Triplet"
+type = "optical"
+
+[[sensors]]
+key = "gnss_ublox"
+label = "u-blox GNSS receiver"
+vendor = "u-blox"
+product = ""
+type = "gnss"
+
+[[sensors]]
+key = "usbl_linkquest"
+label = "LinkQuest TrackLink 1500HA USBL"
+vendor = "LinkQuest"
+product = "TrackLink 1500HA"
+type = "usbl"
+
+[[sensors]]
+key = "usbl_evologics"
+label = "EvoLogics S2C R 18/34 USBL"
+vendor = "EvoLogics"
+product = "S2C R 18/34"
+type = "usbl"
+
+[[sensors]]
+key = "usbl_unrecorded"
+label = "USBL transceiver of unrecorded make"
+vendor = ""
+product = ""
+type = "usbl"
+
+[[sensors]]
+key = "multibeam_deltat"
+label = "Delta T multibeam profiling sonar"
+vendor = ""
+product = ""
+type = "multibeam_sonar"
+
+[[sensors]]
+key = "imu"
+label = "Inertial measurement unit"
+vendor = ""
+product = ""
+type = "imu"
+
+[[sensors]]
+key = "thruster"
+label = "Vehicle thruster"
+vendor = ""
+product = ""
+type = "thruster"
+
+[[sensors]]
+key = "battery_pack"
+label = "Vehicle battery pack"
+vendor = ""
+product = ""
+type = "battery"
+
+[[platform_profiles]]
+key = "2009_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2010_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2011_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2012_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "IMU", identity = "imu" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2013_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2014_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[platform_profiles]]
+key = "2017_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+]
+
+[[vessel_profiles]]
+key = "200906_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201004_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201006_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+]
+
+[[vessel_profiles]]
+key = "201010_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+]
+
+[[vessel_profiles]]
+key = "201102_rv_cape_ferguson"
+vessel_name = "RV Cape Ferguson"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.6902, locy = -0.2213, locz = 5.5554, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+]
+
+[[vessel_profiles]]
+key = "201104_rv_naturaliste"
+vessel_name = "RV Naturaliste"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+]
+
+[[vessel_profiles]]
+key = "201106_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.4044, locy = 4.4116, locz = 4.5342, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+]
+
+[[vessel_profiles]]
+key = "201108_solander"
+vessel_name = "Solander"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+]
+
+[[vessel_profiles]]
+key = "201204_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.1558, locy = -1.4774, locz = 1.5667, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+]
+
+[[vessel_profiles]]
+key = "201205_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.4974, locy = 3.2299, locz = 3.6786, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+]
+
+[[vessel_profiles]]
+key = "201210_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.7233, locy = -5.2351, locz = 1.7692, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+]
+
+[[vessel_profiles]]
+key = "201304_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201306_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.6151, locy = 6.329, locz = 4.5288, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+]
+
+[[vessel_profiles]]
+key = "201310_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.5411, locy = -5.3638, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+]
+
+[[vessel_profiles]]
+key = "201403_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.2602, locy = 0.7042, locz = 2.1945, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+]
+
+[[vessel_profiles]]
+key = "201406_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.9164, locy = 4.7607, locz = 10.7525, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+]
+
+[[vessel_profiles]]
+key = "201502_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.6562, locz = 9.9982, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+]
+
+[[vessel_profiles]]
+key = "201705_silver_streak"
+vessel_name = "Silver Streak"
+sensors = [
+    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.7929, locy = 4.3018, locz = 4.0427, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+]
+
+[[vessel_profiles]]
+key = "202102_poppag"
+vessel_name = "PoppaG"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+]
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20090612_225306"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20100428_020202"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20100605_021022"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20101023_210332"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20110415_020103"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20110416_005411"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20110612_033752"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20120430_002423"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20120501_071203"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20120530_233021"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20121013_060425"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20130406_023610"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20130406_081713"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20130611_002419"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20131022_004934"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20140616_225022"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20170525_234624"
+platform_profile = "2017_auv_sirius"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20100421_022145"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20110410_011202"
+vessel_profile = "201102_rv_cape_ferguson"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20120422_043114"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20130414_013620"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20170523_040815"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20100430_024508"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20120501_033336"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20130405_103429"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20210315_230947"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20100428_020202"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20110415_020103"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20120430_002423"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20130406_023610"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20140327_071251"
+vessel_profile = "201403_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20170526_025746"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20210315_034028"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20110416_005411"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20120501_071203"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20130406_081713"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20140328_063358"
+vessel_profile = "201403_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20170525_234624"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20210315_081519"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20110815_102540"
+vessel_profile = "201108_solander"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150327_015552"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150328_000850"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150328_042551"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20100604_230524"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20120530_064545"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20140616_205232"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20100605_021022"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20120530_233021"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20140616_225022"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20100606_001908"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20120601_070118"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20140616_044549"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20090613_010853"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20090613_104954"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20110612_045149"
+vessel_profile = "201106_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20130611_015335"
+vessel_profile = "201306_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20090612_225306"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20090613_100254"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20110612_033752"
+vessel_profile = "201106_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20130611_002419"
+vessel_profile = "201306_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"

--- a/src/afft/cli/deployment/actions.py
+++ b/src/afft/cli/deployment/actions.py
@@ -2,6 +2,10 @@
 
 from pathlib import Path
 
+from afft.tasks.deployment_catalog import (
+    ScaffoldCatalogCommand,
+    run_scaffold_catalog,
+)
 from afft.tasks.deployment_descriptor import (
     DescribeDeploymentCommand,
     DescribeDeploymentResult,
@@ -30,3 +34,19 @@ def dispatch_describe_deployment(
     result: DescribeDeploymentResult = run_describe_deployment(command)
     if result.diagnostics.failures:
         raise SystemExit(1)
+
+
+def dispatch_scaffold_catalog(
+    input_file: str | Path,
+    output_file: str | Path,
+    verbose: bool = False,
+) -> None:
+    """
+    Scaffold a deployment catalog skeleton from a deployment descriptors file.
+    """
+    command = ScaffoldCatalogCommand(
+        input_file=Path(input_file),
+        output_file=Path(output_file),
+        verbose=verbose,
+    )
+    run_scaffold_catalog(command)

--- a/src/afft/cli/deployment/commands.py
+++ b/src/afft/cli/deployment/commands.py
@@ -2,7 +2,7 @@
 
 import click
 
-from .actions import dispatch_describe_deployment
+from .actions import dispatch_describe_deployment, dispatch_scaffold_catalog
 
 
 @click.group()
@@ -51,3 +51,38 @@ def describe(
     dispatch_describe_deployment(
         root_dir, output_file, deployment_suffix, verbose
     )
+
+
+@deployment_group.command()
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment descriptors TOML file",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    required=True,
+    help="path to write the deployment catalog skeleton as TOML",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="log diagnostics warnings after the run completes",
+)
+def scaffold_catalog(
+    input_file: str,
+    output_file: str,
+    verbose: bool,
+) -> None:
+    """Scaffold a curated deployment catalog from deployment descriptors.
+
+    The skeleton accounts for every deployment, but the curated fields —
+    vessel names, sensor vendors and products, and every mounting pose — are
+    left empty to be filled in by hand.
+    """
+    dispatch_scaffold_catalog(input_file, output_file, verbose)

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -1,5 +1,15 @@
 """Package for AUV deployment configuration."""
 
+from .catalog import (
+    CatalogDeploymentPlatform as CatalogDeploymentPlatform,
+    CatalogDeploymentVessel as CatalogDeploymentVessel,
+    CatalogPlatformProfile as CatalogPlatformProfile,
+    CatalogProfileSensor as CatalogProfileSensor,
+    CatalogSensor as CatalogSensor,
+    CatalogSensorExtrinsics as CatalogSensorExtrinsics,
+    CatalogVesselProfile as CatalogVesselProfile,
+    DeploymentCatalog as DeploymentCatalog,
+)
 from .descriptor import (
     DeploymentDescriptor as DeploymentDescriptor,
     DeploymentFileSection as DeploymentFileSection,
@@ -20,8 +30,10 @@ from .files import (
 )
 from .loader import (
     load_deployment_config as load_deployment_config,
+    read_deployment_catalog as read_deployment_catalog,
     read_deployment_descriptors as read_deployment_descriptors,
     read_deployment_info as read_deployment_info,
+    write_deployment_catalog as write_deployment_catalog,
     write_deployment_descriptors as write_deployment_descriptors,
 )
 from .types import (

--- a/src/afft/deployment/catalog.py
+++ b/src/afft/deployment/catalog.py
@@ -1,0 +1,266 @@
+"""Curated records that deployment descriptor enrichment resolves against."""
+
+from collections.abc import Iterable
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class CatalogSensor(BaseModel):
+    """
+    A curated sensor identity record.
+
+    Attributes
+    ----------
+    key: Catalog lookup key, referenced by ``CatalogProfileSensor.identity``.
+    label: Human-readable sensor name.
+    vendor: Manufacturer.
+    product: Product name.
+    type: Sensor type.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    label: str
+    vendor: str
+    product: str
+    type: str
+
+
+class CatalogSensorExtrinsics(BaseModel):
+    """
+    A curated mounting pose, in the reference frame of the containing profile.
+
+    Attributes
+    ----------
+    locx: X translation in metres.
+    locy: Y translation in metres.
+    locz: Z translation in metres.
+    rotx: Roll angle in radians.
+    roty: Pitch angle in radians.
+    rotz: Yaw angle in radians.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    locx: float
+    locy: float
+    locz: float
+    rotx: float
+    roty: float
+    rotz: float
+
+
+class CatalogProfileSensor(BaseModel):
+    """
+    A sensor mounted on a platform or vessel profile.
+
+    Attributes
+    ----------
+    key: Sensor identifier, matched against ``PlatformSensor.key`` /
+        ``VesselSensor.key`` during enrichment.
+    identity: Key of the ``CatalogSensor`` describing this hardware.
+    extrinsics: Curated mounting pose; ``None`` where the sensor has no
+        surveyed pose.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    identity: str
+    extrinsics: CatalogSensorExtrinsics | None = None
+
+
+class CatalogPlatformProfile(BaseModel):
+    """
+    A platform configuration at a point in time.
+
+    Attributes
+    ----------
+    key: Profile lookup key.
+    platform_label: Human-readable platform name.
+    platform_class: Vehicle class, matching ``system.vehicle_name``.
+    platform_operator: Operating institution.
+    sensors: The platform's sensor roster, with poses in the vehicle (SNAME)
+        body frame.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    platform_label: str
+    platform_class: str
+    platform_operator: str
+    sensors: list[CatalogProfileSensor] = Field(default_factory=list)
+
+
+class CatalogVesselProfile(BaseModel):
+    """
+    A support vessel configuration at a point in time.
+
+    Attributes
+    ----------
+    key: Profile lookup key.
+    vessel_name: Support vessel name.
+    sensors: The vessel's sensor roster, with poses in the ship reference
+        frame.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    vessel_name: str
+    sensors: list[CatalogProfileSensor] = Field(default_factory=list)
+
+
+class CatalogDeploymentPlatform(BaseModel):
+    """
+    Assignment of a platform profile to a deployment.
+
+    Attributes
+    ----------
+    deployment_label: Label of the assigned deployment.
+    platform_profile: Key of the assigned ``CatalogPlatformProfile``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    platform_profile: str
+
+
+class CatalogDeploymentVessel(BaseModel):
+    """
+    Assignment of a vessel profile to a deployment.
+
+    Attributes
+    ----------
+    deployment_label: Label of the assigned deployment.
+    vessel_profile: Key of the assigned ``CatalogVesselProfile``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    vessel_profile: str
+
+
+class DeploymentCatalog(BaseModel):
+    """
+    Curated records that enrichment resolves deployment descriptors against.
+
+    A catalog of the platforms, vessels, and sensors deployments are enriched
+    from — not a catalog of the deployments themselves.
+
+    Attributes
+    ----------
+    sensors: Sensor identity records.
+    platform_profiles: Platform configurations.
+    vessel_profiles: Vessel configurations.
+    deployment_platforms: Per-deployment platform profile assignments.
+    deployment_vessels: Per-deployment vessel profile assignments.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensors: list[CatalogSensor] = Field(default_factory=list)
+    platform_profiles: list[CatalogPlatformProfile] = Field(
+        default_factory=list
+    )
+    vessel_profiles: list[CatalogVesselProfile] = Field(default_factory=list)
+    deployment_platforms: list[CatalogDeploymentPlatform] = Field(
+        default_factory=list
+    )
+    deployment_vessels: list[CatalogDeploymentVessel] = Field(
+        default_factory=list
+    )
+
+    @model_validator(mode="after")
+    def validate_catalog(self) -> Self:
+        """
+        Check the whole-file rules a single record cannot enforce.
+
+        Keys must be unique within each record table, each deployment may be
+        assigned at most one profile of each kind, and every cross-reference
+        must resolve. A dangling reference is a curation error rather than a
+        missing record, so it fails at load.
+
+        Returns
+        -------
+        The validated catalog.
+
+        Raises
+        ------
+        ValueError: If a key is duplicated, a deployment is assigned twice, or
+            a reference names no record.
+        """
+        sensor_keys: set[str] = _unique_keys(
+            (sensor.key for sensor in self.sensors), "sensors"
+        )
+        platform_profile_keys: set[str] = _unique_keys(
+            (profile.key for profile in self.platform_profiles),
+            "platform_profiles",
+        )
+        vessel_profile_keys: set[str] = _unique_keys(
+            (profile.key for profile in self.vessel_profiles),
+            "vessel_profiles",
+        )
+
+        _unique_keys(
+            (entry.deployment_label for entry in self.deployment_platforms),
+            "deployment_platforms",
+        )
+        _unique_keys(
+            (entry.deployment_label for entry in self.deployment_vessels),
+            "deployment_vessels",
+        )
+
+        for platform_profile in self.platform_profiles:
+            _check_sensor_identities(
+                platform_profile.key, platform_profile.sensors, sensor_keys
+            )
+        for vessel_profile in self.vessel_profiles:
+            _check_sensor_identities(
+                vessel_profile.key, vessel_profile.sensors, sensor_keys
+            )
+
+        for platform_entry in self.deployment_platforms:
+            if platform_entry.platform_profile not in platform_profile_keys:
+                raise ValueError(
+                    f"deployment {platform_entry.deployment_label!r} references "
+                    f"unknown platform profile: "
+                    f"{platform_entry.platform_profile!r}"
+                )
+        for vessel_entry in self.deployment_vessels:
+            if vessel_entry.vessel_profile not in vessel_profile_keys:
+                raise ValueError(
+                    f"deployment {vessel_entry.deployment_label!r} references "
+                    f"unknown vessel profile: {vessel_entry.vessel_profile!r}"
+                )
+
+        return self
+
+
+def _unique_keys(keys: Iterable[str], table: str) -> set[str]:
+    """Collect keys into a set, raising on the first duplicate."""
+    unique: set[str] = set()
+    for key in keys:
+        if key in unique:
+            raise ValueError(f"duplicate key in {table}: {key!r}")
+        unique.add(key)
+    return unique
+
+
+def _check_sensor_identities(
+    profile_key: str,
+    sensors: list[CatalogProfileSensor],
+    sensor_keys: set[str],
+) -> None:
+    """Check that every profile sensor identity names a catalog sensor."""
+    for sensor in sensors:
+        if sensor.identity not in sensor_keys:
+            raise ValueError(
+                f"profile {profile_key!r} sensor {sensor.key!r} references "
+                f"unknown sensor identity: {sensor.identity!r}"
+            )

--- a/src/afft/deployment/descriptor.py
+++ b/src/afft/deployment/descriptor.py
@@ -11,12 +11,26 @@ class SensorIdentity(BaseModel):
     """
     Curated identity of a sensor — vendor, product, and label.
 
-    Populated by a later enrichment process; the fields are finalized there.
-    Expected to hold a human-friendly label (e.g. ``"Teledyne RDI Workhorse
-    Navigator 1200"``) plus vendor and product metadata.
+    Populated by a later enrichment process from the curated deployment
+    catalog. Vendor and product stay separate from the free-text label so they
+    remain queryable; either is empty where the hardware has no published
+    record.
+
+    Attributes
+    ----------
+    label: Human-readable sensor name (e.g. ``"Teledyne RDI Work Horse
+        Navigator DVL"``).
+    vendor: Manufacturer (e.g. ``"Teledyne RDI"``).
+    product: Product name (e.g. ``"Work Horse Navigator"``).
+    type: Sensor type (e.g. ``"dvl"``).
     """
 
     model_config = ConfigDict(frozen=True)
+
+    label: str
+    vendor: str
+    product: str
+    type: str
 
 
 class SensorExtrinsics(BaseModel):

--- a/src/afft/deployment/loader.py
+++ b/src/afft/deployment/loader.py
@@ -1,5 +1,8 @@
 """Loaders for deployment configuration and metadata from TOML files."""
 
+import json
+import math
+
 import msgspec
 
 from pathlib import Path
@@ -7,6 +10,7 @@ from typing import Any
 
 from afft.io.config_io import read_config
 
+from .catalog import CatalogProfileSensor, DeploymentCatalog
 from .descriptor import DeploymentDescriptor
 from .types import (
     DeploymentConfig,
@@ -170,3 +174,127 @@ def write_deployment_descriptors(
             }
         )
     )
+
+
+def read_deployment_catalog(path: Path) -> DeploymentCatalog:
+    """
+    Read the curated deployment catalog from a TOML file.
+
+    Arguments
+    ---------
+    path: Path to the deployment catalog TOML file.
+
+    Returns
+    -------
+    The validated deployment catalog.
+
+    Raises
+    ------
+    ValidationError: If a record is malformed, a key is duplicated, or a
+        cross-reference names no record.
+    """
+    raw: dict[str, Any] = read_config(path)
+    return DeploymentCatalog.model_validate(raw)
+
+
+def write_deployment_catalog(path: Path, catalog: DeploymentCatalog) -> None:
+    """
+    Write a deployment catalog to a TOML file.
+
+    Emitted by hand rather than by a TOML encoder so that rotation values,
+    which are stated in radians, carry their degree equivalents as trailing
+    comments — the one place TOML permits a comment on a sensor entry.
+
+    Arguments
+    ---------
+    path: Path to write the deployment catalog TOML file.
+    catalog: Deployment catalog to serialize.
+    """
+    blocks: list[str] = []
+
+    for sensor in catalog.sensors:
+        blocks.append(
+            "[[sensors]]\n"
+            f"key = {_toml_string(sensor.key)}\n"
+            f"label = {_toml_string(sensor.label)}\n"
+            f"vendor = {_toml_string(sensor.vendor)}\n"
+            f"product = {_toml_string(sensor.product)}\n"
+            f"type = {_toml_string(sensor.type)}\n"
+        )
+
+    for platform_profile in catalog.platform_profiles:
+        blocks.append(
+            "[[platform_profiles]]\n"
+            f"key = {_toml_string(platform_profile.key)}\n"
+            f"platform_label = {_toml_string(platform_profile.platform_label)}\n"
+            f"platform_class = {_toml_string(platform_profile.platform_class)}\n"
+            "platform_operator = "
+            f"{_toml_string(platform_profile.platform_operator)}\n"
+            f"{_format_profile_sensors(platform_profile.sensors)}"
+        )
+
+    for vessel_profile in catalog.vessel_profiles:
+        blocks.append(
+            "[[vessel_profiles]]\n"
+            f"key = {_toml_string(vessel_profile.key)}\n"
+            f"vessel_name = {_toml_string(vessel_profile.vessel_name)}\n"
+            f"{_format_profile_sensors(vessel_profile.sensors)}"
+        )
+
+    for platform_entry in catalog.deployment_platforms:
+        blocks.append(
+            "[[deployment_platforms]]\n"
+            f"deployment_label = {_toml_string(platform_entry.deployment_label)}\n"
+            f"platform_profile = {_toml_string(platform_entry.platform_profile)}\n"
+        )
+
+    for vessel_entry in catalog.deployment_vessels:
+        blocks.append(
+            "[[deployment_vessels]]\n"
+            f"deployment_label = {_toml_string(vessel_entry.deployment_label)}\n"
+            f"vessel_profile = {_toml_string(vessel_entry.vessel_profile)}\n"
+        )
+
+    path.write_text("\n".join(blocks))
+
+
+def _toml_string(value: str) -> str:
+    """Format a string as a TOML basic string."""
+    return json.dumps(value)
+
+
+def _format_profile_sensors(sensors: list[CatalogProfileSensor]) -> str:
+    """
+    Format a profile's sensor list as a multi-line TOML array.
+
+    Each sensor is one line, so a sensor carrying a pose can be annotated with
+    its rotations in degrees.
+    """
+    if not sensors:
+        return "sensors = []\n"
+
+    lines: list[str] = ["sensors = ["]
+    for sensor in sensors:
+        entry: str = (
+            f"    {{ key = {_toml_string(sensor.key)}, "
+            f"identity = {_toml_string(sensor.identity)}"
+        )
+        comment: str = ""
+        if sensor.extrinsics is not None:
+            pose = sensor.extrinsics
+            entry += (
+                f", extrinsics = {{ locx = {pose.locx!r}, "
+                f"locy = {pose.locy!r}, locz = {pose.locz!r}, "
+                f"rotx = {pose.rotx!r}, roty = {pose.roty!r}, "
+                f"rotz = {pose.rotz!r} }}"
+            )
+            comment = (
+                "  # rotation in degrees: "
+                f"{math.degrees(pose.rotx):.3f}, "
+                f"{math.degrees(pose.roty):.3f}, "
+                f"{math.degrees(pose.rotz):.3f}"
+            )
+        entry += " },"
+        lines.append(f"{entry}{comment}")
+    lines.append("]\n")
+    return "\n".join(lines)

--- a/src/afft/tasks/deployment_catalog/__init__.py
+++ b/src/afft/tasks/deployment_catalog/__init__.py
@@ -1,0 +1,24 @@
+"""Task for scaffolding a curated deployment catalog from descriptors."""
+
+from .builders import (
+    build_deployment_platforms as build_deployment_platforms,
+    build_deployment_vessels as build_deployment_vessels,
+    build_platform_profile_stubs as build_platform_profile_stubs,
+    build_sensor_stubs as build_sensor_stubs,
+    build_vessel_profile_stubs as build_vessel_profile_stubs,
+    map_platform_profile_keys as map_platform_profile_keys,
+    map_vessel_profile_keys as map_vessel_profile_keys,
+    sensor_identity_key as sensor_identity_key,
+)
+from .runner import (
+    run_scaffold_catalog as run_scaffold_catalog,
+    scaffold_catalog as scaffold_catalog,
+)
+from .types import (
+    CatalogWarning as CatalogWarning,
+    ScaffoldCatalogCommand as ScaffoldCatalogCommand,
+    ScaffoldCatalogDiagnostics as ScaffoldCatalogDiagnostics,
+    ScaffoldCatalogResult as ScaffoldCatalogResult,
+)
+
+__all__ = []

--- a/src/afft/tasks/deployment_catalog/builders.py
+++ b/src/afft/tasks/deployment_catalog/builders.py
@@ -1,0 +1,272 @@
+"""Builders deriving catalog skeleton records from deployment descriptors."""
+
+import re
+
+from afft.deployment import (
+    CatalogDeploymentPlatform,
+    CatalogDeploymentVessel,
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensor,
+    CatalogVesselProfile,
+    DeploymentDescriptor,
+)
+
+from .types import ScaffoldCatalogDiagnostics
+
+_NON_ALPHANUMERIC_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def sensor_identity_key(sensor_key: str) -> str:
+    """
+    Derive a stub sensor identity key from a roster sensor key.
+
+    The identity of the hardware behind a key is not derivable from a
+    deployment, so the stub is keyed on the lowercased roster key (``"RDI"``
+    -> ``"rdi"``) for the curator to rename once vendor and product are known.
+
+    Arguments
+    ---------
+    sensor_key: Roster sensor key, as it appears in the system config.
+
+    Returns
+    -------
+    The stub identity key.
+    """
+    return _snake_case(sensor_key)
+
+
+def map_platform_profile_keys(
+    descriptors: list[DeploymentDescriptor],
+) -> dict[str, str]:
+    """
+    Assign a platform profile key to each deployment.
+
+    Deployments are grouped by calendar year and vehicle name — the granularity
+    platform profiles are curated at. A year that turns out to span two
+    mountings is split by hand afterwards.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to group.
+
+    Returns
+    -------
+    Mapping from deployment label to platform profile key.
+    """
+    return {
+        descriptor.deployment_label: (
+            f"{descriptor.deployment_datetime.year}_"
+            f"{_snake_case(descriptor.system.vehicle_name)}"
+        )
+        for descriptor in descriptors
+    }
+
+
+def map_vessel_profile_keys(
+    descriptors: list[DeploymentDescriptor],
+    diagnostics: ScaffoldCatalogDiagnostics,
+) -> dict[str, str]:
+    """
+    Assign a vessel profile key to each deployment that had a support vessel.
+
+    The ``usbl_logs`` role is the only evidence a deployment was tracked from a
+    vessel, so deployments without it are left unassigned. Deployments are
+    grouped by campaign, and the key's era is the month of the campaign's
+    earliest deployment.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to group.
+    diagnostics: Accumulator for non-fatal issues.
+
+    Returns
+    -------
+    Mapping from deployment label to vessel profile key, covering only the
+    deployments that carry USBL logs.
+    """
+    tracked: list[DeploymentDescriptor] = []
+    for descriptor in descriptors:
+        if descriptor.files.usbl_logs:
+            tracked.append(descriptor)
+        else:
+            diagnostics.warning(
+                descriptor.deployment_label,
+                "no USBL logs; left without a vessel profile",
+            )
+
+    campaign_keys: dict[str, str] = {}
+    for descriptor in sorted(
+        tracked, key=lambda item: item.deployment_datetime
+    ):
+        campaign: str = descriptor.metadata.acfr_campaign_label
+        if campaign not in campaign_keys:
+            campaign_keys[campaign] = (
+                f"{descriptor.deployment_datetime:%Y%m}_"
+                f"{_snake_case(campaign) or 'unknown_campaign'}"
+            )
+
+    return {
+        descriptor.deployment_label: campaign_keys[
+            descriptor.metadata.acfr_campaign_label
+        ]
+        for descriptor in tracked
+    }
+
+
+def build_sensor_stubs(
+    descriptors: list[DeploymentDescriptor],
+) -> list[CatalogSensor]:
+    """
+    Build one sensor identity stub per observed roster sensor key.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to collect sensor keys from.
+
+    Returns
+    -------
+    Sensor stubs with empty curated fields, sorted by key.
+    """
+    identity_keys: set[str] = {
+        sensor_identity_key(sensor.key)
+        for descriptor in descriptors
+        for sensor in descriptor.platform.sensors
+    }
+    return [
+        CatalogSensor(key=key, label="", vendor="", product="", type="")
+        for key in sorted(identity_keys)
+    ]
+
+
+def build_platform_profile_stubs(
+    descriptors: list[DeploymentDescriptor],
+    profile_keys: dict[str, str],
+    diagnostics: ScaffoldCatalogDiagnostics,
+) -> list[CatalogPlatformProfile]:
+    """
+    Build one platform profile stub per assigned profile key.
+
+    A profile's sensor list is the union of the roster keys observed across its
+    deployments: enrichment fills only the slots whose key matches, so a union
+    serves every roster in the group. Extrinsics are omitted rather than
+    zero-filled — an all-zero pose is a real mounting here, not a placeholder.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to collect rosters from.
+    profile_keys: Mapping from deployment label to platform profile key.
+    diagnostics: Accumulator for non-fatal issues.
+
+    Returns
+    -------
+    Platform profile stubs with empty curated fields, sorted by key.
+    """
+    rosters: dict[str, set[str]] = {}
+    platform_classes: dict[str, str] = {}
+    for descriptor in descriptors:
+        profile_key: str = profile_keys[descriptor.deployment_label]
+        if not descriptor.platform.sensors:
+            diagnostics.warning(
+                descriptor.deployment_label, "empty platform sensor roster"
+            )
+        rosters.setdefault(profile_key, set()).update(
+            sensor.key for sensor in descriptor.platform.sensors
+        )
+        platform_classes[profile_key] = descriptor.system.vehicle_name
+
+    return [
+        CatalogPlatformProfile(
+            key=profile_key,
+            platform_label="",
+            platform_class=platform_classes[profile_key],
+            platform_operator="",
+            sensors=[
+                CatalogProfileSensor(
+                    key=sensor_key, identity=sensor_identity_key(sensor_key)
+                )
+                for sensor_key in sorted(rosters[profile_key])
+            ],
+        )
+        for profile_key in sorted(rosters)
+    ]
+
+
+def build_vessel_profile_stubs(
+    profile_keys: dict[str, str],
+) -> list[CatalogVesselProfile]:
+    """
+    Build one vessel profile stub per assigned profile key.
+
+    The stubs carry no sensors: the support vessel is topside, so neither its
+    name nor its transceiver's key and pose appear anywhere in the vehicle's
+    data. The curator adds them.
+
+    Arguments
+    ---------
+    profile_keys: Mapping from deployment label to vessel profile key.
+
+    Returns
+    -------
+    Vessel profile stubs with an empty name and no sensors, sorted by key.
+    """
+    return [
+        CatalogVesselProfile(key=profile_key, vessel_name="")
+        for profile_key in sorted(set(profile_keys.values()))
+    ]
+
+
+def build_deployment_platforms(
+    descriptors: list[DeploymentDescriptor],
+    profile_keys: dict[str, str],
+) -> list[CatalogDeploymentPlatform]:
+    """
+    Build the per-deployment platform profile assignments.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to assign.
+    profile_keys: Mapping from deployment label to platform profile key.
+
+    Returns
+    -------
+    One assignment per deployment, in descriptor order.
+    """
+    return [
+        CatalogDeploymentPlatform(
+            deployment_label=descriptor.deployment_label,
+            platform_profile=profile_keys[descriptor.deployment_label],
+        )
+        for descriptor in descriptors
+    ]
+
+
+def build_deployment_vessels(
+    descriptors: list[DeploymentDescriptor],
+    profile_keys: dict[str, str],
+) -> list[CatalogDeploymentVessel]:
+    """
+    Build the per-deployment vessel profile assignments.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to assign.
+    profile_keys: Mapping from deployment label to vessel profile key.
+
+    Returns
+    -------
+    One assignment per deployment that carries USBL logs, in descriptor order.
+    """
+    return [
+        CatalogDeploymentVessel(
+            deployment_label=descriptor.deployment_label,
+            vessel_profile=profile_keys[descriptor.deployment_label],
+        )
+        for descriptor in descriptors
+        if descriptor.deployment_label in profile_keys
+    ]
+
+
+def _snake_case(value: str) -> str:
+    """Lowercase a label and collapse its non-alphanumeric runs to underscores."""
+    return _NON_ALPHANUMERIC_PATTERN.sub("_", value.lower()).strip("_")

--- a/src/afft/tasks/deployment_catalog/runner.py
+++ b/src/afft/tasks/deployment_catalog/runner.py
@@ -1,0 +1,118 @@
+"""Runner for the scaffold catalog task."""
+
+from afft.deployment import (
+    DeploymentCatalog,
+    DeploymentDescriptor,
+    read_deployment_descriptors,
+    write_deployment_catalog,
+)
+from afft.utils.log import logger
+
+from .builders import (
+    build_deployment_platforms,
+    build_deployment_vessels,
+    build_platform_profile_stubs,
+    build_sensor_stubs,
+    build_vessel_profile_stubs,
+    map_platform_profile_keys,
+    map_vessel_profile_keys,
+)
+from .types import (
+    ScaffoldCatalogCommand,
+    ScaffoldCatalogDiagnostics,
+    ScaffoldCatalogResult,
+)
+
+
+def scaffold_catalog(
+    descriptors: list[DeploymentDescriptor],
+    diagnostics: ScaffoldCatalogDiagnostics,
+) -> DeploymentCatalog:
+    """
+    Scaffold a catalog skeleton from a set of deployment descriptors.
+
+    Curated content — vessel names, vendor and product, and every mounting pose
+    — is not derivable from a deployment and is left empty for the curator. What
+    the skeleton does carry is completeness: every deployment is assigned a
+    profile, so none is silently missed.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to scaffold from.
+    diagnostics: Accumulator for non-fatal issues.
+
+    Returns
+    -------
+    The scaffolded catalog.
+    """
+    platform_keys: dict[str, str] = map_platform_profile_keys(descriptors)
+    vessel_keys: dict[str, str] = map_vessel_profile_keys(
+        descriptors, diagnostics
+    )
+
+    return DeploymentCatalog(
+        sensors=build_sensor_stubs(descriptors),
+        platform_profiles=build_platform_profile_stubs(
+            descriptors, platform_keys, diagnostics
+        ),
+        vessel_profiles=build_vessel_profile_stubs(vessel_keys),
+        deployment_platforms=build_deployment_platforms(
+            descriptors, platform_keys
+        ),
+        deployment_vessels=build_deployment_vessels(descriptors, vessel_keys),
+    )
+
+
+def run_scaffold_catalog(
+    command: ScaffoldCatalogCommand,
+) -> ScaffoldCatalogResult:
+    """
+    Scaffold a deployment catalog from a descriptors file and write it to TOML.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The written catalog and the run's diagnostics.
+    """
+    if not command.input_file.exists():
+        raise FileNotFoundError(
+            f"input file does not exist: {command.input_file}"
+        )
+    if not command.output_file.parent.exists():
+        raise FileNotFoundError(
+            f"output directory does not exist: {command.output_file.parent}"
+        )
+
+    logger.info("-------------------------------------")
+    logger.info("Scaffold Deployment Catalog")
+    logger.info(f"  input file:  {command.input_file}")
+    logger.info(f"  output file: {command.output_file}")
+    logger.info(f"  verbose:     {command.verbose}")
+    logger.info("-------------------------------------")
+
+    descriptors: list[DeploymentDescriptor] = read_deployment_descriptors(
+        command.input_file
+    )
+    if not descriptors:
+        raise ValueError(f"no deployments in {command.input_file}")
+
+    logger.info(f"scaffolding from {len(descriptors)} deployment(s)")
+
+    diagnostics = ScaffoldCatalogDiagnostics()
+    catalog: DeploymentCatalog = scaffold_catalog(descriptors, diagnostics)
+
+    write_deployment_catalog(command.output_file, catalog)
+    logger.info(
+        f"wrote {len(catalog.platform_profiles)} platform profile(s), "
+        f"{len(catalog.vessel_profiles)} vessel profile(s), and "
+        f"{len(catalog.sensors)} sensor stub(s) to {command.output_file}"
+    )
+
+    if command.verbose:
+        for warning in diagnostics.warnings:
+            logger.warning(f"{warning.deployment_label}: {warning.message}")
+
+    return ScaffoldCatalogResult(catalog=catalog, diagnostics=diagnostics)

--- a/src/afft/tasks/deployment_catalog/types.py
+++ b/src/afft/tasks/deployment_catalog/types.py
@@ -1,0 +1,71 @@
+"""Data types for the scaffold catalog task."""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from afft.deployment import DeploymentCatalog
+
+
+@dataclass(slots=True, frozen=True)
+class CatalogWarning:
+    """
+    A non-fatal issue encountered while scaffolding the catalog.
+
+    Attributes
+    ----------
+    deployment_label: Label of the deployment the issue belongs to.
+    message: Human-readable description of the issue.
+    """
+
+    deployment_label: str
+    message: str
+
+
+@dataclass(slots=True)
+class ScaffoldCatalogDiagnostics:
+    """
+    Accumulates issues encountered during the run for deferred reporting.
+
+    Attributes
+    ----------
+    warnings: Non-fatal issues, per deployment.
+    """
+
+    warnings: list[CatalogWarning] = field(default_factory=list)
+
+    def warning(self, deployment_label: str, message: str) -> None:
+        """Append a warning for a deployment."""
+        self.warnings.append(CatalogWarning(deployment_label, message))
+
+
+@dataclass(slots=True, frozen=True)
+class ScaffoldCatalogCommand:
+    """
+    Command for scaffolding a curated deployment catalog from a set of
+    deployment descriptors.
+
+    Attributes
+    ----------
+    input_file: Path to the deployment descriptors TOML file.
+    output_file: Path to write the catalog skeleton as TOML.
+    verbose: Log diagnostics warnings after the run completes.
+    """
+
+    input_file: Path
+    output_file: Path
+    verbose: bool = False
+
+
+@dataclass(slots=True, frozen=True)
+class ScaffoldCatalogResult:
+    """
+    Result of the scaffold catalog task.
+
+    Attributes
+    ----------
+    catalog: The scaffolded catalog skeleton.
+    diagnostics: Warnings from the run.
+    """
+
+    catalog: DeploymentCatalog
+    diagnostics: ScaffoldCatalogDiagnostics

--- a/tests/test_deployment_catalog.py
+++ b/tests/test_deployment_catalog.py
@@ -1,0 +1,244 @@
+"""Tests for the curated deployment catalog datatypes and IO."""
+
+from pathlib import Path
+
+import pytest
+
+from pydantic import ValidationError
+
+from afft.deployment import (
+    CatalogDeploymentPlatform,
+    CatalogDeploymentVessel,
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensor,
+    CatalogSensorExtrinsics,
+    CatalogVesselProfile,
+    DeploymentCatalog,
+    read_deployment_catalog,
+    write_deployment_catalog,
+)
+from afft.io import read_config
+
+DVL_SENSOR: CatalogSensor = CatalogSensor(
+    key="dvl_teledyne",
+    label="Teledyne RDI Work Horse Navigator DVL",
+    vendor="Teledyne RDI",
+    product="Work Horse Navigator",
+    type="dvl",
+)
+USBL_SENSOR: CatalogSensor = CatalogSensor(
+    key="usbl_linkquest",
+    label="LinkQuest TrackLink 1500HA USBL",
+    vendor="LinkQuest",
+    product="TrackLink 1500HA",
+    type="usbl",
+)
+
+
+def _build_catalog() -> DeploymentCatalog:
+    """Builds a catalog covering one platform and one vessel profile."""
+    return DeploymentCatalog(
+        sensors=[DVL_SENSOR, USBL_SENSOR],
+        platform_profiles=[
+            CatalogPlatformProfile(
+                key="2010_auv_sirius",
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="ACFR",
+                sensors=[
+                    CatalogProfileSensor(
+                        key="RDI",
+                        identity="dvl_teledyne",
+                        extrinsics=CatalogSensorExtrinsics(
+                            locx=0.0,
+                            locy=0.0,
+                            locz=0.0,
+                            rotx=0.0,
+                            roty=3.1416,
+                            rotz=-1.5708,
+                        ),
+                    ),
+                    CatalogProfileSensor(
+                        key="LQMODEM", identity="usbl_linkquest"
+                    ),
+                ],
+            )
+        ],
+        vessel_profiles=[
+            CatalogVesselProfile(
+                key="201004_rv_linnaeus",
+                vessel_name="RV Linnaeus",
+                sensors=[
+                    CatalogProfileSensor(
+                        key="USBL",
+                        identity="usbl_linkquest",
+                        extrinsics=CatalogSensorExtrinsics(
+                            locx=-5.715,
+                            locy=-1.258,
+                            locz=1.352,
+                            rotx=0.3316,
+                            roty=0.0,
+                            rotz=0.3138,
+                        ),
+                    )
+                ],
+            )
+        ],
+        deployment_platforms=[
+            CatalogDeploymentPlatform(
+                deployment_label="qdch0ftq_20100428_020202",
+                platform_profile="2010_auv_sirius",
+            )
+        ],
+        deployment_vessels=[
+            CatalogDeploymentVessel(
+                deployment_label="qdch0ftq_20100428_020202",
+                vessel_profile="201004_rv_linnaeus",
+            )
+        ],
+    )
+
+
+def test_catalog_round_trip(tmp_path: Path) -> None:
+    catalog = _build_catalog()
+    path = tmp_path / "catalog.toml"
+
+    write_deployment_catalog(path, catalog)
+
+    assert read_deployment_catalog(path) == catalog
+
+
+def test_absent_extrinsics_are_omitted(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.toml"
+
+    write_deployment_catalog(path, _build_catalog())
+
+    sensors = read_config(path)["platform_profiles"][0]["sensors"]
+    assert "extrinsics" in sensors[0]
+    assert "extrinsics" not in sensors[1]
+    assert (
+        read_deployment_catalog(path).platform_profiles[0].sensors[1].extrinsics
+        is None
+    )
+
+
+def test_rotations_carry_degree_comments(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.toml"
+
+    write_deployment_catalog(path, _build_catalog())
+
+    assert "# rotation in degrees: 0.000, 180.000, -90.000" in path.read_text()
+
+
+def test_empty_catalog_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "catalog.toml"
+
+    write_deployment_catalog(path, DeploymentCatalog())
+
+    assert read_deployment_catalog(path) == DeploymentCatalog()
+
+
+def test_duplicate_sensor_key_is_rejected() -> None:
+    with pytest.raises(ValidationError, match="duplicate key in sensors"):
+        DeploymentCatalog(sensors=[DVL_SENSOR, DVL_SENSOR])
+
+
+def test_duplicate_platform_profile_key_is_rejected() -> None:
+    profile = CatalogPlatformProfile(
+        key="2010_auv_sirius",
+        platform_label="AUV Sirius",
+        platform_class="SEABED",
+        platform_operator="ACFR",
+    )
+    with pytest.raises(
+        ValidationError, match="duplicate key in platform_profiles"
+    ):
+        DeploymentCatalog(platform_profiles=[profile, profile])
+
+
+def test_duplicate_vessel_profile_key_is_rejected() -> None:
+    profile = CatalogVesselProfile(
+        key="201004_rv_linnaeus", vessel_name="RV Linnaeus"
+    )
+    with pytest.raises(
+        ValidationError, match="duplicate key in vessel_profiles"
+    ):
+        DeploymentCatalog(vessel_profiles=[profile, profile])
+
+
+def test_two_platform_assignments_for_one_deployment_are_rejected() -> None:
+    catalog = _build_catalog()
+    with pytest.raises(
+        ValidationError, match="duplicate key in deployment_platforms"
+    ):
+        DeploymentCatalog(
+            sensors=catalog.sensors,
+            platform_profiles=catalog.platform_profiles,
+            deployment_platforms=[
+                *catalog.deployment_platforms,
+                *catalog.deployment_platforms,
+            ],
+        )
+
+
+def test_two_vessel_assignments_for_one_deployment_are_rejected() -> None:
+    catalog = _build_catalog()
+    with pytest.raises(
+        ValidationError, match="duplicate key in deployment_vessels"
+    ):
+        DeploymentCatalog(
+            sensors=catalog.sensors,
+            vessel_profiles=catalog.vessel_profiles,
+            deployment_vessels=[
+                *catalog.deployment_vessels,
+                *catalog.deployment_vessels,
+            ],
+        )
+
+
+def test_unknown_sensor_identity_is_rejected() -> None:
+    with pytest.raises(
+        ValidationError, match="unknown sensor identity: 'dvl_teledyne'"
+    ):
+        DeploymentCatalog(
+            platform_profiles=[
+                CatalogPlatformProfile(
+                    key="2010_auv_sirius",
+                    platform_label="AUV Sirius",
+                    platform_class="SEABED",
+                    platform_operator="ACFR",
+                    sensors=[
+                        CatalogProfileSensor(key="RDI", identity="dvl_teledyne")
+                    ],
+                )
+            ]
+        )
+
+
+def test_unknown_platform_profile_reference_is_rejected() -> None:
+    with pytest.raises(
+        ValidationError, match="unknown platform profile: '2010_auv_sirius'"
+    ):
+        DeploymentCatalog(
+            deployment_platforms=[
+                CatalogDeploymentPlatform(
+                    deployment_label="qdch0ftq_20100428_020202",
+                    platform_profile="2010_auv_sirius",
+                )
+            ]
+        )
+
+
+def test_unknown_vessel_profile_reference_is_rejected() -> None:
+    with pytest.raises(
+        ValidationError, match="unknown vessel profile: '201004_rv_linnaeus'"
+    ):
+        DeploymentCatalog(
+            deployment_vessels=[
+                CatalogDeploymentVessel(
+                    deployment_label="qdch0ftq_20100428_020202",
+                    vessel_profile="201004_rv_linnaeus",
+                )
+            ]
+        )

--- a/tests/test_scaffold_catalog.py
+++ b/tests/test_scaffold_catalog.py
@@ -1,0 +1,223 @@
+"""Tests for the scaffold catalog task and its CLI."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.deployment import (
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    DeploymentMetadata,
+    DeploymentPlatformSection,
+    DeploymentSystemSection,
+    DeploymentTelemetrySection,
+    PlatformSensor,
+    read_deployment_catalog,
+    write_deployment_descriptors,
+)
+from afft.tasks.deployment_catalog import (
+    ScaffoldCatalogCommand,
+    ScaffoldCatalogDiagnostics,
+    run_scaffold_catalog,
+    scaffold_catalog,
+)
+
+
+def _build_descriptor(
+    label: str,
+    moment: datetime,
+    campaign: str,
+    sensor_keys: tuple[str, ...],
+    usbl_logs: tuple[str, ...] = ("usbl/log-1.txt",),
+) -> DeploymentDescriptor:
+    """Builds a descriptor carrying only the fields the scaffolder reads."""
+    return DeploymentDescriptor(
+        deployment_label=label,
+        deployment_datetime=moment,
+        metadata=DeploymentMetadata(
+            acfr_deployment_label=label,
+            acfr_campaign_label=campaign,
+            acfr_platform_label="",
+            origin_latitude=-28.8,
+            origin_longitude=113.9,
+            magnetic_variation=-1.16,
+        ),
+        files=DeploymentFileSection(usbl_logs=list(usbl_logs)),
+        telemetry=DeploymentTelemetrySection(topics=[]),
+        platform=DeploymentPlatformSection(
+            sensors=[PlatformSensor(key=key) for key in sensor_keys]
+        ),
+        system=DeploymentSystemSection(
+            vehicle_name="SEABED",
+            vehicle_config="NORM_CFG",
+            log_directory="/files1/Log",
+            logged_streams=["RAW"],
+        ),
+    )
+
+
+@pytest.fixture
+def descriptors() -> list[DeploymentDescriptor]:
+    """Two deployments in one year and campaign, plus one in the next year."""
+    return [
+        _build_descriptor(
+            "qdch0ftq_20100428_020202",
+            datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+            "WA201004",
+            ("RDI", "VIS"),
+        ),
+        _build_descriptor(
+            "qd61g27j_20100421_022145",
+            datetime(2010, 4, 21, 2, 21, 45, tzinfo=timezone.utc),
+            "WA201004",
+            ("RDI", "PAROSCI"),
+        ),
+        _build_descriptor(
+            "qdch0ftq_20110415_020103",
+            datetime(2011, 4, 15, 2, 1, 3, tzinfo=timezone.utc),
+            "WA201104",
+            ("RDI",),
+            usbl_logs=(),
+        ),
+    ]
+
+
+def test_platform_profiles_are_grouped_per_year(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
+
+    assert [profile.key for profile in catalog.platform_profiles] == [
+        "2010_seabed",
+        "2011_seabed",
+    ]
+    assert catalog.platform_profiles[0].platform_class == "SEABED"
+
+
+def test_platform_profile_sensors_are_the_union_of_the_year(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
+
+    profile = catalog.platform_profiles[0]
+    assert [sensor.key for sensor in profile.sensors] == [
+        "PAROSCI",
+        "RDI",
+        "VIS",
+    ]
+    assert [sensor.identity for sensor in profile.sensors] == [
+        "parosci",
+        "rdi",
+        "vis",
+    ]
+    assert all(sensor.extrinsics is None for sensor in profile.sensors)
+
+
+def test_sensor_stubs_cover_every_observed_key(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
+
+    assert [sensor.key for sensor in catalog.sensors] == [
+        "parosci",
+        "rdi",
+        "vis",
+    ]
+    assert all(sensor.vendor == "" for sensor in catalog.sensors)
+
+
+def test_vessel_profiles_are_grouped_per_campaign(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
+
+    assert [profile.key for profile in catalog.vessel_profiles] == [
+        "201004_wa201004"
+    ]
+    assert catalog.vessel_profiles[0].vessel_name == ""
+    assert catalog.vessel_profiles[0].sensors == []
+
+
+def test_deployments_without_usbl_logs_get_no_vessel(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    diagnostics = ScaffoldCatalogDiagnostics()
+
+    catalog = scaffold_catalog(descriptors, diagnostics)
+
+    assert [
+        entry.deployment_label for entry in catalog.deployment_platforms
+    ] == [
+        "qdch0ftq_20100428_020202",
+        "qd61g27j_20100421_022145",
+        "qdch0ftq_20110415_020103",
+    ]
+    assert [entry.deployment_label for entry in catalog.deployment_vessels] == [
+        "qdch0ftq_20100428_020202",
+        "qd61g27j_20100421_022145",
+    ]
+    assert [warning.deployment_label for warning in diagnostics.warnings] == [
+        "qdch0ftq_20110415_020103"
+    ]
+
+
+def test_mappings_reference_the_derived_profile_keys(
+    descriptors: list[DeploymentDescriptor],
+) -> None:
+    catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
+
+    assert catalog.deployment_platforms[2].platform_profile == "2011_seabed"
+    assert catalog.deployment_vessels[0].vessel_profile == "201004_wa201004"
+
+
+def test_run_writes_a_readable_catalog(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file = tmp_path / "descriptors.toml"
+    output_file = tmp_path / "catalog.toml"
+    write_deployment_descriptors(input_file, descriptors)
+
+    result = run_scaffold_catalog(
+        ScaffoldCatalogCommand(input_file=input_file, output_file=output_file)
+    )
+
+    assert read_deployment_catalog(output_file) == result.catalog
+
+
+def test_run_rejects_an_empty_descriptors_file(tmp_path: Path) -> None:
+    input_file = tmp_path / "descriptors.toml"
+    write_deployment_descriptors(input_file, [])
+
+    with pytest.raises(ValueError, match="no deployments"):
+        run_scaffold_catalog(
+            ScaffoldCatalogCommand(
+                input_file=input_file, output_file=tmp_path / "catalog.toml"
+            )
+        )
+
+
+def test_cli_scaffolds_a_catalog(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file = tmp_path / "descriptors.toml"
+    output_file = tmp_path / "catalog.toml"
+    write_deployment_descriptors(input_file, descriptors)
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "deployment",
+            "scaffold-catalog",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(read_deployment_catalog(output_file).platform_profiles) == 2


### PR DESCRIPTION
Closes #179.

Adds the curated catalog that descriptor enrichment (#171) fills the platform and vessel sections from, the task that scaffolds one, and the first curation of it.

## Format and models

`src/afft/deployment/catalog.py` holds the eight types, all frozen. `DeploymentCatalog` carries the whole-file rules as a model validator run once at load — unique keys within `sensors` / `platform_profiles` / `vessel_profiles`, one assignment per deployment in each mapping table, and every cross-reference resolving. These fail at load rather than warn, since a dangling reference is a curation error rather than a missing record.

`read_deployment_catalog` / `write_deployment_catalog` live in `loader.py`. The writer is hand-rolled rather than encoded through `msgspec`: each profile sensor is one line, so a sensor with a pose can end with `# rotation in degrees: 0.000, 180.000, -90.000`, which no plain TOML dump would produce.

`SensorIdentity` gains its `label` / `vendor` / `product` / `type` fields, where it was previously an empty `BaseModel`.

## Scaffolder

`afft deployment scaffold-catalog --input <descriptors> --output <catalog>`, in `src/afft/tasks/deployment_catalog/`. Over the 17 deployments available locally it emits 7 platform profiles, 14 vessel profiles, 20 sensor stubs, and both mapping tables, warning on the one deployment with no USBL logs. Stub keys are derived for the curator to rename — platform `<year>_<vehicle_name>`, vessel `<YYYYMM>_<campaign>`, sensor identity the lowercased roster key.

## Curation

`config/deployment_catalog_v1.toml`: 7 platform profiles with extrinsics from the localizer configs via the family-to-key table, 19 vessel profiles reshaped from `usbl_extrinsics_profiles`, 17 platform assignments, and all 52 vessel assignments. `201403_rv_linnaeus_uncalibrated` is dropped and the calibrated profile renamed to `201403_rv_linnaeus` to fit the key convention.

The per-year premise was verified rather than assumed: no year spans two pose configurations, and the four distinct configurations fall where the issue predicted — 2009, 2010-2011, 2012-2014, 2017.

Three curation calls worth a look, all recorded in the file's header comment:

- **`MP_INPUT` is uncurated**, alongside `OAS` / `MICRON`. The issue listed it as a candidate; it is not a sensor, so it belongs with `nav_frame`. `IMU`, the thrusters, and the batteries are curated, with empty `vendor` / `product`.
- **Two vessel transceivers have no make on record.** `201502_tasmania_bluefin` and `202102_poppag` fall outside the LinkQuest-through-2014 / EvoLogics-from-2017 evidence, so they carry a `usbl_unrecorded` identity rather than a guess, which keeps their real poses instead of dropping the sensor entry.
- **`multibeam_deltat`, `imu`, `thruster`, `battery_pack`** are named without a vendor token, since inventing one would assert hardware that is not confirmed.

## Testing

`ruff check`, `ruff format --check`, `mypy --strict`, and the full suite pass. New coverage: a catalog round trip, one test per validation rule, extrinsics absent and present, and the scaffolder's grouping, union rosters, USBL gating, mapping rows, and CLI.