### PR TITLE
Patch: Correct camera extrinsics half baseline in the catalog

### DIFF
--- a/data/deployment_catalog_v1.toml
+++ b/data/deployment_catalog_v1.toml
@@ -137,7 +137,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -157,7 +157,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -177,7 +177,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -200,7 +200,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -222,7 +222,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -244,7 +244,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -266,7 +266,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_catalog_v1_all.toml
+++ b/data/deployment_catalog_v1_all.toml
@@ -137,7 +137,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -157,7 +157,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -177,7 +177,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -200,7 +200,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -222,7 +222,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -244,7 +244,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -266,7 +266,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_catalog_v1_subset.toml
+++ b/data/deployment_catalog_v1_subset.toml
@@ -137,7 +137,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -157,7 +157,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -177,7 +177,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -200,7 +200,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -299,7 +299,7 @@ identity = "camera_prosilica"
 
 [platform_profiles.sensors.extrinsics]
 locx = 0.82
-locy = 0.0
+locy = -0.035  # half of the ~0.07 m stereo baseline
 locz = 0.0
 rotx = -0.0373  # -2.137 deg
 roty = -0.0065  # -0.372 deg
@@ -324,7 +324,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -346,7 +346,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = 0.0, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740
+    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `VIS` extrinsics in the catalog's platform profiles carried `locy = 0.0`, while `config/vehicles/sirius.toml` — the file `transform_camera_poses` reads today — states `posy = -0.035  # half baseline of ~0.07 meters`. The two sources disagreed by 3.5 cm for the same camera on the same vehicle.

This sets `locy = -0.035` for all seven platform profiles in each of the three catalog files, and records the baseline in a trailing comment so the value is not mistaken for a stray offset later.

Rotations are untouched and stay in radians, as they are elsewhere in the catalog.

## Context

Surfaced by the survey in #187 as one of two discrepancies blocking `transform_camera_poses` from taking its extrinsics from a deployment descriptor, and settled as part of #188. The other discrepancy — degrees vs radians — needed no catalog change.

## Impact

Descriptors enriched before this change carry the old `locy = 0.0` and need re-enrichment to pick up the correction. Once `transform_camera_poses` reads extrinsics from a descriptor (#188), every transformed pose shifts 3.5 cm laterally relative to today's output.

If the catalog is ever regenerated from the localizer configs (#183), this correction is overwritten — the localizer config is the source of the `0.0`.

## Verification

All three catalog files parse, and every `VIS` entry resolves to the corrected value:

```
data/deployment_catalog_v1.toml 7 {-0.035}
data/deployment_catalog_v1_all.toml 7 {-0.035}
data/deployment_catalog_v1_subset.toml 7 {-0.035}
```