### PR TITLE
Rename the catalog sensor identity records and track the curated files

### DIFF
--- a/data/deployment_catalog_v1.toml
+++ b/data/deployment_catalog_v1.toml
@@ -22,94 +22,94 @@
 # Roster keys with no entry here are simply left unenriched.
 
 # --------------------------------------------------------------------------------------
-# Sensors
+# Sensor identities
 # --------------------------------------------------------------------------------------
 
-[[sensors]]
+[[sensor_identities]]
 key = "camera_prosilica"
 label = "AVT Prosilica GC1380 stereo camera"
 vendor = "AVT"
 product = "Prosilica GC1380"
 type = "stereo_camera"
 
-[[sensors]]
+[[sensor_identities]]
 key = "dvl_teledyne"
 label = "Teledyne RDI Work Horse Navigator DVL"
 vendor = "Teledyne RDI"
 product = "Work Horse Navigator"
 type = "dvl"
 
-[[sensors]]
+[[sensor_identities]]
 key = "pressure_parosci"
 label = "Paroscientific Digiquartz pressure sensor"
 vendor = "Paroscientific"
 product = "Digiquartz"
 type = "pressure"
 
-[[sensors]]
+[[sensor_identities]]
 key = "ctd_seabird"
 label = "Seabird SBE 37-SIP CTD"
 vendor = "Seabird"
 product = "SBE 37-SIP"
 type = "ctd"
 
-[[sensors]]
+[[sensor_identities]]
 key = "ecopuck_wetlabs"
 label = "WET Labs ECO Puck Triplet sensor"
 vendor = "WET Labs"
 product = "ECO Puck Triplet"
 type = "optical"
 
-[[sensors]]
+[[sensor_identities]]
 key = "gnss_ublox"
 label = "u-blox GNSS receiver"
 vendor = "u-blox"
 product = ""
 type = "gnss"
 
-[[sensors]]
+[[sensor_identities]]
 key = "usbl_linkquest"
 label = "LinkQuest TrackLink 1500HA USBL"
 vendor = "LinkQuest"
 product = "TrackLink 1500HA"
 type = "usbl"
 
-[[sensors]]
+[[sensor_identities]]
 key = "usbl_evologics"
 label = "EvoLogics S2C R 18/34 USBL"
 vendor = "EvoLogics"
 product = "S2C R 18/34"
 type = "usbl"
 
-[[sensors]]
+[[sensor_identities]]
 key = "usbl_unrecorded"
 label = "USBL transceiver of unrecorded make"
 vendor = ""
 product = ""
 type = "usbl"
 
-[[sensors]]
+[[sensor_identities]]
 key = "multibeam_deltat"
 label = "Delta T multibeam profiling sonar"
 vendor = ""
 product = ""
 type = "multibeam_sonar"
 
-[[sensors]]
+[[sensor_identities]]
 key = "imu"
 label = "Inertial measurement unit"
 vendor = ""
 product = ""
 type = "imu"
 
-[[sensors]]
+[[sensor_identities]]
 key = "thruster"
 label = "Vehicle thruster"
 vendor = ""
 product = ""
 type = "thruster"
 
-[[sensors]]
+[[sensor_identities]]
 key = "battery_pack"
 label = "Vehicle battery pack"
 vendor = ""
