### PR TITLE
Feature: Take camera extrinsics from the deployment descriptor

### DIFF
--- a/src/afft/cli/renav/actions.py
+++ b/src/afft/cli/renav/actions.py
@@ -1,9 +1,13 @@
 """Actions for Renav CLI commands."""
 
 from pathlib import Path
-from typing import Any
 
-from afft.io.config_io import read_config
+from afft.deployment import (
+    DeploymentDescriptor,
+    PlatformSensor,
+    SensorExtrinsics,
+    read_deployment_descriptors,
+)
 from afft.tasks.collect_renav_stereo_poses import (
     CollectRenavStereoPosesCommand,
     run_collect_renav_stereo_poses,
@@ -27,6 +31,8 @@ from afft.tasks.transform_camera_poses import (
     run_transform_camera_poses,
     run_transform_camera_poses_batch,
 )
+
+CAMERA_SENSOR_KEY: str = "VIS"
 
 
 def dispatch_process_renav(
@@ -108,11 +114,12 @@ def dispatch_batch_correct_renav_poses(
 def dispatch_transform_camera_poses(
     input_file: str | Path,
     output_file: str | Path,
-    vehicle_config_file: str | Path,
+    descriptor_file: str | Path,
+    deployment_label: str,
 ) -> None:
     """Transform camera poses to vehicle reference-point poses."""
-    extrinsics: CameraVehicleExtrinsics = _load_stereo_extrinsics(
-        Path(vehicle_config_file)
+    extrinsics: CameraVehicleExtrinsics = _load_camera_extrinsics(
+        Path(descriptor_file), deployment_label
     )
     command = TransformCameraPosesCommand(
         input_file=Path(input_file),
@@ -124,13 +131,13 @@ def dispatch_transform_camera_poses(
 def dispatch_transform_camera_poses_batch(
     input_dir: str | Path,
     output_dir: str | Path,
-    vehicle_config_file: str | Path,
+    descriptor_file: str | Path,
     input_suffix: str = "_renav_stereo_poses.csv",
     output_suffix: str = "_vehicle_poses.csv",
 ) -> None:
     """Batch-transform camera poses to vehicle reference-point poses."""
-    extrinsics: CameraVehicleExtrinsics = _load_stereo_extrinsics(
-        Path(vehicle_config_file)
+    extrinsics: dict[str, CameraVehicleExtrinsics] = (
+        _load_camera_extrinsics_by_deployment(Path(descriptor_file))
     )
     command = TransformCameraPosesBatchCommand(
         input_dir=Path(input_dir),
@@ -141,16 +148,94 @@ def dispatch_transform_camera_poses_batch(
     run_transform_camera_poses_batch(command, extrinsics)
 
 
-def _load_stereo_extrinsics(
-    vehicle_config_file: Path,
+def _load_camera_extrinsics(
+    descriptor_file: Path,
+    deployment_label: str,
 ) -> CameraVehicleExtrinsics:
-    data: dict[str, Any] = read_config(vehicle_config_file)
-    stereo: dict[str, Any] = data["sensors"]["stereo"]
+    descriptors: list[DeploymentDescriptor] = read_deployment_descriptors(
+        descriptor_file
+    )
+    matches: list[DeploymentDescriptor] = [
+        descriptor
+        for descriptor in descriptors
+        if descriptor.deployment_label == deployment_label
+    ]
+    if not matches:
+        labels: str = ", ".join(
+            sorted(descriptor.deployment_label for descriptor in descriptors)
+        )
+        raise KeyError(
+            f"deployment {deployment_label} not in {descriptor_file};"
+            f" available: {labels}"
+        )
+    return _camera_extrinsics(matches[0])
+
+
+def _load_camera_extrinsics_by_deployment(
+    descriptor_file: Path,
+) -> dict[str, CameraVehicleExtrinsics]:
+    """
+    Resolve camera extrinsics for every deployment in a descriptors file that
+    has them.
+
+    Deployments without a usable camera pose are left out rather than raising
+    here: the batch runner raises for the deployments it actually processes, so
+    an unrelated unenriched entry in the file does not fail the whole run.
+    """
+    descriptors: list[DeploymentDescriptor] = read_deployment_descriptors(
+        descriptor_file
+    )
+    resolved: dict[str, CameraVehicleExtrinsics] = {}
+    for descriptor in descriptors:
+        sensor: PlatformSensor | None = _find_camera_sensor(descriptor)
+        if sensor is not None and sensor.extrinsics is not None:
+            resolved[descriptor.deployment_label] = _camera_vehicle_extrinsics(
+                sensor.extrinsics
+            )
+    return resolved
+
+
+def _camera_extrinsics(
+    descriptor: DeploymentDescriptor,
+) -> CameraVehicleExtrinsics:
+    """
+    Resolve a deployment's stereo camera extrinsics from its platform roster.
+
+    The task transforms the poses of a single deployment, so a descriptor
+    without a usable camera pose is an error rather than something to skip.
+    """
+    sensor: PlatformSensor | None = _find_camera_sensor(descriptor)
+    if sensor is None:
+        raise KeyError(
+            f"deployment {descriptor.deployment_label} has no"
+            f" {CAMERA_SENSOR_KEY} sensor in its platform roster"
+        )
+    if sensor.extrinsics is None:
+        raise ValueError(
+            f"deployment {descriptor.deployment_label} has no extrinsics for"
+            f" its {CAMERA_SENSOR_KEY} sensor"
+        )
+    return _camera_vehicle_extrinsics(sensor.extrinsics)
+
+
+def _find_camera_sensor(
+    descriptor: DeploymentDescriptor,
+) -> PlatformSensor | None:
+    for sensor in descriptor.platform.sensors:
+        if sensor.key == CAMERA_SENSOR_KEY:
+            return sensor
+    return None
+
+
+def _camera_vehicle_extrinsics(
+    extrinsics: SensorExtrinsics,
+) -> CameraVehicleExtrinsics:
+    # Descriptor rotations are in radians, as CameraVehicleExtrinsics expects.
     return CameraVehicleExtrinsics(
-        posx=stereo["posx"],
-        posy=stereo["posy"],
-        posz=stereo["posz"],
-        rotx=stereo["rotx"],
-        roty=stereo["roty"],
-        rotz=stereo["rotz"],
+        posx=extrinsics.locx,
+        posy=extrinsics.locy,
+        posz=extrinsics.locz,
+        rotx=extrinsics.rotx,
+        roty=extrinsics.roty,
+        rotz=extrinsics.rotz,
     )

--- a/src/afft/cli/renav/commands.py
+++ b/src/afft/cli/renav/commands.py
@@ -169,20 +169,28 @@ def correct_poses(
     help="path to write the vehicle poses as CSV",
 )
 @click.option(
-    "--vehicle-config",
-    "vehicle_config_file",
+    "--descriptors",
+    "descriptor_file",
     type=click.Path(exists=True, dir_okay=False),
     required=True,
-    help="vehicle TOML config containing stereo camera extrinsics",
+    help="deployment descriptors TOML file containing camera extrinsics",
+)
+@click.option(
+    "--deployment",
+    "deployment_label",
+    type=str,
+    required=True,
+    help="deployment label to look up in the deployment descriptors file",
 )
 def transform_poses(
     input_file: str,
     output_file: str,
-    vehicle_config_file: str,
+    descriptor_file: str,
+    deployment_label: str,
 ) -> None:
     """Transform camera poses to vehicle reference-point poses using stereo extrinsics."""
     dispatch_transform_camera_poses(
-        input_file, output_file, vehicle_config_file
+        input_file, output_file, descriptor_file, deployment_label
     )
 
 
@@ -202,11 +210,11 @@ def transform_poses(
     help="directory to write vehicle pose CSV files into",
 )
 @click.option(
-    "--vehicle-config",
-    "vehicle_config_file",
+    "--descriptors",
+    "descriptor_file",
     type=click.Path(exists=True, dir_okay=False),
     required=True,
-    help="vehicle TOML config containing stereo camera extrinsics",
+    help="deployment descriptors TOML file containing camera extrinsics",
 )
 @click.option(
     "--input-suffix",
@@ -227,13 +235,13 @@ def transform_poses(
 def batch_transform_poses(
     input_dir: str,
     output_dir: str,
-    vehicle_config_file: str,
+    descriptor_file: str,
     input_suffix: str,
     output_suffix: str,
 ) -> None:
     """Batch-transform camera poses to vehicle reference-point poses."""
     dispatch_transform_camera_poses_batch(
-        input_dir, output_dir, vehicle_config_file, input_suffix, output_suffix
+        input_dir, output_dir, descriptor_file, input_suffix, output_suffix
     )
 
 

--- a/src/afft/tasks/transform_camera_poses/runner.py
+++ b/src/afft/tasks/transform_camera_poses/runner.py
@@ -1,5 +1,6 @@
 """Runner for the transform camera poses task."""
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import numpy as np
@@ -72,7 +73,7 @@ def run_transform_camera_poses(
 
 def run_transform_camera_poses_batch(
     command: TransformCameraPosesBatchCommand,
-    extrinsics: CameraVehicleExtrinsics,
+    extrinsics: Mapping[str, CameraVehicleExtrinsics],
     config: TransformCameraPosesConfig = TransformCameraPosesConfig(),
 ) -> TransformCameraPosesBatchResult:
     """
@@ -85,7 +86,8 @@ def run_transform_camera_poses_batch(
     Arguments
     ---------
     command: Task I/O configuration.
-    extrinsics: Camera position in the vehicle body frame.
+    extrinsics: Camera position in the vehicle body frame, keyed by deployment
+        label. Every discovered input file must have an entry.
     config: Column label configuration.
 
     Returns
@@ -123,12 +125,16 @@ def run_transform_camera_poses_batch(
         input_files, description="Transforming camera poses"
     ):
         label: str = input_file.name.removesuffix(command.input_suffix)
+        if label not in extrinsics:
+            raise KeyError(f"no camera extrinsics for deployment: {label}")
         output_file: Path = (
             command.output_dir / f"{label}{command.output_suffix}"
         )
 
         cameras: pd.DataFrame = pd.read_csv(input_file)
-        vehicles: pd.DataFrame = _apply_extrinsics(cameras, extrinsics, config)
+        vehicles: pd.DataFrame = _apply_extrinsics(
+            cameras, extrinsics[label], config
+        )
         vehicles.to_csv(output_file, index=False)
 
         results[label] = TransformCameraPosesResult(total=len(vehicles))

--- a/src/afft/tasks/transform_camera_poses/types.py
+++ b/src/afft/tasks/transform_camera_poses/types.py
@@ -11,16 +11,17 @@ class CameraVehicleExtrinsics:
 
     Coordinate convention follows SNAME: posx is forward (bow), posy is
     starboard, posz is downward. Rotation angles follow ZYX intrinsic Euler
-    convention (rotz=yaw, roty=pitch, rotx=roll) and are expressed in degrees.
+    convention (rotz=yaw, roty=pitch, rotx=roll) and are expressed in radians,
+    matching the deployment descriptor's sensor extrinsics.
 
     Attributes
     ----------
     posx: Forward offset from vehicle reference point in metres.
     posy: Lateral offset in metres (positive starboard).
     posz: Vertical offset in metres (positive downward).
-    rotx: Roll in degrees (positive: starboard down).
-    roty: Pitch in degrees (positive: bow up).
-    rotz: Yaw in degrees (positive clockwise viewed from above).
+    rotx: Roll in radians (positive: starboard down).
+    roty: Pitch in radians (positive: bow up).
+    rotz: Yaw in radians (positive clockwise viewed from above).
     """
 
     posx: float = 0.0

--- a/tests/test_transform_camera_poses.py
+++ b/tests/test_transform_camera_poses.py
@@ -1,0 +1,567 @@
+"""Tests for the transform camera poses task and its CLI."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pymap3d
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.cli.renav.actions import (
+    _camera_extrinsics,
+    _load_camera_extrinsics,
+    _load_camera_extrinsics_by_deployment,
+)
+from afft.deployment import (
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    DeploymentMetadata,
+    DeploymentPlatformSection,
+    DeploymentSystemSection,
+    DeploymentTelemetrySection,
+    PlatformSensor,
+    SensorExtrinsics,
+    write_deployment_descriptors,
+)
+from afft.tasks.transform_camera_poses import (
+    CameraVehicleExtrinsics,
+    TransformCameraPosesBatchCommand,
+    TransformCameraPosesCommand,
+    run_transform_camera_poses,
+    run_transform_camera_poses_batch,
+)
+
+
+def _displacement(
+    cameras: pd.DataFrame,
+    vehicles: pd.DataFrame,
+    index: int = 0,
+) -> tuple[float, float]:
+    """
+    Displacement from a camera pose to its transformed vehicle pose, in metres.
+
+    Returns the north and east components, so the expectations below are stated
+    in the vehicle body frame rather than in degrees of latitude and longitude.
+
+    Arguments
+    ---------
+    cameras: Camera poses as read from the task's input file.
+    vehicles: Vehicle poses as written by the task.
+    index: Row to compare.
+
+    Returns
+    -------
+    North and east displacement in metres.
+    """
+    north: float
+    east: float
+    north, east, _ = pymap3d.geodetic2ned(
+        vehicles["latitude"].iloc[index],
+        vehicles["longitude"].iloc[index],
+        0.0,
+        cameras["latitude"].iloc[index],
+        cameras["longitude"].iloc[index],
+        0.0,
+    )
+    return float(north), float(east)
+
+
+def _build_descriptor(
+    label: str,
+    sensors: list[PlatformSensor],
+) -> DeploymentDescriptor:
+    """Builds a descriptor carrying only the fields the extrinsics lookup reads."""
+    return DeploymentDescriptor(
+        deployment_label=label,
+        deployment_datetime=datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+        metadata=DeploymentMetadata(
+            acfr_deployment_label=label,
+            acfr_campaign_label="WA201004",
+            acfr_platform_label="",
+            origin_latitude=-28.8,
+            origin_longitude=113.9,
+            magnetic_variation=-1.16,
+        ),
+        files=DeploymentFileSection(),
+        telemetry=DeploymentTelemetrySection(topics=[]),
+        platform=DeploymentPlatformSection(sensors=sensors),
+        system=DeploymentSystemSection(
+            vehicle_name="SEABED",
+            vehicle_config="NORM_CFG",
+            log_directory="/files1/Log",
+            logged_streams=["RAW"],
+        ),
+    )
+
+
+def _camera_sensor(posx: float = 0.82) -> PlatformSensor:
+    """A VIS sensor carrying the catalog's curated stereo camera pose."""
+    return PlatformSensor(
+        key="VIS",
+        extrinsics=SensorExtrinsics(
+            locx=posx,
+            locy=-0.035,
+            locz=0.0,
+            rotx=-0.0373,
+            roty=-0.0065,
+            rotz=1.5488,
+        ),
+    )
+
+
+def _write_descriptors(
+    path: Path,
+    descriptors: list[DeploymentDescriptor],
+) -> Path:
+    write_deployment_descriptors(path, descriptors)
+    return path
+
+
+def _write_poses(
+    path: Path,
+    latitude: float = -28.8,
+    longitude: float = 113.9,
+    heading: float = 0.0,
+    total: int = 3,
+) -> Path:
+    """Writes a camera pose CSV with a passthrough column."""
+    frame = pd.DataFrame(
+        {
+            "timestamp": [float(index) for index in range(total)],
+            "latitude": [latitude] * total,
+            "longitude": [longitude] * total,
+            "heading": [heading] * total,
+            "pitch": [0.0] * total,
+            "roll": [0.0] * total,
+        }
+    )
+    frame.to_csv(path, index=False)
+    return path
+
+
+# --------------------------------------------------------------------------------------
+# Extrinsics resolution
+# --------------------------------------------------------------------------------------
+
+
+def test_extrinsics_resolve_from_descriptor(tmp_path: Path) -> None:
+    """Descriptor values pass through in radians, unconverted."""
+    path = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [_build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()])],
+    )
+
+    extrinsics = _load_camera_extrinsics(path, "qdch0ftq_20100428_020202")
+
+    assert extrinsics == CameraVehicleExtrinsics(
+        posx=0.82,
+        posy=-0.035,
+        posz=0.0,
+        rotx=-0.0373,
+        roty=-0.0065,
+        rotz=1.5488,
+    )
+
+
+def test_extrinsics_lookup_rejects_unknown_deployment(tmp_path: Path) -> None:
+    path = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [_build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()])],
+    )
+
+    with pytest.raises(KeyError, match="qd61g27j_20100421_022145"):
+        _load_camera_extrinsics(path, "qd61g27j_20100421_022145")
+
+
+def test_extrinsics_lookup_names_available_deployments(
+    tmp_path: Path,
+) -> None:
+    path = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [_build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()])],
+    )
+
+    with pytest.raises(KeyError, match="available: qdch0ftq_20100428_020202"):
+        _load_camera_extrinsics(path, "absent")
+
+
+def test_extrinsics_rejects_roster_without_camera() -> None:
+    descriptor = _build_descriptor(
+        "qdch0ftq_20100428_020202", [PlatformSensor(key="RDI")]
+    )
+
+    with pytest.raises(KeyError, match="no VIS sensor"):
+        _camera_extrinsics(descriptor)
+
+
+def test_extrinsics_rejects_unenriched_camera() -> None:
+    """The common case: a roster entry whose extrinsics enrichment never filled."""
+    descriptor = _build_descriptor(
+        "qdch0ftq_20100428_020202", [PlatformSensor(key="VIS")]
+    )
+
+    with pytest.raises(ValueError, match="no extrinsics"):
+        _camera_extrinsics(descriptor)
+
+
+def test_extrinsics_resolve_per_deployment(tmp_path: Path) -> None:
+    path = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [
+            _build_descriptor(
+                "qdch0ftq_20100428_020202", [_camera_sensor(posx=0.82)]
+            ),
+            _build_descriptor(
+                "qd61g27j_20100421_022145", [_camera_sensor(posx=1.50)]
+            ),
+        ],
+    )
+
+    extrinsics = _load_camera_extrinsics_by_deployment(path)
+
+    assert set(extrinsics) == {
+        "qdch0ftq_20100428_020202",
+        "qd61g27j_20100421_022145",
+    }
+    assert extrinsics["qdch0ftq_20100428_020202"].posx == 0.82
+    assert extrinsics["qd61g27j_20100421_022145"].posx == 1.50
+
+
+def test_extrinsics_skip_unenriched_deployments(tmp_path: Path) -> None:
+    """An unenriched entry is left out rather than failing the whole file."""
+    path = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [
+            _build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()]),
+            _build_descriptor(
+                "qd61g27j_20100421_022145", [PlatformSensor(key="VIS")]
+            ),
+            _build_descriptor(
+                "qdch0ftq_20110415_020103", [PlatformSensor(key="RDI")]
+            ),
+        ],
+    )
+
+    extrinsics = _load_camera_extrinsics_by_deployment(path)
+
+    assert set(extrinsics) == {"qdch0ftq_20100428_020202"}
+
+
+# --------------------------------------------------------------------------------------
+# Single-deployment runner
+# --------------------------------------------------------------------------------------
+
+
+def test_transform_shifts_pose_against_heading(tmp_path: Path) -> None:
+    """A north-facing camera 10 m forward puts the vehicle 10 m south of it."""
+    input_file = _write_poses(tmp_path / "poses.csv", heading=0.0, total=1)
+    output_file = tmp_path / "vehicle.csv"
+
+    run_transform_camera_poses(
+        TransformCameraPosesCommand(
+            input_file=input_file, output_file=output_file
+        ),
+        CameraVehicleExtrinsics(posx=10.0),
+    )
+
+    north, east = _displacement(
+        pd.read_csv(input_file), pd.read_csv(output_file)
+    )
+    assert north == pytest.approx(-10.0, abs=1e-6)
+    assert east == pytest.approx(0.0, abs=1e-6)
+
+
+def test_transform_shifts_pose_with_heading(tmp_path: Path) -> None:
+    """Facing east, the same forward offset puts the vehicle 10 m west."""
+    input_file = _write_poses(tmp_path / "poses.csv", heading=90.0, total=1)
+    output_file = tmp_path / "vehicle.csv"
+
+    run_transform_camera_poses(
+        TransformCameraPosesCommand(
+            input_file=input_file, output_file=output_file
+        ),
+        CameraVehicleExtrinsics(posx=10.0),
+    )
+
+    north, east = _displacement(
+        pd.read_csv(input_file), pd.read_csv(output_file)
+    )
+    assert north == pytest.approx(0.0, abs=1e-6)
+    assert east == pytest.approx(-10.0, abs=1e-6)
+
+
+def test_transform_with_zero_extrinsics_is_identity(tmp_path: Path) -> None:
+    input_file = _write_poses(
+        tmp_path / "poses.csv", latitude=-28.8, longitude=113.9
+    )
+    output_file = tmp_path / "vehicle.csv"
+
+    run_transform_camera_poses(
+        TransformCameraPosesCommand(
+            input_file=input_file, output_file=output_file
+        ),
+        CameraVehicleExtrinsics(),
+    )
+
+    cameras = pd.read_csv(input_file)
+    vehicles = pd.read_csv(output_file)
+    assert np.allclose(vehicles["latitude"], cameras["latitude"])
+    assert np.allclose(vehicles["longitude"], cameras["longitude"])
+
+
+def test_transform_passes_other_columns_through(tmp_path: Path) -> None:
+    input_file = _write_poses(tmp_path / "poses.csv", heading=45.0)
+    output_file = tmp_path / "vehicle.csv"
+
+    result = run_transform_camera_poses(
+        TransformCameraPosesCommand(
+            input_file=input_file, output_file=output_file
+        ),
+        CameraVehicleExtrinsics(posx=0.82, posy=-0.035),
+    )
+
+    cameras = pd.read_csv(input_file)
+    vehicles = pd.read_csv(output_file)
+    assert result.total == len(cameras)
+    assert list(vehicles.columns) == list(cameras.columns)
+    for column in ["timestamp", "heading", "pitch", "roll"]:
+        assert np.allclose(vehicles[column], cameras[column])
+
+
+def test_transform_rejects_missing_input(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="input file"):
+        run_transform_camera_poses(
+            TransformCameraPosesCommand(
+                input_file=tmp_path / "absent.csv",
+                output_file=tmp_path / "vehicle.csv",
+            ),
+            CameraVehicleExtrinsics(),
+        )
+
+
+def test_transform_rejects_missing_output_directory(tmp_path: Path) -> None:
+    input_file = _write_poses(tmp_path / "poses.csv")
+
+    with pytest.raises(FileNotFoundError, match="output directory"):
+        run_transform_camera_poses(
+            TransformCameraPosesCommand(
+                input_file=input_file,
+                output_file=tmp_path / "absent" / "vehicle.csv",
+            ),
+            CameraVehicleExtrinsics(),
+        )
+
+
+def test_transform_rejects_output_equal_to_input(tmp_path: Path) -> None:
+    input_file = _write_poses(tmp_path / "poses.csv")
+
+    with pytest.raises(ValueError, match="must differ"):
+        run_transform_camera_poses(
+            TransformCameraPosesCommand(
+                input_file=input_file, output_file=input_file
+            ),
+            CameraVehicleExtrinsics(),
+        )
+
+
+# --------------------------------------------------------------------------------------
+# Batch runner
+# --------------------------------------------------------------------------------------
+
+
+def test_batch_applies_extrinsics_per_deployment(tmp_path: Path) -> None:
+    """Each deployment is transformed with its own geometry, not a shared one."""
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_poses(input_dir / "first_renav_stereo_poses.csv", total=1)
+    _write_poses(input_dir / "second_renav_stereo_poses.csv", total=1)
+
+    run_transform_camera_poses_batch(
+        TransformCameraPosesBatchCommand(
+            input_dir=input_dir, output_dir=output_dir
+        ),
+        {
+            "first": CameraVehicleExtrinsics(posx=10.0),
+            "second": CameraVehicleExtrinsics(posx=20.0),
+        },
+    )
+
+    first_north, _ = _displacement(
+        pd.read_csv(input_dir / "first_renav_stereo_poses.csv"),
+        pd.read_csv(output_dir / "first_vehicle_poses.csv"),
+    )
+    second_north, _ = _displacement(
+        pd.read_csv(input_dir / "second_renav_stereo_poses.csv"),
+        pd.read_csv(output_dir / "second_vehicle_poses.csv"),
+    )
+    assert first_north == pytest.approx(-10.0, abs=1e-6)
+    assert second_north == pytest.approx(-20.0, abs=1e-6)
+
+
+def test_batch_reports_counts_per_deployment(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_poses(input_dir / "first_renav_stereo_poses.csv", total=3)
+    _write_poses(input_dir / "second_renav_stereo_poses.csv", total=5)
+
+    result = run_transform_camera_poses_batch(
+        TransformCameraPosesBatchCommand(
+            input_dir=input_dir, output_dir=output_dir
+        ),
+        {
+            "first": CameraVehicleExtrinsics(),
+            "second": CameraVehicleExtrinsics(),
+        },
+    )
+
+    assert {
+        label: counts.total for label, counts in result.results.items()
+    } == {"first": 3, "second": 5}
+
+
+def test_batch_rejects_deployment_without_extrinsics(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_poses(input_dir / "first_renav_stereo_poses.csv")
+
+    with pytest.raises(KeyError, match="first"):
+        run_transform_camera_poses_batch(
+            TransformCameraPosesBatchCommand(
+                input_dir=input_dir, output_dir=output_dir
+            ),
+            {"second": CameraVehicleExtrinsics()},
+        )
+
+
+def test_batch_rejects_directory_without_matches(tmp_path: Path) -> None:
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+
+    _write_poses(input_dir / "unrelated.csv")
+
+    with pytest.raises(FileNotFoundError, match="no files ending in"):
+        run_transform_camera_poses_batch(
+            TransformCameraPosesBatchCommand(
+                input_dir=input_dir, output_dir=output_dir
+            ),
+            {},
+        )
+
+
+# --------------------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------------------
+
+
+def test_cli_transform_poses_uses_descriptor_extrinsics(
+    tmp_path: Path,
+) -> None:
+    descriptor_file = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [
+            _build_descriptor(
+                "qdch0ftq_20100428_020202", [_camera_sensor(posx=10.0)]
+            )
+        ],
+    )
+    input_file = _write_poses(tmp_path / "poses.csv", total=1)
+    output_file = tmp_path / "vehicle.csv"
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "renav",
+            "transform-poses",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+            "--descriptors",
+            str(descriptor_file),
+            "--deployment",
+            "qdch0ftq_20100428_020202",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    north, _ = _displacement(pd.read_csv(input_file), pd.read_csv(output_file))
+    assert north == pytest.approx(-10.0, abs=1e-6)
+
+
+def test_cli_transform_poses_fails_on_unknown_deployment(
+    tmp_path: Path,
+) -> None:
+    descriptor_file = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [_build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()])],
+    )
+    input_file = _write_poses(tmp_path / "poses.csv")
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "renav",
+            "transform-poses",
+            "--input",
+            str(input_file),
+            "--output",
+            str(tmp_path / "vehicle.csv"),
+            "--descriptors",
+            str(descriptor_file),
+            "--deployment",
+            "absent",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "qdch0ftq_20100428_020202" in str(result.exception)
+
+
+def test_cli_batch_transform_poses_uses_descriptor_extrinsics(
+    tmp_path: Path,
+) -> None:
+    descriptor_file = _write_descriptors(
+        tmp_path / "descriptors.toml",
+        [_build_descriptor("first", [_camera_sensor(posx=10.0)])],
+    )
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    _write_poses(input_dir / "first_renav_stereo_poses.csv", total=1)
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "renav",
+            "batch-transform-poses",
+            "--input-dir",
+            str(input_dir),
+            "--output-dir",
+            str(output_dir),
+            "--descriptors",
+            str(descriptor_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    north, _ = _displacement(
+        pd.read_csv(input_dir / "first_renav_stereo_poses.csv"),
+        pd.read_csv(output_dir / "first_vehicle_poses.csv"),
+    )
+    assert north == pytest.approx(-10.0, abs=1e-6)


### PR DESCRIPTION
Closes #188. First candidate from the survey in #187.

## Summary

`transform_camera_poses` read its stereo extrinsics from a single global `config/vehicles/sirius.toml`, which assumed every deployment shares one rig geometry. It now resolves them per deployment from the descriptor, as `platform.sensors[key = "VIS"].extrinsics`.

## CLI

`renav transform-poses` takes `--descriptors` and `--deployment`, following the USBL commands, which already resolve extrinsics as a file plus a label to look up in it (`--deployment-configs` / `--deployment`). `renav batch-transform-poses` takes `--descriptors` and keeps deriving labels from `--input-suffix`, so it needs no label option.

```
renav transform-poses --input poses.csv --output vehicle.csv \
    --descriptors descriptors.toml --deployment qdch0ftq_20100428_020202
```

## Decisions

- **Miss policy.** The task transforms a single deployment's poses, so a descriptor with no usable camera pose raises rather than skipping, and there is no fallback to the vehicle config. A missing deployment names the available labels; a roster without `VIS` and a `VIS` entry whose `extrinsics` is `None` each raise on their own.
- **Batch blast radius.** The batch loader leaves unenriched deployments out of the mapping and lets the runner raise for the deployments it actually processes. An unrelated unenriched entry in the descriptors file does not fail a run that never touches it.
- **Units.** Descriptor rotations are in radians, so `CameraVehicleExtrinsics` moves to radians with them and values pass through unconverted. Only the translations are applied today — `_apply_extrinsics` reads `posx`/`posy`/`posz` — so this changes no output.

## Signature change

`run_transform_camera_poses_batch` now takes `Mapping[str, CameraVehicleExtrinsics]` keyed by deployment label rather than one set for the whole directory. Per-deployment geometry is the point of the change, so the signature moves with it. The single-deployment runner is unchanged.

## Tests

The task package had no tests. This adds `tests/test_transform_camera_poses.py` with 21, covering extrinsics resolution and its three failure modes, the previously untested single-deployment runner (displacement, identity, passthrough, its three error cases), the batch runner's per-deployment geometry and miss policy, and the CLI surface.

Geodetic expectations convert the task's output back to metres with `pymap3d.geodetic2ned` and assert the vehicle sits the expected distance behind the camera in the body frame, rather than comparing hand-computed degrees.

## Verification

`ruff check`, `ruff format`, and `mypy` clean; 200 tests pass.

Smoke-tested against `data/deployment_descriptors_v1_subset_enriched.toml` — all 17 deployments resolve.

## Follow-up

That file was enriched before #189 and still carries `locy = 0.0`; it needs re-enrichment against the corrected catalog before real runs. `config/vehicles/sirius.toml` now has no consumer at all — nothing in the repo references it or the `config/vehicles/` directory. It is left in place rather than deleted as part of this change; removing it is a triage call for #187.