### PR TITLE
Add deployment descriptor enrichment task and CLI

### DIFF
--- a/src/afft/cli/deployment/actions.py
+++ b/src/afft/cli/deployment/actions.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from afft.deployment import EnrichmentSection
 from afft.tasks.deployment_catalog import (
     ScaffoldCatalogCommand,
     run_scaffold_catalog,
@@ -10,6 +11,10 @@ from afft.tasks.deployment_descriptor import (
     DescribeDeploymentCommand,
     DescribeDeploymentResult,
     run_describe_deployment,
+)
+from afft.tasks.deployment_enrichment import (
+    EnrichDescriptorCommand,
+    run_enrich_descriptor,
 )
 
 
@@ -50,3 +55,26 @@ def dispatch_scaffold_catalog(
         verbose=verbose,
     )
     run_scaffold_catalog(command)
+
+
+def dispatch_enrich_descriptor(
+    input_file: str | Path,
+    catalog_file: str | Path,
+    output_file: str | Path,
+    section: str = EnrichmentSection.ALL,
+    verbose: bool = False,
+) -> None:
+    """
+    Enrich deployment descriptors from a curated deployment catalog.
+
+    Exits zero whatever the diagnostics hold: a deployment the catalog assigns
+    no profile keeps its unfilled slots rather than failing the run.
+    """
+    command = EnrichDescriptorCommand(
+        input_file=Path(input_file),
+        catalog_file=Path(catalog_file),
+        output_file=Path(output_file),
+        section=EnrichmentSection(section),
+        verbose=verbose,
+    )
+    run_enrich_descriptor(command)

--- a/src/afft/cli/deployment/commands.py
+++ b/src/afft/cli/deployment/commands.py
@@ -2,7 +2,13 @@
 
 import click
 
-from .actions import dispatch_describe_deployment, dispatch_scaffold_catalog
+from afft.deployment import EnrichmentSection
+
+from .actions import (
+    dispatch_describe_deployment,
+    dispatch_enrich_descriptor,
+    dispatch_scaffold_catalog,
+)
 
 
 @click.group()
@@ -86,3 +92,56 @@ def scaffold_catalog(
     left empty to be filled in by hand.
     """
     dispatch_scaffold_catalog(input_file, output_file, verbose)
+
+
+@deployment_group.command()
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment descriptors TOML file",
+)
+@click.option(
+    "--catalog",
+    "catalog_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the curated deployment catalog TOML file",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    required=True,
+    help="path to write the enriched descriptors as TOML",
+)
+@click.option(
+    "--section",
+    type=click.Choice([section.value for section in EnrichmentSection]),
+    default=EnrichmentSection.ALL.value,
+    show_default=True,
+    help="descriptor sections to fill from the catalog",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="log diagnostics warnings after the run completes",
+)
+def enrich(
+    input_file: str,
+    catalog_file: str,
+    output_file: str,
+    section: str,
+    verbose: bool,
+) -> None:
+    """Enrich deployment descriptors from a curated deployment catalog.
+
+    Fills the curated slots the deployment data files cannot supply — platform
+    and vessel identities, sensor identities, and mounting poses. Passing the
+    input path as the output enriches the descriptors in place.
+    """
+    dispatch_enrich_descriptor(
+        input_file, catalog_file, output_file, section, verbose
+    )

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -32,6 +32,14 @@ from .descriptor_io import (
     read_deployment_descriptors as read_deployment_descriptors,
     write_deployment_descriptors as write_deployment_descriptors,
 )
+from .enrichment import (
+    DeploymentCatalogIndex as DeploymentCatalogIndex,
+    DeploymentEnrichment as DeploymentEnrichment,
+    EnrichmentSection as EnrichmentSection,
+    enrich_descriptor as enrich_descriptor,
+    enrich_platform_section as enrich_platform_section,
+    enrich_vessel_section as enrich_vessel_section,
+)
 from .files import (
     DeploymentFiles as DeploymentFiles,
     collect_deployment_files as collect_deployment_files,

--- a/src/afft/deployment/descriptor_types.py
+++ b/src/afft/deployment/descriptor_types.py
@@ -251,8 +251,8 @@ class DeploymentDescriptor(BaseModel):
     telemetry: Message topics observed in the RAW AUV logs.
     platform: The platform's curated identity and its sensor roster.
     system: The vehicle's identity and logging setup.
-    vessel: The support vessel's curated identity and its sensor roster;
-        ``None`` until enrichment fills it.
+    vessel: The support vessel's curated identity and its sensor roster; empty
+        until enrichment fills it.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -266,4 +266,6 @@ class DeploymentDescriptor(BaseModel):
     platform: DeploymentPlatformSection
     system: DeploymentSystemSection
 
-    vessel: DeploymentVesselSection | None = None
+    vessel: DeploymentVesselSection = Field(
+        default_factory=DeploymentVesselSection
+    )

--- a/src/afft/deployment/enrichment.py
+++ b/src/afft/deployment/enrichment.py
@@ -1,0 +1,320 @@
+"""Enrichment of deployment descriptors from a curated deployment catalog."""
+
+from enum import StrEnum
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict
+
+from .catalog_types import (
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensorIdentity,
+    CatalogVesselProfile,
+    DeploymentCatalog,
+)
+from .descriptor_types import (
+    DeploymentDescriptor,
+    DeploymentPlatformSection,
+    DeploymentVesselSection,
+    PlatformIdentity,
+    PlatformSensor,
+    SensorExtrinsics,
+    SensorIdentity,
+    VesselIdentity,
+    VesselSensor,
+)
+
+type CatalogKey = str
+type DeploymentLabel = str
+
+
+class EnrichmentSection(StrEnum):
+    """The descriptor sections enrichment can be asked to fill."""
+
+    PLATFORM = "platform"
+    VESSEL = "vessel"
+    ALL = "all"
+
+
+class DeploymentCatalogIndex(BaseModel):
+    """
+    The catalog's record tables keyed for lookup, built once per run.
+
+    Attributes
+    ----------
+    sensor_identities: Sensor identity records, keyed by catalog key.
+    platform_profiles: Platform profiles, keyed by catalog key.
+    vessel_profiles: Vessel profiles, keyed by catalog key.
+    platform_assignments: Platform profile key, per deployment label.
+    vessel_assignments: Vessel profile key, per deployment label.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_identities: dict[CatalogKey, CatalogSensorIdentity]
+    platform_profiles: dict[CatalogKey, CatalogPlatformProfile]
+    vessel_profiles: dict[CatalogKey, CatalogVesselProfile]
+    platform_assignments: dict[DeploymentLabel, CatalogKey]
+    vessel_assignments: dict[DeploymentLabel, CatalogKey]
+
+    @classmethod
+    def from_catalog(cls, catalog: DeploymentCatalog) -> Self:
+        """
+        Index a catalog for lookup by deployment label and record key.
+
+        Arguments
+        ---------
+        catalog: The curated catalog to index.
+
+        Returns
+        -------
+        The indexed catalog.
+        """
+        return cls(
+            sensor_identities={
+                sensor.key: sensor for sensor in catalog.sensor_identities
+            },
+            platform_profiles={
+                profile.key: profile for profile in catalog.platform_profiles
+            },
+            vessel_profiles={
+                profile.key: profile for profile in catalog.vessel_profiles
+            },
+            platform_assignments={
+                entry.deployment_label: entry.platform_profile
+                for entry in catalog.deployment_platforms
+            },
+            vessel_assignments={
+                entry.deployment_label: entry.vessel_profile
+                for entry in catalog.deployment_vessels
+            },
+        )
+
+    def platform_profile(
+        self, deployment_label: DeploymentLabel
+    ) -> CatalogPlatformProfile | None:
+        """
+        Look up the platform profile assigned to a deployment.
+
+        Arguments
+        ---------
+        deployment_label: Label of the deployment to look up.
+
+        Returns
+        -------
+        The assigned platform profile, or ``None`` if the deployment has no
+        assignment.
+        """
+        key: CatalogKey | None = self.platform_assignments.get(deployment_label)
+        return self.platform_profiles.get(key) if key is not None else None
+
+    def vessel_profile(
+        self, deployment_label: DeploymentLabel
+    ) -> CatalogVesselProfile | None:
+        """
+        Look up the vessel profile assigned to a deployment.
+
+        Arguments
+        ---------
+        deployment_label: Label of the deployment to look up.
+
+        Returns
+        -------
+        The assigned vessel profile, or ``None`` if the deployment has no
+        assignment.
+        """
+        key: CatalogKey | None = self.vessel_assignments.get(deployment_label)
+        return self.vessel_profiles.get(key) if key is not None else None
+
+
+class DeploymentEnrichment(BaseModel):
+    """
+    A descriptor with its curated slots filled, and whether each requested
+    section resolved to a catalog profile. A ``None`` flag means the section
+    was not requested.
+
+    Attributes
+    ----------
+    descriptor: The enriched descriptor.
+    platform_matched: Whether the platform section resolved to a profile;
+        ``None`` if the platform section was not requested.
+    vessel_matched: Whether the vessel section resolved to a profile; ``None``
+        if the vessel section was not requested.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    descriptor: DeploymentDescriptor
+    platform_matched: bool | None = None
+    vessel_matched: bool | None = None
+
+
+def enrich_descriptor(
+    descriptor: DeploymentDescriptor,
+    index: DeploymentCatalogIndex,
+    section: EnrichmentSection = EnrichmentSection.ALL,
+) -> DeploymentEnrichment:
+    """
+    Fill a descriptor's curated slots from an indexed catalog.
+
+    The catalog is authoritative: the requested sections are filled from it
+    whatever they held before, so enrichment is a pure function of the
+    descriptor and the catalog. Sections that were not requested are left
+    exactly as the descriptor held them.
+
+    Arguments
+    ---------
+    descriptor: The descriptor to enrich.
+    index: The indexed catalog to resolve curated records against.
+    section: The sections to fill.
+
+    Returns
+    -------
+    The enriched descriptor and which requested sections resolved.
+    """
+    updates: dict[str, DeploymentPlatformSection | DeploymentVesselSection] = {}
+    platform_matched: bool | None = None
+    vessel_matched: bool | None = None
+
+    if section in (EnrichmentSection.PLATFORM, EnrichmentSection.ALL):
+        platform_profile: CatalogPlatformProfile | None = (
+            index.platform_profile(descriptor.deployment_label)
+        )
+        platform_matched = platform_profile is not None
+        if platform_profile is not None:
+            updates["platform"] = enrich_platform_section(
+                descriptor.platform, platform_profile, index.sensor_identities
+            )
+
+    if section in (EnrichmentSection.VESSEL, EnrichmentSection.ALL):
+        vessel_profile: CatalogVesselProfile | None = index.vessel_profile(
+            descriptor.deployment_label
+        )
+        vessel_matched = vessel_profile is not None
+        if vessel_profile is not None:
+            updates["vessel"] = enrich_vessel_section(
+                descriptor.vessel, vessel_profile, index.sensor_identities
+            )
+
+    return DeploymentEnrichment(
+        descriptor=descriptor.model_copy(update=updates),
+        platform_matched=platform_matched,
+        vessel_matched=vessel_matched,
+    )
+
+
+def enrich_platform_section(
+    section: DeploymentPlatformSection,
+    profile: CatalogPlatformProfile,
+    identities: dict[CatalogKey, CatalogSensorIdentity],
+) -> DeploymentPlatformSection:
+    """
+    Fill a platform section's curated slots from a platform profile.
+
+    The roster comes from the deployment's system config, so it is preserved
+    key by key: a roster key the profile does not carry keeps its empty slots,
+    and a profile entry no roster key names is unused.
+
+    Arguments
+    ---------
+    section: The platform section to enrich.
+    profile: The platform profile assigned to the deployment.
+    identities: Catalog sensor identities, keyed by catalog key.
+
+    Returns
+    -------
+    The enriched platform section.
+    """
+    entries: dict[str, CatalogProfileSensor] = {
+        sensor.key: sensor for sensor in profile.sensors
+    }
+    return section.model_copy(
+        update={
+            "identity": PlatformIdentity(
+                platform_label=profile.platform_label,
+                platform_class=profile.platform_class,
+                platform_operator=profile.platform_operator,
+            ),
+            "sensors": [
+                PlatformSensor(
+                    key=sensor.key,
+                    identity=_sensor_identity(
+                        entries.get(sensor.key), identities
+                    ),
+                    extrinsics=_sensor_extrinsics(entries.get(sensor.key)),
+                )
+                for sensor in section.sensors
+            ],
+        }
+    )
+
+
+def enrich_vessel_section(
+    section: DeploymentVesselSection,
+    profile: CatalogVesselProfile,
+    identities: dict[CatalogKey, CatalogSensorIdentity],
+) -> DeploymentVesselSection:
+    """
+    Fill a vessel section from a vessel profile.
+
+    Every field of the section is curated — nothing in the deployment data
+    names the support vessel — so the profile's roster replaces the section's
+    contents outright rather than filling slots around derived content.
+
+    Arguments
+    ---------
+    section: The vessel section to enrich.
+    profile: The vessel profile assigned to the deployment.
+    identities: Catalog sensor identities, keyed by catalog key.
+
+    Returns
+    -------
+    The enriched vessel section.
+    """
+    return section.model_copy(
+        update={
+            "identity": VesselIdentity(vessel_name=profile.vessel_name),
+            "sensors": [
+                VesselSensor(
+                    key=sensor.key,
+                    identity=_sensor_identity(sensor, identities),
+                    extrinsics=_sensor_extrinsics(sensor),
+                )
+                for sensor in profile.sensors
+            ],
+        }
+    )
+
+
+def _sensor_identity(
+    entry: CatalogProfileSensor | None,
+    identities: dict[CatalogKey, CatalogSensorIdentity],
+) -> SensorIdentity | None:
+    """Resolve a profile sensor's identity reference against the catalog."""
+    if entry is None:
+        return None
+    identity: CatalogSensorIdentity | None = identities.get(entry.identity)
+    if identity is None:
+        return None
+    return SensorIdentity(
+        label=identity.label,
+        vendor=identity.vendor,
+        product=identity.product,
+        type=identity.type,
+    )
+
+
+def _sensor_extrinsics(
+    entry: CatalogProfileSensor | None,
+) -> SensorExtrinsics | None:
+    """Convert a profile sensor's curated pose to descriptor extrinsics."""
+    if entry is None or entry.extrinsics is None:
+        return None
+    return SensorExtrinsics(
+        locx=entry.extrinsics.locx,
+        locy=entry.extrinsics.locy,
+        locz=entry.extrinsics.locz,
+        rotx=entry.extrinsics.rotx,
+        roty=entry.extrinsics.roty,
+        rotz=entry.extrinsics.rotz,
+    )

--- a/src/afft/tasks/deployment_enrichment/__init__.py
+++ b/src/afft/tasks/deployment_enrichment/__init__.py
@@ -1,0 +1,14 @@
+"""Task for enriching deployment descriptors from a curated catalog."""
+
+from .runner import (
+    enrich_descriptors as enrich_descriptors,
+    run_enrich_descriptor as run_enrich_descriptor,
+)
+from .types import (
+    EnrichDescriptorCommand as EnrichDescriptorCommand,
+    EnrichDescriptorDiagnostics as EnrichDescriptorDiagnostics,
+    EnrichDescriptorResult as EnrichDescriptorResult,
+    EnrichmentWarning as EnrichmentWarning,
+)
+
+__all__ = []

--- a/src/afft/tasks/deployment_enrichment/runner.py
+++ b/src/afft/tasks/deployment_enrichment/runner.py
@@ -1,0 +1,126 @@
+"""Runner for the enrich descriptor task."""
+
+from afft.deployment import (
+    DeploymentCatalog,
+    DeploymentCatalogIndex,
+    DeploymentDescriptor,
+    DeploymentEnrichment,
+    EnrichmentSection,
+    enrich_descriptor,
+    read_deployment_catalog,
+    read_deployment_descriptors,
+    write_deployment_descriptors,
+)
+from afft.utils.log import logger
+
+from .types import (
+    EnrichDescriptorCommand,
+    EnrichDescriptorDiagnostics,
+    EnrichDescriptorResult,
+)
+
+
+def enrich_descriptors(
+    descriptors: list[DeploymentDescriptor],
+    catalog: DeploymentCatalog,
+    diagnostics: EnrichDescriptorDiagnostics,
+    section: EnrichmentSection = EnrichmentSection.ALL,
+) -> list[DeploymentDescriptor]:
+    """
+    Enrich a set of deployment descriptors from a curated catalog.
+
+    A deployment the catalog assigns no profile is a curation gap rather than
+    a failure: it is reported as a warning and keeps its unfilled slots.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to enrich.
+    catalog: The curated catalog to resolve against.
+    diagnostics: Accumulator for non-fatal issues.
+    section: The descriptor sections to fill.
+
+    Returns
+    -------
+    The enriched descriptors, in input order.
+    """
+    index: DeploymentCatalogIndex = DeploymentCatalogIndex.from_catalog(catalog)
+
+    enriched: list[DeploymentDescriptor] = []
+    for descriptor in descriptors:
+        enrichment: DeploymentEnrichment = enrich_descriptor(
+            descriptor, index, section
+        )
+        if enrichment.platform_matched is False:
+            diagnostics.warning(
+                descriptor.deployment_label, "no platform profile assigned"
+            )
+        if enrichment.vessel_matched is False:
+            diagnostics.warning(
+                descriptor.deployment_label, "no vessel profile assigned"
+            )
+        enriched.append(enrichment.descriptor)
+
+    return enriched
+
+
+def run_enrich_descriptor(
+    command: EnrichDescriptorCommand,
+) -> EnrichDescriptorResult:
+    """
+    Enrich a descriptors file from a catalog file and write it back to TOML.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The written descriptors and the run's diagnostics.
+    """
+    if not command.input_file.exists():
+        raise FileNotFoundError(
+            f"input file does not exist: {command.input_file}"
+        )
+    if not command.catalog_file.exists():
+        raise FileNotFoundError(
+            f"catalog file does not exist: {command.catalog_file}"
+        )
+    if not command.output_file.parent.exists():
+        raise FileNotFoundError(
+            f"output directory does not exist: {command.output_file.parent}"
+        )
+
+    logger.info("-------------------------------------")
+    logger.info("Enrich Deployment Descriptors")
+    logger.info(f"  input file:   {command.input_file}")
+    logger.info(f"  catalog file: {command.catalog_file}")
+    logger.info(f"  output file:  {command.output_file}")
+    logger.info(f"  section:      {command.section}")
+    logger.info(f"  verbose:      {command.verbose}")
+    logger.info("-------------------------------------")
+
+    descriptors: list[DeploymentDescriptor] = read_deployment_descriptors(
+        command.input_file
+    )
+    if not descriptors:
+        raise ValueError(f"no deployments in {command.input_file}")
+
+    catalog: DeploymentCatalog = read_deployment_catalog(command.catalog_file)
+
+    logger.info(f"enriching {len(descriptors)} deployment(s)")
+
+    diagnostics = EnrichDescriptorDiagnostics()
+    enriched: list[DeploymentDescriptor] = enrich_descriptors(
+        descriptors, catalog, diagnostics, command.section
+    )
+
+    write_deployment_descriptors(command.output_file, enriched)
+    logger.info(
+        f"wrote {len(enriched)} enriched deployment(s) to {command.output_file}"
+    )
+
+    if command.verbose:
+        for warning in diagnostics.warnings:
+            logger.warning(f"{warning.deployment_label}: {warning.message}")
+
+    return EnrichDescriptorResult(descriptors=enriched, diagnostics=diagnostics)

--- a/src/afft/tasks/deployment_enrichment/types.py
+++ b/src/afft/tasks/deployment_enrichment/types.py
@@ -1,0 +1,82 @@
+"""Data types for the enrich descriptor task."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from afft.deployment import DeploymentDescriptor, EnrichmentSection
+
+
+class EnrichmentWarning(BaseModel):
+    """
+    A non-fatal issue encountered while enriching one deployment.
+
+    Attributes
+    ----------
+    deployment_label: Label of the deployment the issue belongs to.
+    message: Human-readable description of the issue.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    message: str
+
+
+class EnrichDescriptorDiagnostics(BaseModel):
+    """
+    Accumulates issues encountered during the run for deferred reporting.
+
+    Attributes
+    ----------
+    warnings: Non-fatal issues, per deployment.
+    """
+
+    warnings: list[EnrichmentWarning] = Field(default_factory=list)
+
+    def warning(self, deployment_label: str, message: str) -> None:
+        """Append a warning for a deployment."""
+        self.warnings.append(
+            EnrichmentWarning(
+                deployment_label=deployment_label, message=message
+            )
+        )
+
+
+class EnrichDescriptorCommand(BaseModel):
+    """
+    Command for enriching deployment descriptors from a curated catalog.
+
+    Attributes
+    ----------
+    input_file: Path to the deployment descriptors TOML file.
+    catalog_file: Path to the curated deployment catalog TOML file.
+    output_file: Path to write the enriched descriptors as TOML; the input
+        path enriches in place.
+    section: The descriptor sections to fill.
+    verbose: Log diagnostics warnings after the run completes.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    catalog_file: Path
+    output_file: Path
+    section: EnrichmentSection = EnrichmentSection.ALL
+    verbose: bool = False
+
+
+class EnrichDescriptorResult(BaseModel):
+    """
+    Result of the enrich descriptor task.
+
+    Attributes
+    ----------
+    descriptors: The enriched descriptors, in input order.
+    diagnostics: Warnings from the run.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    descriptors: list[DeploymentDescriptor]
+    diagnostics: EnrichDescriptorDiagnostics

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -111,13 +111,13 @@ def test_unfilled_curated_slots_are_omitted(tmp_path: Path) -> None:
     write_deployment_descriptors(path, [_build_descriptor()])
 
     entry = read_config(path)["deployments"][0]
-    assert "vessel" not in entry
+    assert entry["vessel"] == {"sensors": []}
     assert "identity" not in entry["platform"]
     assert "identity" not in entry["platform"]["sensors"][0]
     assert "extrinsics" not in entry["platform"]["sensors"][0]
 
     descriptors = read_deployment_descriptors(path)
-    assert descriptors[0].vessel is None
+    assert descriptors[0].vessel == DeploymentVesselSection()
     assert descriptors[0].platform.identity is None
     assert descriptors[0].platform.sensors[0].identity is None
     assert descriptors[0].platform.sensors[0].extrinsics is None

--- a/tests/test_deployment_enrichment.py
+++ b/tests/test_deployment_enrichment.py
@@ -1,0 +1,469 @@
+"""Tests for the deployment descriptor enrichment task and its CLI."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.deployment import (
+    CatalogDeploymentPlatform,
+    CatalogDeploymentVessel,
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensorExtrinsics,
+    CatalogSensorIdentity,
+    CatalogVesselProfile,
+    DeploymentCatalog,
+    DeploymentCatalogIndex,
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    DeploymentMetadata,
+    DeploymentPlatformSection,
+    DeploymentSystemSection,
+    DeploymentTelemetrySection,
+    EnrichmentSection,
+    PlatformSensor,
+    enrich_descriptor,
+    read_deployment_descriptors,
+    write_deployment_catalog,
+    write_deployment_descriptors,
+)
+from afft.tasks.deployment_enrichment import (
+    EnrichDescriptorCommand,
+    EnrichDescriptorDiagnostics,
+    enrich_descriptors,
+    run_enrich_descriptor,
+)
+
+PLATFORM_LABEL: str = "qdch0ftq_20100428_020202"
+UNASSIGNED_LABEL: str = "qd61g27j_20100421_022145"
+
+
+def _build_descriptor(
+    label: str,
+    sensor_keys: tuple[str, ...] = ("RDI", "VIS", "MICRON"),
+) -> DeploymentDescriptor:
+    """Builds a descriptor carrying only the fields enrichment reads."""
+    return DeploymentDescriptor(
+        deployment_label=label,
+        deployment_datetime=datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+        metadata=DeploymentMetadata(
+            acfr_deployment_label=label,
+            acfr_campaign_label="WA201004",
+            acfr_platform_label="",
+            origin_latitude=-28.8,
+            origin_longitude=113.9,
+            magnetic_variation=-1.16,
+        ),
+        files=DeploymentFileSection(),
+        telemetry=DeploymentTelemetrySection(topics=[]),
+        platform=DeploymentPlatformSection(
+            sensors=[PlatformSensor(key=key) for key in sensor_keys]
+        ),
+        system=DeploymentSystemSection(
+            vehicle_name="SEABED",
+            vehicle_config="NORM_CFG",
+            log_directory="/files1/Log",
+            logged_streams=["RAW"],
+        ),
+    )
+
+
+def _build_catalog() -> DeploymentCatalog:
+    """
+    Builds a catalog assigning both profiles to one deployment and neither to
+    the other, with a platform profile carrying an entry — ``DELTA_T`` — that
+    no roster names and lacking one — ``MICRON`` — that every roster does.
+    """
+    return DeploymentCatalog(
+        sensor_identities=[
+            CatalogSensorIdentity(
+                key="dvl_teledyne",
+                label="Teledyne RDI Work Horse Navigator DVL",
+                vendor="Teledyne RDI",
+                product="Work Horse Navigator",
+                type="dvl",
+            ),
+            CatalogSensorIdentity(
+                key="camera_prosilica",
+                label="AVT Prosilica GC1380 stereo camera",
+                vendor="AVT",
+                product="Prosilica GC1380",
+                type="stereo_camera",
+            ),
+            CatalogSensorIdentity(
+                key="sonar_deltat",
+                label="Imagenex DeltaT multibeam sonar",
+                vendor="Imagenex",
+                product="DeltaT 837B",
+                type="multibeam_sonar",
+            ),
+            CatalogSensorIdentity(
+                key="usbl_evologics",
+                label="EvoLogics S2CR USBL modem",
+                vendor="EvoLogics",
+                product="S2CR 18/34",
+                type="usbl",
+            ),
+        ],
+        platform_profiles=[
+            CatalogPlatformProfile(
+                key="2010_seabed",
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="ACFR",
+                sensors=[
+                    CatalogProfileSensor(
+                        key="RDI",
+                        identity="dvl_teledyne",
+                        extrinsics=CatalogSensorExtrinsics(
+                            locx=0.55,
+                            locy=0.0,
+                            locz=0.28,
+                            rotx=0.0,
+                            roty=0.0,
+                            rotz=-0.785,
+                        ),
+                    ),
+                    # Curated without a surveyed pose, the common outcome.
+                    CatalogProfileSensor(
+                        key="VIS", identity="camera_prosilica"
+                    ),
+                    # Carried by the profile but named by no roster.
+                    CatalogProfileSensor(
+                        key="DELTA_T", identity="sonar_deltat"
+                    ),
+                ],
+            )
+        ],
+        vessel_profiles=[
+            CatalogVesselProfile(
+                key="201004_wa201004",
+                vessel_name="RV Linnaeus",
+                sensors=[
+                    CatalogProfileSensor(
+                        key="USBL",
+                        identity="usbl_evologics",
+                        extrinsics=CatalogSensorExtrinsics(
+                            locx=1.2,
+                            locy=-0.4,
+                            locz=3.1,
+                            rotx=0.0,
+                            roty=0.0,
+                            rotz=1.571,
+                        ),
+                    )
+                ],
+            )
+        ],
+        deployment_platforms=[
+            CatalogDeploymentPlatform(
+                deployment_label=PLATFORM_LABEL,
+                platform_profile="2010_seabed",
+            )
+        ],
+        deployment_vessels=[
+            CatalogDeploymentVessel(
+                deployment_label=PLATFORM_LABEL,
+                vessel_profile="201004_wa201004",
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def catalog() -> DeploymentCatalog:
+    """The curated catalog under test."""
+    return _build_catalog()
+
+
+@pytest.fixture
+def index(catalog: DeploymentCatalog) -> DeploymentCatalogIndex:
+    """The catalog indexed for lookup."""
+    return DeploymentCatalogIndex.from_catalog(catalog)
+
+
+@pytest.fixture
+def descriptors() -> list[DeploymentDescriptor]:
+    """One fully assigned deployment and one with no assignment at all."""
+    return [
+        _build_descriptor(PLATFORM_LABEL),
+        _build_descriptor(UNASSIGNED_LABEL),
+    ]
+
+
+def test_matched_sensor_gets_its_identity_and_extrinsics(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+
+    platform = enrichment.descriptor.platform
+    assert enrichment.platform_matched is True
+    assert platform.identity is not None
+    assert platform.identity.platform_label == "AUV Sirius"
+    assert platform.identity.platform_class == "SEABED"
+    assert platform.identity.platform_operator == "ACFR"
+
+    dvl = platform.sensors[0]
+    assert dvl.key == "RDI"
+    assert dvl.identity is not None
+    assert dvl.identity.vendor == "Teledyne RDI"
+    assert dvl.extrinsics is not None
+    assert dvl.extrinsics.locx == 0.55
+    assert dvl.extrinsics.rotz == -0.785
+
+
+def test_catalog_entry_without_extrinsics_fills_identity_only(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+
+    camera = enrichment.descriptor.platform.sensors[1]
+    assert camera.key == "VIS"
+    assert camera.identity is not None
+    assert camera.identity.product == "Prosilica GC1380"
+    assert camera.extrinsics is None
+
+
+def test_roster_key_absent_from_the_profile_stays_unfilled(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+
+    sonar = enrichment.descriptor.platform.sensors[2]
+    assert sonar.key == "MICRON"
+    assert sonar.identity is None
+    assert sonar.extrinsics is None
+
+
+def test_profile_entry_absent_from_the_roster_is_not_added(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+
+    assert [
+        sensor.key for sensor in enrichment.descriptor.platform.sensors
+    ] == ["RDI", "VIS", "MICRON"]
+
+
+def test_vessel_section_is_filled_entirely_from_the_profile(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+
+    vessel = enrichment.descriptor.vessel
+    assert enrichment.vessel_matched is True
+    assert vessel.identity is not None
+    assert vessel.identity.vessel_name == "RV Linnaeus"
+    assert [sensor.key for sensor in vessel.sensors] == ["USBL"]
+
+    modem = vessel.sensors[0]
+    assert modem.identity is not None
+    assert modem.identity.type == "usbl"
+    assert modem.extrinsics is not None
+    assert modem.extrinsics.locz == 3.1
+
+
+def test_deployment_without_assignments_keeps_its_empty_slots(
+    index: DeploymentCatalogIndex,
+) -> None:
+    descriptor = _build_descriptor(UNASSIGNED_LABEL)
+
+    enrichment = enrich_descriptor(descriptor, index)
+
+    assert enrichment.platform_matched is False
+    assert enrichment.vessel_matched is False
+    assert enrichment.descriptor == descriptor
+
+
+def test_missing_assignments_are_warned_about_per_section(
+    descriptors: list[DeploymentDescriptor], catalog: DeploymentCatalog
+) -> None:
+    diagnostics = EnrichDescriptorDiagnostics()
+
+    enrich_descriptors(descriptors, catalog, diagnostics)
+
+    assert [
+        (warning.deployment_label, warning.message)
+        for warning in diagnostics.warnings
+    ] == [
+        (UNASSIGNED_LABEL, "no platform profile assigned"),
+        (UNASSIGNED_LABEL, "no vessel profile assigned"),
+    ]
+
+
+def test_platform_section_leaves_the_vessel_untouched(
+    index: DeploymentCatalogIndex,
+) -> None:
+    descriptor = _build_descriptor(PLATFORM_LABEL)
+
+    enrichment = enrich_descriptor(
+        descriptor, index, EnrichmentSection.PLATFORM
+    )
+
+    assert enrichment.descriptor.platform.identity is not None
+    assert enrichment.descriptor.vessel == descriptor.vessel
+    assert enrichment.platform_matched is True
+    assert enrichment.vessel_matched is None
+
+
+def test_vessel_section_leaves_the_platform_untouched(
+    index: DeploymentCatalogIndex,
+) -> None:
+    descriptor = _build_descriptor(PLATFORM_LABEL)
+
+    enrichment = enrich_descriptor(descriptor, index, EnrichmentSection.VESSEL)
+
+    assert enrichment.descriptor.vessel.identity is not None
+    assert enrichment.descriptor.platform == descriptor.platform
+    assert enrichment.platform_matched is None
+    assert enrichment.vessel_matched is True
+
+
+def test_unrequested_section_is_not_warned_about(
+    descriptors: list[DeploymentDescriptor], catalog: DeploymentCatalog
+) -> None:
+    diagnostics = EnrichDescriptorDiagnostics()
+
+    enrich_descriptors(
+        descriptors, catalog, diagnostics, EnrichmentSection.VESSEL
+    )
+
+    assert [warning.message for warning in diagnostics.warnings] == [
+        "no vessel profile assigned"
+    ]
+
+
+def _write_inputs(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> tuple[Path, Path]:
+    """Writes the descriptors and catalog files, returning their paths."""
+    input_file = tmp_path / "descriptors.toml"
+    catalog_file = tmp_path / "catalog.toml"
+    write_deployment_descriptors(input_file, descriptors)
+    write_deployment_catalog(catalog_file, _build_catalog())
+    return input_file, catalog_file
+
+
+def test_run_writes_a_readable_descriptors_file(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file, catalog_file = _write_inputs(tmp_path, descriptors)
+    output_file = tmp_path / "enriched.toml"
+
+    result = run_enrich_descriptor(
+        EnrichDescriptorCommand(
+            input_file=input_file,
+            catalog_file=catalog_file,
+            output_file=output_file,
+        )
+    )
+
+    assert read_deployment_descriptors(output_file) == result.descriptors
+
+
+def test_run_enriches_in_place_and_is_idempotent(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file, catalog_file = _write_inputs(tmp_path, descriptors)
+    command = EnrichDescriptorCommand(
+        input_file=input_file,
+        catalog_file=catalog_file,
+        output_file=input_file,
+    )
+
+    run_enrich_descriptor(command)
+    once = input_file.read_bytes()
+    run_enrich_descriptor(command)
+
+    assert input_file.read_bytes() == once
+    assert (
+        read_deployment_descriptors(input_file)[0].vessel.identity is not None
+    )
+
+
+def test_run_rejects_a_missing_catalog(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file, _ = _write_inputs(tmp_path, descriptors)
+
+    with pytest.raises(FileNotFoundError, match="catalog file"):
+        run_enrich_descriptor(
+            EnrichDescriptorCommand(
+                input_file=input_file,
+                catalog_file=tmp_path / "absent.toml",
+                output_file=tmp_path / "enriched.toml",
+            )
+        )
+
+
+def test_run_rejects_an_empty_descriptors_file(tmp_path: Path) -> None:
+    input_file, catalog_file = _write_inputs(tmp_path, [])
+
+    with pytest.raises(ValueError, match="no deployments"):
+        run_enrich_descriptor(
+            EnrichDescriptorCommand(
+                input_file=input_file,
+                catalog_file=catalog_file,
+                output_file=tmp_path / "enriched.toml",
+            )
+        )
+
+
+def test_cli_enriches_descriptors(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file, catalog_file = _write_inputs(tmp_path, descriptors)
+    output_file = tmp_path / "enriched.toml"
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "deployment",
+            "enrich",
+            "--input",
+            str(input_file),
+            "--catalog",
+            str(catalog_file),
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    enriched = read_deployment_descriptors(output_file)
+    assert enriched[0].platform.identity is not None
+    assert enriched[0].vessel.identity is not None
+    # The unassigned deployment is a curation gap, not a failure.
+    assert enriched[1].platform.identity is None
+
+
+def test_cli_enriches_only_the_requested_section(
+    tmp_path: Path, descriptors: list[DeploymentDescriptor]
+) -> None:
+    input_file, catalog_file = _write_inputs(tmp_path, descriptors)
+    output_file = tmp_path / "enriched.toml"
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "deployment",
+            "enrich",
+            "--input",
+            str(input_file),
+            "--catalog",
+            str(catalog_file),
+            "--output",
+            str(output_file),
+            "--section",
+            "platform",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    enriched = read_deployment_descriptors(output_file)
+    assert enriched[0].platform.identity is not None
+    assert enriched[0].vessel.identity is None

--- a/tests/test_describe_deployment.py
+++ b/tests/test_describe_deployment.py
@@ -317,7 +317,7 @@ def test_run_leaves_curated_slots_absent(tmp_path: Path) -> None:
 
     contents = output_file.read_text()
     assert "[deployments.platform]" in contents
-    assert "[deployments.vessel]" not in contents
+    assert "[deployments.vessel]" in contents
     assert "identity" not in contents
     assert "extrinsics" not in contents
 


### PR DESCRIPTION
Implements #171.

Fills the curated descriptor slots that `deployment describe` leaves empty, resolving each by deployment label through the catalog's profile assignments.

## What it does

`afft deployment enrich --input <descriptors> --catalog <catalog> --output <descriptors>` fills:

- `platform.identity` from the assigned `[[platform_profiles]]` record.
- `platform.sensors[].identity` and `.extrinsics` for the roster keys the profile carries, matched on the syscfg key.
- The whole `vessel` section, identity and roster both, since vessel sensors exist only in the catalog.

`--section platform|vessel|all` (default `all`) restricts it to one section. Passing the same path for `--input` and `--output` enriches in place. The catalog is authoritative, so the command overwrites curated slots and is a pure function of (descriptor, catalog) — re-running over its own output is a no-op.

## Placement

- `deployment/enrichment.py` — the catalog index, `enrich_descriptor`, and the two section enrichers. A total function of a descriptor and a catalog, with no notion of paths, logging, or a run.
- `tasks/deployment_enrichment/` — command, result, diagnostics, and the runner. No `builders.py`; the transform lives in `deployment/`, so this package is thinner than the other two task packages.

The enrichers cannot take a task diagnostics sink without reversing the `tasks/` -> `deployment/` dependency, so they return misses as domain data — `platform_matched` / `vessel_matched` — and the runner phrases them as warnings.

Task types are pydantic models rather than the `@dataclass(slots=True, frozen=True)` the two existing task packages use, as a deliberate departure; those packages are not converted here.

## Failure modes

Enrichment has no per-deployment failures. A deployment with no assignment is a curation gap: it is warned about, keeps its unfilled slots, and the run exits zero. Hard failures raise before any deployment is enriched — `FileNotFoundError` for a missing input, catalog, or output directory, and `ValueError` for an input holding no deployments.

Roster keys with no profile entry (`MP_INPUT`, `OAS`, `MICRON`) and profile entries no roster names (`DELTA_T`, `IMU`, `ECOPUCK`) are both normal and go unreported; either warning would fire roughly twice per deployment on the current data.

## Descriptor contract change

`DeploymentDescriptor.vessel` becomes a default-constructed `DeploymentVesselSection` rather than `None`, superseding #178. The `None` meant "not enriched", which `vessel.identity` already means, and it cost a check at every read. It is also what lets the two section enrichers share one signature.

Existing descriptor files read unchanged, since the default factory fills the section in when the key is absent. Three assertions were updated; `describe` output gains a `[deployments.vessel]` table carrying `sensors = []`.

## Verification

- `tests/test_deployment_enrichment.py` — 16 tests mirroring `test_scaffold_catalog.py`: in-memory tests of the enrichers plus a `CliRunner` pass over the real entrypoint. Covers a full match, a roster key absent from the profile, a profile entry absent from the roster, a missing platform assignment, a missing vessel assignment, an entry with no extrinsics, each `--section` value leaving the other untouched, and enriching in place.
- Checked against the real 17-deployment descriptors and `data/deployment_catalog_v1.toml`: all 17 enriched, no warnings, and a second run produced a byte-identical file.
- Lint, format, type check, and tests pass — 179 tests.