@@ -132,12 +132,12 @@ sensors = [
     { key = "GPS", identity = "gnss_ublox" },
     { key = "LQMODEM", identity = "usbl_linkquest" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -152,12 +152,12 @@ sensors = [
     { key = "GPS", identity = "gnss_ublox" },
     { key = "LQMODEM", identity = "usbl_linkquest" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -172,12 +172,12 @@ sensors = [
     { key = "GPS", identity = "gnss_ublox" },
     { key = "LQMODEM", identity = "usbl_linkquest" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -195,12 +195,12 @@ sensors = [
     { key = "IMU", identity = "imu" },
     { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -217,12 +217,12 @@ sensors = [
     { key = "GPS", identity = "gnss_ublox" },
     { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -239,12 +239,12 @@ sensors = [
     { key = "GPS", identity = "gnss_ublox" },
     { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 [[platform_profiles]]
@@ -261,12 +261,12 @@ sensors = [
     { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "GPS", identity = "gnss_ublox" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.141592653, rotz = -1.570796327 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.037314835001888, roty = -0.0065389806502882, rotz = 1.5487628789420478 } },  # rotation in degrees: -2.138, -0.375, 88.738
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
 ]
 
 # --------------------------------------------------------------------------------------
@@ -305,7 +305,7 @@ sensors = [
 key = "201102_rv_cape_ferguson"
 vessel_name = "RV Cape Ferguson"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.6902, locy = -0.2213, locz = 5.5554, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
 ]
 
 [[vessel_profiles]]
@@ -319,7 +319,7 @@ sensors = [
 key = "201106_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.4044, locy = 4.4116, locz = 4.5342, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
 ]
 
 [[vessel_profiles]]
@@ -333,21 +333,21 @@ sensors = [
 key = "201204_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.1558, locy = -1.4774, locz = 1.5667, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
 ]
 
 [[vessel_profiles]]
 key = "201205_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.4974, locy = 3.2299, locz = 3.6786, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
 ]
 
 [[vessel_profiles]]
 key = "201210_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.7233, locy = -5.2351, locz = 1.7692, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
 ]
 
 [[vessel_profiles]]
@@ -361,42 +361,42 @@ sensors = [
 key = "201306_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.6151, locy = 6.329, locz = 4.5288, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
 ]
 
 [[vessel_profiles]]
 key = "201310_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.5411, locy = -5.3638, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
 ]
 
 [[vessel_profiles]]
 key = "201403_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.2602, locy = 0.7042, locz = 2.1945, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
 ]
 
 [[vessel_profiles]]
 key = "201406_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.9164, locy = 4.7607, locz = 10.7525, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
 ]
 
 [[vessel_profiles]]
 key = "201502_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.6562, locz = 9.9982, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
 ]
 
 [[vessel_profiles]]
 key = "201705_silver_streak"
 vessel_name = "Silver Streak"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.7929, locy = 4.3018, locz = 4.0427, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
 ]
 
 [[vessel_profiles]]

--- a/data/deployment_catalog_v1_all.toml
+++ b/data/deployment_catalog_v1_all.toml
@@ -1,0 +1,691 @@
+# Curated records that deployment descriptor enrichment resolves against.
+#
+# Translations are in metres and rotations in radians, matching the localizer
+# config and the SensorExtrinsics model. Rotation entries carry their degree
+# equivalents as a trailing comment.
+#
+# Platform profiles are curated at one per calendar year, from the AUV pose
+# families of the 17 deployments whose localizer configs are on disk; no year
+# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
+# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
+# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
+# excluded as an unmeasured placeholder for a device nothing consumes, and
+# nav_frame is not a sensor. PAROSCI carries its pose as written, including the
+# locx the localizer config flags for measurement.
+#
+# Vessel profiles are reshaped from usbl_extrinsics_profiles in
+# config/deployment_configs_all.toml and cover all 52 deployments; the platform
+# side covers the 17 on disk, and the rest follow when the archive does.
+#
+# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
+# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
+# Roster keys with no entry here are simply left unenriched.
+
+# --------------------------------------------------------------------------------------
+# Sensor identities
+# --------------------------------------------------------------------------------------
+
+[[sensor_identities]]
+key = "camera_prosilica"
+label = "AVT Prosilica GC1380 stereo camera"
+vendor = "AVT"
+product = "Prosilica GC1380"
+type = "stereo_camera"
+
+[[sensor_identities]]
+key = "dvl_teledyne"
+label = "Teledyne RDI Work Horse Navigator DVL"
+vendor = "Teledyne RDI"
+product = "Work Horse Navigator"
+type = "dvl"
+
+[[sensor_identities]]
+key = "pressure_parosci"
+label = "Paroscientific Digiquartz pressure sensor"
+vendor = "Paroscientific"
+product = "Digiquartz"
+type = "pressure"
+
+[[sensor_identities]]
+key = "ctd_seabird"
+label = "Seabird SBE 37-SIP CTD"
+vendor = "Seabird"
+product = "SBE 37-SIP"
+type = "ctd"
+
+[[sensor_identities]]
+key = "ecopuck_wetlabs"
+label = "WET Labs ECO Puck Triplet sensor"
+vendor = "WET Labs"
+product = "ECO Puck Triplet"
+type = "optical"
+
+[[sensor_identities]]
+key = "gnss_ublox"
+label = "u-blox GNSS receiver"
+vendor = "u-blox"
+product = ""
+type = "gnss"
+
+[[sensor_identities]]
+key = "usbl_linkquest"
+label = "LinkQuest TrackLink 1500HA USBL"
+vendor = "LinkQuest"
+product = "TrackLink 1500HA"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_evologics"
+label = "EvoLogics S2C R 18/34 USBL"
+vendor = "EvoLogics"
+product = "S2C R 18/34"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_unrecorded"
+label = "USBL transceiver of unrecorded make"
+vendor = ""
+product = ""
+type = "usbl"
+
+[[sensor_identities]]
+key = "multibeam_deltat"
+label = "Delta T multibeam profiling sonar"
+vendor = ""
+product = ""
+type = "multibeam_sonar"
+
+[[sensor_identities]]
+key = "imu"
+label = "Inertial measurement unit"
+vendor = ""
+product = ""
+type = "imu"
+
+[[sensor_identities]]
+key = "thruster"
+label = "Vehicle thruster"
+vendor = ""
+product = ""
+type = "thruster"
+
+[[sensor_identities]]
+key = "battery_pack"
+label = "Vehicle battery pack"
+vendor = ""
+product = ""
+type = "battery"
+
+# --------------------------------------------------------------------------------------
+# Platform profiles
+# --------------------------------------------------------------------------------------
+
+[[platform_profiles]]
+key = "2009_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2010_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2011_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2012_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "IMU", identity = "imu" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2013_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2014_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2017_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+# --------------------------------------------------------------------------------------
+# Vessel profiles
+# --------------------------------------------------------------------------------------
+
+[[vessel_profiles]]
+key = "200906_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201004_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201006_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+]
+
+[[vessel_profiles]]
+key = "201010_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+]
+
+[[vessel_profiles]]
+key = "201102_rv_cape_ferguson"
+vessel_name = "RV Cape Ferguson"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+]
+
+[[vessel_profiles]]
+key = "201104_rv_naturaliste"
+vessel_name = "RV Naturaliste"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+]
+
+[[vessel_profiles]]
+key = "201106_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+]
+
+[[vessel_profiles]]
+key = "201108_solander"
+vessel_name = "Solander"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+]
+
+[[vessel_profiles]]
+key = "201204_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+]
+
+[[vessel_profiles]]
+key = "201205_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+]
+
+[[vessel_profiles]]
+key = "201210_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+]
+
+[[vessel_profiles]]
+key = "201304_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201306_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+]
+
+[[vessel_profiles]]
+key = "201310_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+]
+
+[[vessel_profiles]]
+key = "201403_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+]
+
+[[vessel_profiles]]
+key = "201406_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+]
+
+[[vessel_profiles]]
+key = "201502_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+]
+
+[[vessel_profiles]]
+key = "201705_silver_streak"
+vessel_name = "Silver Streak"
+sensors = [
+    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+]
+
+[[vessel_profiles]]
+key = "202102_poppag"
+vessel_name = "PoppaG"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+]
+
+# --------------------------------------------------------------------------------------
+# Deployment platforms
+# --------------------------------------------------------------------------------------
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20100428_020202"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20110415_020103"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20120430_002423"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20130406_023610"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20110416_005411"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20120501_071203"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20130406_081713"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20170525_234624"
+platform_profile = "2017_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20100605_021022"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20120530_233021"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20140616_225022"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20090612_225306"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20110612_033752"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20130611_002419"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20101023_210332"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20121013_060425"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20131022_004934"
+platform_profile = "2013_auv_sirius"
+
+# --------------------------------------------------------------------------------------
+# Deployment vessels
+# --------------------------------------------------------------------------------------
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20100421_022145"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20110410_011202"
+vessel_profile = "201102_rv_cape_ferguson"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20120422_043114"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20130414_013620"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qd61g27j_20170523_040815"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20100430_024508"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20120501_033336"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20130405_103429"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdc5ghs3_20210315_230947"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20100428_020202"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20110415_020103"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20120430_002423"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20130406_023610"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20140327_071251"
+vessel_profile = "201403_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20170526_025746"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20210315_034028"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20110416_005411"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20120501_071203"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20130406_081713"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20140328_063358"
+vessel_profile = "201403_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20170525_234624"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20210315_081519"
+vessel_profile = "202102_poppag"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20110815_102540"
+vessel_profile = "201108_solander"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150327_015552"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150328_000850"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "qtqxshxs_20150328_042551"
+vessel_profile = "201502_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20100604_230524"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20120530_064545"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r234xgje_20140616_205232"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20100605_021022"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20120530_233021"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20140616_225022"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20100606_001908"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20120601_070118"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23m7ms0_20140616_044549"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20090613_010853"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20090613_104954"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20110612_045149"
+vessel_profile = "201106_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd12_20130611_015335"
+vessel_profile = "201306_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20090612_225306"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20090613_100254"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20110612_033752"
+vessel_profile = "201106_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20130611_002419"
+vessel_profile = "201306_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjss8n_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjssbh_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"

--- a/data/deployment_catalog_v1_subset.toml
+++ b/data/deployment_catalog_v1_subset.toml
@@ -1,0 +1,631 @@
+# Curated records that deployment descriptor enrichment resolves against.
+#
+# Translations are in metres and rotations in radians, matching the localizer
+# config and the SensorExtrinsics model. Rotation entries carry their degree
+# equivalents as a trailing comment.
+#
+# Platform profiles are curated at one per calendar year, from the AUV pose
+# families of the 17 deployments whose localizer configs are on disk; no year
+# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
+# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
+# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
+# excluded as an unmeasured placeholder for a device nothing consumes, and
+# nav_frame is not a sensor. PAROSCI carries its pose as written, including the
+# locx the localizer config flags for measurement.
+#
+# Vessel profiles are reshaped from usbl_extrinsics_profiles in
+# config/deployment_configs_all.toml and cover all 52 deployments; the platform
+# side covers the 17 on disk, and the rest follow when the archive does.
+#
+# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
+# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
+# Roster keys with no entry here are simply left unenriched.
+
+# --------------------------------------------------------------------------------------
+# Sensor identities
+# --------------------------------------------------------------------------------------
+
+[[sensor_identities]]
+key = "camera_prosilica"
+label = "AVT Prosilica GC1380 stereo camera"
+vendor = "AVT"
+product = "Prosilica GC1380"
+type = "stereo_camera"
+
+[[sensor_identities]]
+key = "dvl_teledyne"
+label = "Teledyne RDI Work Horse Navigator DVL"
+vendor = "Teledyne RDI"
+product = "Work Horse Navigator"
+type = "dvl"
+
+[[sensor_identities]]
+key = "pressure_parosci"
+label = "Paroscientific Digiquartz pressure sensor"
+vendor = "Paroscientific"
+product = "Digiquartz"
+type = "pressure"
+
+[[sensor_identities]]
+key = "ctd_seabird"
+label = "Seabird SBE 37-SIP CTD"
+vendor = "Seabird"
+product = "SBE 37-SIP"
+type = "ctd"
+
+[[sensor_identities]]
+key = "ecopuck_wetlabs"
+label = "WET Labs ECO Puck Triplet sensor"
+vendor = "WET Labs"
+product = "ECO Puck Triplet"
+type = "optical"
+
+[[sensor_identities]]
+key = "gnss_ublox"
+label = "u-blox GNSS receiver"
+vendor = "u-blox"
+product = ""
+type = "gnss"
+
+[[sensor_identities]]
+key = "usbl_linkquest"
+label = "LinkQuest TrackLink 1500HA USBL"
+vendor = "LinkQuest"
+product = "TrackLink 1500HA"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_evologics"
+label = "EvoLogics S2C R 18/34 USBL"
+vendor = "EvoLogics"
+product = "S2C R 18/34"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_unrecorded"
+label = "USBL transceiver of unrecorded make"
+vendor = ""
+product = ""
+type = "usbl"
+
+[[sensor_identities]]
+key = "multibeam_deltat"
+label = "Delta T multibeam profiling sonar"
+vendor = ""
+product = ""
+type = "multibeam_sonar"
+
+[[sensor_identities]]
+key = "imu"
+label = "Inertial measurement unit"
+vendor = ""
+product = ""
+type = "imu"
+
+[[sensor_identities]]
+key = "thruster"
+label = "Vehicle thruster"
+vendor = ""
+product = ""
+type = "thruster"
+
+[[sensor_identities]]
+key = "battery_pack"
+label = "Vehicle battery pack"
+vendor = ""
+product = ""
+type = "battery"
+
+# --------------------------------------------------------------------------------------
+# Platform profiles
+# --------------------------------------------------------------------------------------
+
+[[platform_profiles]]
+key = "2009_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2010_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2011_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2012_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "IMU", identity = "imu" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2013_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[platform_profiles.sensors]]
+key = "BATT0"
+identity = "battery_pack"
+
+[[platform_profiles.sensors]]
+key = "BATT1"
+identity = "battery_pack"
+
+[[platform_profiles.sensors]]
+key = "BATT2"
+identity = "battery_pack"
+
+[[platform_profiles.sensors]]
+key = "DELTA_T"
+identity = "multibeam_deltat"
+
+[platform_profiles.sensors.extrinsics]
+locx = 0.588
+locy = 0.25
+locz = 0.048
+rotx = -0.0076  # -0.435 deg
+roty = 0.084  # 4.813 deg
+rotz = 0.0
+
+[[platform_profiles.sensors]]
+key = "ECOPUCK"
+identity = "ecopuck_wetlabs"
+
+[[platform_profiles.sensors]]
+key = "GPS"
+identity = "gnss_ublox"
+
+[[platform_profiles.sensors]]
+key = "LQMODEM"
+identity = "usbl_linkquest"
+
+[platform_profiles.sensors.extrinsics]
+locx = -1.27
+locy = 0.0
+locz = -0.9
+rotx = 0.0
+roty = 0.0
+rotz = 0.0
+
+[[platform_profiles.sensors]]
+key = "PAROSCI"
+identity = "pressure_parosci"
+
+[platform_profiles.sensors.extrinsics]
+locx = 0.4
+locy = 0.0
+locz = -0.23
+rotx = 0.0
+roty = 0.0
+rotz = 0.0
+
+[[platform_profiles.sensors]]
+key = "RDI"
+identity = "dvl_teledyne"
+
+[platform_profiles.sensors.extrinsics]
+locx = 0.0
+locy = 0.0
+locz = 0.0
+rotx = 0.0
+roty = 3.1416  # 180.000 deg
+rotz = -1.5708  # -90.000 deg
+
+[[platform_profiles.sensors]]
+key = "SEABIRD"
+identity = "ctd_seabird"
+
+[[platform_profiles.sensors]]
+key = "THR_PORT"
+identity = "thruster"
+
+[[platform_profiles.sensors]]
+key = "THR_STBD"
+identity = "thruster"
+
+[[platform_profiles.sensors]]
+key = "THR_VERT"
+identity = "thruster"
+
+[[platform_profiles.sensors]]
+key = "VIS"
+identity = "camera_prosilica"
+
+[platform_profiles.sensors.extrinsics]
+locx = 0.82
+locy = 0.0
+locz = 0.0
+rotx = -0.0373  # -2.137 deg
+roty = -0.0065  # -0.372 deg
+rotz = 1.5488  # 88.740 deg
+
+[[platform_profiles]]
+key = "2014_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+[[platform_profiles]]
+key = "2017_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+]
+
+# --------------------------------------------------------------------------------------
+# Vessel profiles
+# --------------------------------------------------------------------------------------
+
+[[vessel_profiles]]
+key = "200906_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201004_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201006_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+]
+
+[[vessel_profiles]]
+key = "201010_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+]
+
+[[vessel_profiles]]
+key = "201102_rv_cape_ferguson"
+vessel_name = "RV Cape Ferguson"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+]
+
+[[vessel_profiles]]
+key = "201104_rv_naturaliste"
+vessel_name = "RV Naturaliste"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+]
+
+[[vessel_profiles]]
+key = "201106_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+]
+
+[[vessel_profiles]]
+key = "201108_solander"
+vessel_name = "Solander"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+]
+
+[[vessel_profiles]]
+key = "201204_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+]
+
+[[vessel_profiles]]
+key = "201205_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+]
+
+[[vessel_profiles]]
+key = "201210_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+]
+
+[[vessel_profiles]]
+key = "201304_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
+
+[[vessel_profiles]]
+key = "201306_rv_challenger"
+vessel_name = "RV Challenger"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+]
+
+[[vessel_profiles]]
+key = "201310_rv_tom_marshall"
+vessel_name = "RV Tom Marshall"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+]
+
+[[vessel_profiles]]
+key = "201403_rv_linnaeus"
+vessel_name = "RV Linnaeus"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+]
+
+[[vessel_profiles]]
+key = "201406_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+]
+
+[[vessel_profiles]]
+key = "201502_tasmania_bluefin"
+vessel_name = "Tasmania Bluefin"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+]
+
+[[vessel_profiles]]
+key = "201705_silver_streak"
+vessel_name = "Silver Streak"
+sensors = [
+    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+]
+
+[[vessel_profiles]]
+key = "202102_poppag"
+vessel_name = "PoppaG"
+sensors = [
+    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+]
+
+# --------------------------------------------------------------------------------------
+# Deployment platforms
+# --------------------------------------------------------------------------------------
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20100428_020202"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20110415_020103"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20120430_002423"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20130406_023610"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20110416_005411"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20120501_071203"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20130406_081713"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20170525_234624"
+platform_profile = "2017_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20100605_021022"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20120530_233021"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23685bc_20140616_225022"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20090612_225306"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20110612_033752"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20130611_002419"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20101023_210332"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20121013_060425"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjskxq_20131022_004934"
+platform_profile = "2013_auv_sirius"
+
+# --------------------------------------------------------------------------------------
+# Deployment vessels
+# --------------------------------------------------------------------------------------
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20100428_020202"
+vessel_profile = "201004_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20110415_020103"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20120430_002423"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdch0ftq_20130406_023610"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20110416_005411"
+vessel_profile = "201104_rv_naturaliste"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20120501_071203"
+vessel_profile = "201204_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20130406_081713"
+vessel_profile = "201304_rv_linnaeus"
+
+[[deployment_vessels]]
+deployment_label = "qdchdmy1_20170525_234624"
+vessel_profile = "201705_silver_streak"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20100605_021022"
+vessel_profile = "201006_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20120530_233021"
+vessel_profile = "201205_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r23685bc_20140616_225022"
+vessel_profile = "201406_tasmania_bluefin"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20090612_225306"
+vessel_profile = "200906_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20110612_033752"
+vessel_profile = "201106_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r29mrd5h_20130611_002419"
+vessel_profile = "201306_rv_challenger"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20101023_210332"
+vessel_profile = "201010_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20121013_060425"
+vessel_profile = "201210_rv_tom_marshall"
+
+[[deployment_vessels]]
+deployment_label = "r7jjskxq_20131022_004934"
+vessel_profile = "201310_rv_tom_marshall"

--- a/data/deployment_descriptors_v1.toml
+++ b/data/deployment_descriptors_v1.toml
@@ -1,0 +1,1575 @@
+[[deployments]]
+deployment_label = "qdch0ftq_20100428_020202"
+deployment_datetime = 2010-04-28 02:02:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_16_15m_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100428_0202.RAW.auv",
+    "messages/20100428_0300.RAW.auv",
+    "messages/20100428_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100428_0202.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100428_0202.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100428_0202.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100428_0208.geebank_16_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100428/scott20090730_merge2.calib",
+    "camera_calibration/renav20120603/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100428/stereo_pose_est.data",
+    "camera_poses/renav20100428_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100428-011723.txt",
+    "usbl/log-20100428-012839.txt",
+    "usbl/log-20100428-035621.txt",
+    "usbl/log-20100428-040229.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20110415_020103"
+deployment_datetime = 2011-04-15 02:01:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_24_15m_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.12
+
+[deployments.files]
+raw_messages = [
+    "messages/20110415_0201.RAW.auv",
+    "messages/20110415_0300.RAW.auv",
+    "messages/20110415_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110415_0201.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110415_0201.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110415_0201.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110415_0201.geebank_24_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110415/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20110612/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20111223/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110415/stereo_pose_est.data",
+    "camera_poses/renav20110415_stereo_pose_est.data",
+    "camera_poses/renav20111223/stereo_pose_est.data",
+    "camera_poses/renav20111223_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110414-080014.txt",
+    "usbl/log-20110414-080157.txt",
+    "usbl/log-20110415-014036.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20120430_002423"
+deployment_datetime = 2012-04-30 00:24:23+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_34_15m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.07
+
+[deployments.files]
+raw_messages = [
+    "messages/20120430_0024.RAW.auv",
+    "messages/20120430_0100.RAW.auv",
+    "messages/20120430_0200.RAW.auv",
+    "messages/20120430_0300.RAW.auv",
+]
+system_config = [
+    "messages/20120430_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120430_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120430_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120430_0026.geebank_34_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120429-233948.txt",
+    "usbl/log-20120429-234022.txt",
+    "usbl/log-20120430-002623.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20130406_023610"
+deployment_datetime = 2013-04-06 02:36:10+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_03_15m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.03
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0236.RAW.auv",
+    "messages/20130406_0300.RAW.auv",
+    "messages/20130406_0400.RAW.auv",
+    "messages/20130406_0500.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0236.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0236.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0236.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0236.geebank_03_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-010454.txt",
+    "usbl/log-20130406-011204.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20110416_005411"
+deployment_datetime = 2011-04-16 00:54:11+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_27"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.05
+
+[deployments.files]
+raw_messages = [
+    "messages/20110416_0054.RAW.auv",
+    "messages/20110416_0100.RAW.auv",
+    "messages/20110416_0200.RAW.auv",
+    "messages/20110416_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110416_0054.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110416_0054.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110416_0054.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110416_0054.snapperbank_27.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110416/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110416/stereo_pose_est.data",
+    "camera_poses/renav20110416_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110416-002340.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20120501_071203"
+deployment_datetime = 2012-05-01 07:12:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_37"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.01
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0712.RAW.auv",
+    "messages/20120501_0800.RAW.auv",
+    "messages/20120501_0900.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0713.snapperbank_37.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = []
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20130406_081713"
+deployment_datetime = 2013-04-06 08:17:13+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.97
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0817.RAW.auv",
+    "messages/20130406_0900.RAW.auv",
+    "messages/20130406_1000.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0817.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0817.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0817.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0817.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-073750.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20170525_234624"
+deployment_datetime = 2017-05-25 23:46:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS11_snapperbank"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.79
+
+[deployments.files]
+raw_messages = [
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170526_0100.RAW.auv",
+    "messages/20170526_0200.RAW.auv",
+]
+system_config = [
+    "messages/20170525_2346.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170525_2346.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170525_2346.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+    { key = "EVOLOGICS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20100605_021022"
+deployment_datetime = 2010-06-05 02:10:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_15_deep"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100605_0210.RAW.auv",
+    "messages/20100605_0300.RAW.auv",
+    "messages/20100605_0400.RAW.auv",
+    "messages/20100605_0500.RAW.auv",
+]
+system_config = [
+    "messages/20100605_0210.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100605_0210.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100605_0210.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100605_0211.lanterns_15_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100605-005939.txt",
+    "usbl/log-20100605-014520.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20120530_233021"
+deployment_datetime = 2012-05-30 23:30:21+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_10_deep"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_2330.RAW.auv",
+    "messages/20120531_0000.RAW.auv",
+    "messages/20120531_0100.RAW.auv",
+    "messages/20120531_0200.RAW.auv",
+]
+system_config = [
+    "messages/20120530_2330.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_2330.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_2330.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_2332.lanterns_10_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-231147.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20140616_225022"
+deployment_datetime = 2014-06-16 22:50:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_13_lanterns_deep"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2250.RAW.auv",
+    "messages/20140616_2300.RAW.auv",
+    "messages/20140617_0000.RAW.auv",
+    "messages/20140617_0100.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2250.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2250.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2250.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2250.tas_13_lanterns_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140618/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140618/stereo_pose_est.data",
+    "camera_poses/renav20140618_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-225027.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090612_225306"
+deployment_datetime = 2009-06-12 22:53:06+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_07_elephant_rock_deep"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090612_2253.RAW.auv",
+    "messages/20090612_2300.RAW.auv",
+    "messages/20090613_0000.RAW.auv",
+]
+system_config = [
+    "messages/20090612_2253.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090612_2253.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090612_2254.st_helens_07_elephant_rock_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+    "camera_calibration/renav20120228/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090612-224117.txt",
+    "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "RDI" },
+    { key = "GPS" },
+    { key = "ECOPUCK" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "DELTA_T" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20110612_033752"
+deployment_datetime = 2011-06-12 03:37:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0337.RAW.auv",
+    "messages/20110612_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0337.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0337.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0337.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0338.st_helens_01_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-032957.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20130611_002419"
+deployment_datetime = 2013-06-11 00:24:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0024.RAW.auv",
+    "messages/20130611_0100.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0026.st_helens_13_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130612/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130612/stereo_pose_est.data",
+    "camera_poses/renav20130612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130610-233945.txt",
+    "usbl/log-20130610-234950.txt",
+    "usbl/log-20130610-235109.txt",
+    "usbl/log-20130611-000201.txt",
+    "usbl/log-20130611-001308.txt",
+    "usbl/log-20130611-002331.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]

--- a/data/deployment_descriptors_v1_all.toml
+++ b/data/deployment_descriptors_v1_all.toml
@@ -1,0 +1,1575 @@
+[[deployments]]
+deployment_label = "qdch0ftq_20100428_020202"
+deployment_datetime = 2010-04-28 02:02:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_16_15m_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100428_0202.RAW.auv",
+    "messages/20100428_0300.RAW.auv",
+    "messages/20100428_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100428_0202.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100428_0202.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100428_0202.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100428_0208.geebank_16_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100428/scott20090730_merge2.calib",
+    "camera_calibration/renav20120603/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100428/stereo_pose_est.data",
+    "camera_poses/renav20100428_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100428-011723.txt",
+    "usbl/log-20100428-012839.txt",
+    "usbl/log-20100428-035621.txt",
+    "usbl/log-20100428-040229.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20110415_020103"
+deployment_datetime = 2011-04-15 02:01:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_24_15m_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.12
+
+[deployments.files]
+raw_messages = [
+    "messages/20110415_0201.RAW.auv",
+    "messages/20110415_0300.RAW.auv",
+    "messages/20110415_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110415_0201.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110415_0201.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110415_0201.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110415_0201.geebank_24_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110415/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20110612/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20111223/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110415/stereo_pose_est.data",
+    "camera_poses/renav20110415_stereo_pose_est.data",
+    "camera_poses/renav20111223/stereo_pose_est.data",
+    "camera_poses/renav20111223_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110414-080014.txt",
+    "usbl/log-20110414-080157.txt",
+    "usbl/log-20110415-014036.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20120430_002423"
+deployment_datetime = 2012-04-30 00:24:23+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_34_15m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.07
+
+[deployments.files]
+raw_messages = [
+    "messages/20120430_0024.RAW.auv",
+    "messages/20120430_0100.RAW.auv",
+    "messages/20120430_0200.RAW.auv",
+    "messages/20120430_0300.RAW.auv",
+]
+system_config = [
+    "messages/20120430_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120430_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120430_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120430_0026.geebank_34_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120429-233948.txt",
+    "usbl/log-20120429-234022.txt",
+    "usbl/log-20120430-002623.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdch0ftq_20130406_023610"
+deployment_datetime = 2013-04-06 02:36:10+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_03_15m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.03
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0236.RAW.auv",
+    "messages/20130406_0300.RAW.auv",
+    "messages/20130406_0400.RAW.auv",
+    "messages/20130406_0500.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0236.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0236.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0236.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0236.geebank_03_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-010454.txt",
+    "usbl/log-20130406-011204.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20110416_005411"
+deployment_datetime = 2011-04-16 00:54:11+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_27"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.05
+
+[deployments.files]
+raw_messages = [
+    "messages/20110416_0054.RAW.auv",
+    "messages/20110416_0100.RAW.auv",
+    "messages/20110416_0200.RAW.auv",
+    "messages/20110416_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110416_0054.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110416_0054.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110416_0054.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110416_0054.snapperbank_27.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110416/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110416/stereo_pose_est.data",
+    "camera_poses/renav20110416_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110416-002340.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20120501_071203"
+deployment_datetime = 2012-05-01 07:12:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_37"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.01
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0712.RAW.auv",
+    "messages/20120501_0800.RAW.auv",
+    "messages/20120501_0900.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0713.snapperbank_37.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = []
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20130406_081713"
+deployment_datetime = 2013-04-06 08:17:13+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.97
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0817.RAW.auv",
+    "messages/20130406_0900.RAW.auv",
+    "messages/20130406_1000.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0817.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0817.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0817.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0817.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-073750.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "qdchdmy1_20170525_234624"
+deployment_datetime = 2017-05-25 23:46:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS11_snapperbank"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.79
+
+[deployments.files]
+raw_messages = [
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170526_0100.RAW.auv",
+    "messages/20170526_0200.RAW.auv",
+]
+system_config = [
+    "messages/20170525_2346.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170525_2346.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170525_2346.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+    { key = "EVOLOGICS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20100605_021022"
+deployment_datetime = 2010-06-05 02:10:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_15_deep"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100605_0210.RAW.auv",
+    "messages/20100605_0300.RAW.auv",
+    "messages/20100605_0400.RAW.auv",
+    "messages/20100605_0500.RAW.auv",
+]
+system_config = [
+    "messages/20100605_0210.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100605_0210.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100605_0210.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100605_0211.lanterns_15_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100605-005939.txt",
+    "usbl/log-20100605-014520.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20120530_233021"
+deployment_datetime = 2012-05-30 23:30:21+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_10_deep"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_2330.RAW.auv",
+    "messages/20120531_0000.RAW.auv",
+    "messages/20120531_0100.RAW.auv",
+    "messages/20120531_0200.RAW.auv",
+]
+system_config = [
+    "messages/20120530_2330.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_2330.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_2330.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_2332.lanterns_10_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-231147.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "IMU" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r23685bc_20140616_225022"
+deployment_datetime = 2014-06-16 22:50:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_13_lanterns_deep"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2250.RAW.auv",
+    "messages/20140616_2300.RAW.auv",
+    "messages/20140617_0000.RAW.auv",
+    "messages/20140617_0100.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2250.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2250.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2250.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2250.tas_13_lanterns_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140618/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140618/stereo_pose_est.data",
+    "camera_poses/renav20140618_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-225027.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090612_225306"
+deployment_datetime = 2009-06-12 22:53:06+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_07_elephant_rock_deep"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090612_2253.RAW.auv",
+    "messages/20090612_2300.RAW.auv",
+    "messages/20090613_0000.RAW.auv",
+]
+system_config = [
+    "messages/20090612_2253.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090612_2253.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090612_2254.st_helens_07_elephant_rock_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+    "camera_calibration/renav20120228/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090612-224117.txt",
+    "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_STBD" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "RDI" },
+    { key = "GPS" },
+    { key = "ECOPUCK" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+    { key = "DELTA_T" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20110612_033752"
+deployment_datetime = 2011-06-12 03:37:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0337.RAW.auv",
+    "messages/20110612_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0337.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0337.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0337.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0338.st_helens_01_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-032957.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r29mrd5h_20130611_002419"
+deployment_datetime = 2013-06-11 00:24:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0024.RAW.auv",
+    "messages/20130611_0100.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0026.st_helens_13_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130612/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130612/stereo_pose_est.data",
+    "camera_poses/renav20130612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130610-233945.txt",
+    "usbl/log-20130610-234950.txt",
+    "usbl/log-20130610-235109.txt",
+    "usbl/log-20130611-000201.txt",
+    "usbl/log-20130611-001308.txt",
+    "usbl/log-20130611-002331.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "ECOPUCK" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "OAS" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[[deployments]]
+deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+sensors = [
+    { key = "DELTA_T" },
+    { key = "MP_INPUT" },
+    { key = "VIS" },
+    { key = "RDI" },
+    { key = "PAROSCI" },
+    { key = "THR_PORT" },
+    { key = "THR_VERT" },
+    { key = "BATT0" },
+    { key = "BATT1" },
+    { key = "BATT2" },
+    { key = "LQMODEM" },
+    { key = "GPS" },
+    { key = "THR_STBD" },
+    { key = "SEABIRD" },
+    { key = "MICRON" },
+]
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -5,8 +5,8 @@ from .catalog_types import (
     CatalogDeploymentVessel as CatalogDeploymentVessel,
     CatalogPlatformProfile as CatalogPlatformProfile,
     CatalogProfileSensor as CatalogProfileSensor,
-    CatalogSensor as CatalogSensor,
     CatalogSensorExtrinsics as CatalogSensorExtrinsics,
+    CatalogSensorIdentity as CatalogSensorIdentity,
     CatalogVesselProfile as CatalogVesselProfile,
     DeploymentCatalog as DeploymentCatalog,
 )

--- a/src/afft/deployment/catalog_io.py
+++ b/src/afft/deployment/catalog_io.py
@@ -48,9 +48,9 @@ def write_deployment_catalog(path: Path, catalog: DeploymentCatalog) -> None:
     """
     blocks: list[str] = []
 
-    for sensor in catalog.sensors:
+    for sensor in catalog.sensor_identities:
         blocks.append(
-            "[[sensors]]\n"
+            "[[sensor_identities]]\n"
             f"key = {_toml_string(sensor.key)}\n"
             f"label = {_toml_string(sensor.label)}\n"
             f"vendor = {_toml_string(sensor.vendor)}\n"

--- a/src/afft/deployment/catalog_types.py
+++ b/src/afft/deployment/catalog_types.py
@@ -6,7 +6,7 @@ from typing import Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
-class CatalogSensor(BaseModel):
+class CatalogSensorIdentity(BaseModel):
     """
     A curated sensor identity record.
 
@@ -60,7 +60,7 @@ class CatalogProfileSensor(BaseModel):
     ----------
     key: Sensor identifier, matched against ``PlatformSensor.key`` /
         ``VesselSensor.key`` during enrichment.
-    identity: Key of the ``CatalogSensor`` describing this hardware.
+    identity: Key of the ``CatalogSensorIdentity`` describing this hardware.
     extrinsics: Curated mounting pose; ``None`` where the sensor has no
         surveyed pose.
     """
@@ -153,7 +153,7 @@ class DeploymentCatalog(BaseModel):
 
     Attributes
     ----------
-    sensors: Sensor identity records.
+    sensor_identities: Sensor identity records.
     platform_profiles: Platform configurations.
     vessel_profiles: Vessel configurations.
     deployment_platforms: Per-deployment platform profile assignments.
@@ -162,7 +162,7 @@ class DeploymentCatalog(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    sensors: list[CatalogSensor] = Field(default_factory=list)
+    sensor_identities: list[CatalogSensorIdentity] = Field(default_factory=list)
     platform_profiles: list[CatalogPlatformProfile] = Field(
         default_factory=list
     )
@@ -191,7 +191,8 @@ class DeploymentCatalog(BaseModel):
             a reference names no record.
         """
         sensor_keys: set[str] = _unique_keys(
-            (sensor.key for sensor in self.sensors), "sensors"
+            (sensor.key for sensor in self.sensor_identities),
+            "sensor_identities",
         )
         platform_profile_keys: set[str] = _unique_keys(
             (profile.key for profile in self.platform_profiles),

--- a/src/afft/tasks/deployment_catalog/builders.py
+++ b/src/afft/tasks/deployment_catalog/builders.py
@@ -7,7 +7,7 @@ from afft.deployment import (
     CatalogDeploymentVessel,
     CatalogPlatformProfile,
     CatalogProfileSensor,
-    CatalogSensor,
+    CatalogSensorIdentity,
     CatalogVesselProfile,
     DeploymentDescriptor,
 )
@@ -116,7 +116,7 @@ def map_vessel_profile_keys(
 
 def build_sensor_stubs(
     descriptors: list[DeploymentDescriptor],
-) -> list[CatalogSensor]:
+) -> list[CatalogSensorIdentity]:
     """
     Build one sensor identity stub per observed roster sensor key.
 
@@ -134,7 +134,7 @@ def build_sensor_stubs(
         for sensor in descriptor.platform.sensors
     }
     return [
-        CatalogSensor(key=key, label="", vendor="", product="", type="")
+        CatalogSensorIdentity(key=key, label="", vendor="", product="", type="")
         for key in sorted(identity_keys)
     ]
 

--- a/src/afft/tasks/deployment_catalog/runner.py
+++ b/src/afft/tasks/deployment_catalog/runner.py
@@ -51,7 +51,7 @@ def scaffold_catalog(
     )
 
     return DeploymentCatalog(
-        sensors=build_sensor_stubs(descriptors),
+        sensor_identities=build_sensor_stubs(descriptors),
         platform_profiles=build_platform_profile_stubs(
             descriptors, platform_keys, diagnostics
         ),
@@ -108,7 +108,8 @@ def run_scaffold_catalog(
     logger.info(
         f"wrote {len(catalog.platform_profiles)} platform profile(s), "
         f"{len(catalog.vessel_profiles)} vessel profile(s), and "
-        f"{len(catalog.sensors)} sensor stub(s) to {command.output_file}"
+        f"{len(catalog.sensor_identities)} sensor stub(s) to "
+        f"{command.output_file}"
     )
 
     if command.verbose:

--- a/tests/test_deployment_catalog.py
+++ b/tests/test_deployment_catalog.py
@@ -11,7 +11,7 @@ from afft.deployment import (
     CatalogDeploymentVessel,
     CatalogPlatformProfile,
     CatalogProfileSensor,
-    CatalogSensor,
+    CatalogSensorIdentity,
     CatalogSensorExtrinsics,
     CatalogVesselProfile,
     DeploymentCatalog,
@@ -20,14 +20,14 @@ from afft.deployment import (
 )
 from afft.io import read_config
 
-DVL_SENSOR: CatalogSensor = CatalogSensor(
+DVL_SENSOR: CatalogSensorIdentity = CatalogSensorIdentity(
     key="dvl_teledyne",
     label="Teledyne RDI Work Horse Navigator DVL",
     vendor="Teledyne RDI",
     product="Work Horse Navigator",
     type="dvl",
 )
-USBL_SENSOR: CatalogSensor = CatalogSensor(
+USBL_SENSOR: CatalogSensorIdentity = CatalogSensorIdentity(
     key="usbl_linkquest",
     label="LinkQuest TrackLink 1500HA USBL",
     vendor="LinkQuest",
@@ -39,7 +39,7 @@ USBL_SENSOR: CatalogSensor = CatalogSensor(
 def _build_catalog() -> DeploymentCatalog:
     """Builds a catalog covering one platform and one vessel profile."""
     return DeploymentCatalog(
-        sensors=[DVL_SENSOR, USBL_SENSOR],
+        sensor_identities=[DVL_SENSOR, USBL_SENSOR],
         platform_profiles=[
             CatalogPlatformProfile(
                 key="2010_auv_sirius",
@@ -136,7 +136,7 @@ def test_mapping_tables_are_written_sorted_by_deployment_label(
 ) -> None:
     catalog = _build_catalog()
     unsorted = DeploymentCatalog(
-        sensors=catalog.sensors,
+        sensor_identities=catalog.sensor_identities,
         platform_profiles=catalog.platform_profiles,
         vessel_profiles=catalog.vessel_profiles,
         deployment_platforms=[
@@ -178,8 +178,10 @@ def test_empty_catalog_round_trips(tmp_path: Path) -> None:
 
 
 def test_duplicate_sensor_key_is_rejected() -> None:
-    with pytest.raises(ValidationError, match="duplicate key in sensors"):
-        DeploymentCatalog(sensors=[DVL_SENSOR, DVL_SENSOR])
+    with pytest.raises(
+        ValidationError, match="duplicate key in sensor_identities"
+    ):
+        DeploymentCatalog(sensor_identities=[DVL_SENSOR, DVL_SENSOR])
 
 
 def test_duplicate_platform_profile_key_is_rejected() -> None:
@@ -211,7 +213,7 @@ def test_two_platform_assignments_for_one_deployment_are_rejected() -> None:
         ValidationError, match="duplicate key in deployment_platforms"
     ):
         DeploymentCatalog(
-            sensors=catalog.sensors,
+            sensor_identities=catalog.sensor_identities,
             platform_profiles=catalog.platform_profiles,
             deployment_platforms=[
                 *catalog.deployment_platforms,
@@ -226,7 +228,7 @@ def test_two_vessel_assignments_for_one_deployment_are_rejected() -> None:
         ValidationError, match="duplicate key in deployment_vessels"
     ):
         DeploymentCatalog(
-            sensors=catalog.sensors,
+            sensor_identities=catalog.sensor_identities,
             vessel_profiles=catalog.vessel_profiles,
             deployment_vessels=[
                 *catalog.deployment_vessels,

--- a/tests/test_scaffold_catalog.py
+++ b/tests/test_scaffold_catalog.py
@@ -122,12 +122,12 @@ def test_sensor_stubs_cover_every_observed_key(
 ) -> None:
     catalog = scaffold_catalog(descriptors, ScaffoldCatalogDiagnostics())
 
-    assert [sensor.key for sensor in catalog.sensors] == [
+    assert [sensor.key for sensor in catalog.sensor_identities] == [
         "parosci",
         "rdi",
         "vis",
     ]
-    assert all(sensor.vendor == "" for sensor in catalog.sensors)
+    assert all(sensor.vendor == "" for sensor in catalog.sensor_identities)
 
 
 def test_vessel_profiles_are_grouped_per_campaign(


### PR DESCRIPTION
Small patch ahead of the enrichment work in #171.

## Rename

`CatalogSensor` becomes `CatalogSensorIdentity`, and the `DeploymentCatalog` field it backs becomes `sensor_identities`. The old names read as a second sensor roster sitting alongside the profiles' own `sensors` lists, when the table actually holds curated identities of hardware that profile entries reference by key. The per-profile `sensors` field is deliberately unchanged, and the rename makes the two easier to tell apart.

Touched: the class, the field, the validator's table name in its error messages, the writer's table header, the scaffolder's construction and log line, and the tests.

## Format change

The field rename changes the file format, so `[[sensors]]` becomes `[[sensor_identities]]` in the three curated catalogs.

A catalog left in the old form does not load quietly: the identity table comes back empty, so every profile sensor's `identity` fails to resolve and the model validator raises at load, naming the first offender.

```
profile '2009_auv_sirius' sensor 'BATT' references unknown sensor identity: 'battery_pack'
```

## Tracking the curated files

The curated catalogs and the deployment descriptors move under `data/` and are now tracked. They were untracked while the one committed copy was staged for deletion, so the curation — the rounding, the banners, the provenance header — existed only in the working tree.

These are hand-curated artifacts rather than build outputs. #183 covers deriving more of the catalog from the localizer configs; until that lands, the files themselves are the record.

`config/deployment_catalog_v1.toml` is recorded as a rename to `data/deployment_catalog_v1.toml`, so its history follows.

## Testing

`ruff check`, `ruff format --check`, `mypy --strict`, and the 163 tests pass. All three catalogs load with their expected counts, and an old-format file was confirmed to fail loudly.

## Notes

Two loose ends left alone, both cosmetic and neither blocking:

- `data/deployment_catalog_v1.toml` and `data/deployment_catalog_v1_all.toml` are byte-identical, so one is redundant.
- `data/deployment_catalog_v1_subset.toml` has `2013_auv_sirius` written as expanded `[[platform_profiles.sensors]]` tables while its six siblings use inline tables. It parses either way.