### PR TITLE
Add task and CLI command to summarize deployment descriptors

### DIFF
--- a/src/afft/cli/deployment/actions.py
+++ b/src/afft/cli/deployment/actions.py
@@ -10,7 +10,9 @@ from afft.tasks.deployment_catalog import (
 from afft.tasks.deployment_descriptor import (
     DescribeDeploymentCommand,
     DescribeDeploymentResult,
+    SummarizeDescriptorCommand,
     run_describe_deployment,
+    run_summarize_descriptor,
 )
 from afft.tasks.deployment_enrichment import (
     EnrichDescriptorCommand,
@@ -78,3 +80,22 @@ def dispatch_enrich_descriptor(
         verbose=verbose,
     )
     run_enrich_descriptor(command)
+
+
+def dispatch_summarize_descriptor(
+    input_file: str | Path,
+    output_file: str | Path | None = None,
+    verbose: bool = False,
+) -> None:
+    """
+    Summarize the deployments in a deployment descriptors file.
+
+    Always exits zero: unfilled curated slots are the summary's output, not a
+    failure of the run.
+    """
+    command = SummarizeDescriptorCommand(
+        input_file=Path(input_file),
+        output_file=Path(output_file) if output_file else None,
+        verbose=verbose,
+    )
+    run_summarize_descriptor(command)

--- a/src/afft/cli/deployment/commands.py
+++ b/src/afft/cli/deployment/commands.py
@@ -8,6 +8,7 @@ from .actions import (
     dispatch_describe_deployment,
     dispatch_enrich_descriptor,
     dispatch_scaffold_catalog,
+    dispatch_summarize_descriptor,
 )
 
 
@@ -145,3 +146,37 @@ def enrich(
     dispatch_enrich_descriptor(
         input_file, catalog_file, output_file, section, verbose
     )
+
+
+@deployment_group.command()
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment descriptors TOML file",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="path to write a detailed Markdown report; omit to print a summary",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="list the deployments affected by each curation gap",
+)
+def summarize(
+    input_file: str,
+    output_file: str | None,
+    verbose: bool,
+) -> None:
+    """Summarize the deployments in a deployment descriptors file.
+
+    Without an output path, prints per-file aggregates to the terminal. With
+    one, writes a detailed per-deployment report as Markdown.
+    """
+    dispatch_summarize_descriptor(input_file, output_file, verbose)

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -28,9 +28,22 @@ from .descriptor_types import (
     VesselIdentity as VesselIdentity,
     VesselSensor as VesselSensor,
 )
+from .descriptor_exporters import (
+    format_table as format_table,
+    write_summary_report as write_summary_report,
+)
 from .descriptor_io import (
     read_deployment_descriptors as read_deployment_descriptors,
     write_deployment_descriptors as write_deployment_descriptors,
+)
+from .descriptor_summary import (
+    CurationGap as CurationGap,
+    DeploymentSummary as DeploymentSummary,
+    DescriptorSummary as DescriptorSummary,
+    GeographicExtent as GeographicExtent,
+    collect_curation_gaps as collect_curation_gaps,
+    collect_unfilled_fields as collect_unfilled_fields,
+    summarize_descriptors as summarize_descriptors,
 )
 from .enrichment import (
     DeploymentCatalogIndex as DeploymentCatalogIndex,

--- a/src/afft/deployment/descriptor_exporters.py
+++ b/src/afft/deployment/descriptor_exporters.py
@@ -1,0 +1,180 @@
+"""Markdown export for deployment descriptor summaries."""
+
+from pathlib import Path
+
+from .descriptor_summary import DescriptorSummary
+
+type MarkdownLines = list[str]
+
+
+def format_table(headers: list[str], rows: list[list[str]]) -> MarkdownLines:
+    """
+    Format rows as a GitHub-flavoured Markdown pipe table.
+
+    Arguments
+    ---------
+    headers: Column headers.
+    rows: Row cells, one list per row.
+
+    Returns
+    -------
+    The table lines, followed by a blank line.
+    """
+    return [
+        "| " + " | ".join(headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+        *("| " + " | ".join(row) + " |" for row in rows),
+        "",
+    ]
+
+
+def format_overview(summary: DescriptorSummary) -> MarkdownLines:
+    """Format the deployment count, datetime range, and extent."""
+    extent = summary.extent
+    return [
+        "## Overview",
+        "",
+        f"- Deployments: {summary.deployment_count}",
+        f"- Campaigns: {len(summary.campaign_counts)}",
+        f"- Earliest: {summary.earliest_datetime.isoformat()}",
+        f"- Latest: {summary.latest_datetime.isoformat()}",
+        f"- Latitude: {extent.min_latitude} to {extent.max_latitude}",
+        f"- Longitude: {extent.min_longitude} to {extent.max_longitude}",
+        f"- Enriched: {'yes' if summary.enriched else 'no'}",
+        "",
+    ]
+
+
+def format_campaigns(summary: DescriptorSummary) -> MarkdownLines:
+    """Format the deployment count per campaign as a table."""
+    return [
+        "## Campaigns",
+        "",
+        *format_table(
+            ["Campaign", "Deployments"],
+            [
+                [campaign, str(count)]
+                for campaign, count in summary.campaign_counts.items()
+            ],
+        ),
+    ]
+
+
+def format_section_coverage(summary: DescriptorSummary) -> MarkdownLines:
+    """Format file-section coverage as a table."""
+    return [
+        "## File coverage",
+        "",
+        *format_table(
+            ["Section", "Deployments", "Missing"],
+            [
+                [
+                    section,
+                    str(count),
+                    str(summary.deployment_count - count),
+                ]
+                for section, count in summary.section_coverage.items()
+            ],
+        ),
+    ]
+
+
+def format_topics(summary: DescriptorSummary) -> MarkdownLines:
+    """Format telemetry topic frequency as a table."""
+    return [
+        "## Telemetry topics",
+        "",
+        *format_table(
+            ["Topic", "Deployments"],
+            [
+                [topic, str(count)]
+                for topic, count in summary.topic_counts.items()
+            ],
+        ),
+    ]
+
+
+def format_curation_gaps(summary: DescriptorSummary) -> MarkdownLines:
+    """Format the unfilled curated slots, with the deployments affected."""
+    if not summary.enriched:
+        return [
+            "## Curation gaps",
+            "",
+            "The descriptors are not enriched, so every curated slot is "
+            "unfilled.",
+            "",
+        ]
+
+    if not summary.curation_gaps:
+        return ["## Curation gaps", "", "No unfilled curated slots.", ""]
+
+    lines: MarkdownLines = ["## Curation gaps", ""]
+    lines.extend(
+        format_table(
+            ["Field", "Deployments"],
+            [
+                [f"`{gap.field_name}`", str(gap.count)]
+                for gap in summary.curation_gaps
+            ],
+        )
+    )
+    for gap in summary.curation_gaps:
+        lines.extend(
+            [
+                f"### `{gap.field_name}`",
+                "",
+                *(f"- {label}" for label in gap.deployment_labels),
+                "",
+            ]
+        )
+    return lines
+
+
+def format_deployments(summary: DescriptorSummary) -> MarkdownLines:
+    """Format the per-deployment detail, one subsection per deployment."""
+    lines: MarkdownLines = ["## Deployments", ""]
+    for deployment in summary.deployments:
+        files: str = ", ".join(
+            f"{section} ({count})"
+            for section, count in deployment.file_counts.items()
+            if count > 0
+        )
+        lines.extend(
+            [
+                f"### {deployment.deployment_label}",
+                "",
+                f"- Datetime: {deployment.deployment_datetime.isoformat()}",
+                f"- Campaign: {deployment.campaign_label}",
+                f"- Files: {files if files else 'none'}",
+                f"- Topics: {', '.join(deployment.topics) or 'none'}",
+                "- Platform sensors: "
+                f"{', '.join(deployment.platform_sensor_keys) or 'none'}",
+                "- Vessel sensors: "
+                f"{', '.join(deployment.vessel_sensor_keys) or 'none'}",
+                f"- Unfilled slots: {len(deployment.unfilled_fields)}",
+                "",
+            ]
+        )
+    return lines
+
+
+def write_summary_report(path: Path, summary: DescriptorSummary) -> None:
+    """
+    Write a detailed summary report as Markdown.
+
+    Arguments
+    ---------
+    path: Path to write the report to.
+    summary: The computed summary.
+    """
+    lines: MarkdownLines = [
+        "# Deployment Descriptor Summary",
+        "",
+        *format_overview(summary),
+        *format_campaigns(summary),
+        *format_section_coverage(summary),
+        *format_topics(summary),
+        *format_curation_gaps(summary),
+        *format_deployments(summary),
+    ]
+    path.write_text("\n".join(lines).rstrip("\n") + "\n")

--- a/src/afft/deployment/descriptor_summary.py
+++ b/src/afft/deployment/descriptor_summary.py
@@ -1,0 +1,341 @@
+"""Aggregate views over a set of deployment descriptors."""
+
+from collections import Counter
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .descriptor_types import (
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    PlatformSensor,
+    SensorIdentity,
+    VesselSensor,
+)
+
+type FieldName = str
+type CampaignLabel = str
+type TopicName = str
+type SectionName = str
+
+
+class GeographicExtent(BaseModel):
+    """
+    Bounding box of the deployment origins.
+
+    Attributes
+    ----------
+    min_latitude: Southernmost origin latitude in degrees.
+    max_latitude: Northernmost origin latitude in degrees.
+    min_longitude: Westernmost origin longitude in degrees.
+    max_longitude: Easternmost origin longitude in degrees.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    min_latitude: float
+    max_latitude: float
+    min_longitude: float
+    max_longitude: float
+
+
+class CurationGap(BaseModel):
+    """
+    A curated slot left unfilled across one or more deployments.
+
+    Attributes
+    ----------
+    field_name: Dotted path of the unfilled field, e.g.
+        ``"platform.identity.platform_label"``.
+    deployment_labels: Labels of the deployments the slot is unfilled for.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    field_name: FieldName
+    deployment_labels: list[str]
+
+    @property
+    def count(self) -> int:
+        """Number of deployments the slot is unfilled for."""
+        return len(self.deployment_labels)
+
+
+class DeploymentSummary(BaseModel):
+    """
+    Per-deployment detail, written only to the report file.
+
+    Attributes
+    ----------
+    deployment_label: Label of the summarized deployment.
+    deployment_datetime: Deployment datetime.
+    campaign_label: ACFR campaign the deployment belongs to.
+    file_counts: File count per file section name.
+    topics: Telemetry topics observed for the deployment.
+    platform_sensor_keys: Keys of the platform's sensors.
+    vessel_sensor_keys: Keys of the vessel's sensors.
+    unfilled_fields: Dotted paths of the deployment's unfilled curated slots.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    deployment_datetime: datetime
+    campaign_label: str
+    file_counts: dict[SectionName, int]
+    topics: list[TopicName]
+    platform_sensor_keys: list[str]
+    vessel_sensor_keys: list[str]
+    unfilled_fields: list[FieldName]
+
+
+class DescriptorSummary(BaseModel):
+    """
+    Aggregate summary of a deployment descriptor file.
+
+    Attributes
+    ----------
+    deployment_count: Number of deployments in the file.
+    campaign_counts: Deployment count per campaign label.
+    earliest_datetime: Earliest deployment datetime.
+    latest_datetime: Latest deployment datetime.
+    extent: Bounding box of the deployment origins.
+    section_coverage: Number of deployments with a non-empty file section,
+        per section name.
+    topic_counts: Number of deployments reporting a topic, per topic name.
+    enriched: Whether any deployment carries a platform identity.
+    curation_gaps: Unfilled curated slots, per field; empty when the
+        descriptors are not enriched.
+    deployments: Per-deployment detail, in file order.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_count: int
+    campaign_counts: dict[CampaignLabel, int]
+    earliest_datetime: datetime
+    latest_datetime: datetime
+    extent: GeographicExtent
+    section_coverage: dict[SectionName, int]
+    topic_counts: dict[TopicName, int]
+    enriched: bool
+    curation_gaps: list[CurationGap] = Field(default_factory=list)
+    deployments: list[DeploymentSummary] = Field(default_factory=list)
+
+
+def _sort_counts(counts: Counter[str]) -> dict[str, int]:
+    """Order counts by descending count, then by name."""
+    return {
+        name: count
+        for name, count in sorted(
+            counts.items(), key=lambda item: (-item[1], item[0])
+        )
+    }
+
+
+def _empty_identity_fields(
+    identity: SensorIdentity,
+    prefix: str,
+) -> list[FieldName]:
+    """Collect the empty string fields of a sensor identity."""
+    return [
+        f"{prefix}.{field}"
+        for field in ("label", "vendor", "product", "type")
+        if not getattr(identity, field)
+    ]
+
+
+def _sensor_gaps(
+    sensors: list[PlatformSensor] | list[VesselSensor],
+    section: str,
+) -> list[FieldName]:
+    """Collect the unfilled slots of a platform or vessel sensor roster."""
+    unfilled: list[FieldName] = []
+    for sensor in sensors:
+        prefix: str = f"{section}.sensors[{sensor.key}]"
+        if sensor.identity is None:
+            unfilled.append(f"{prefix}.identity")
+        else:
+            unfilled.extend(
+                _empty_identity_fields(sensor.identity, f"{prefix}.identity")
+            )
+        if sensor.extrinsics is None:
+            unfilled.append(f"{prefix}.extrinsics")
+    return unfilled
+
+
+def collect_unfilled_fields(
+    descriptor: DeploymentDescriptor,
+) -> list[FieldName]:
+    """
+    Collect the dotted paths of a deployment's unfilled curated slots.
+
+    A slot is unfilled when its model field is ``None``, or when a string
+    field is empty.
+
+    Arguments
+    ---------
+    descriptor: Deployment descriptor to inspect.
+
+    Returns
+    -------
+    Dotted paths of the unfilled slots, in declaration order.
+    """
+    unfilled: list[FieldName] = []
+
+    if not descriptor.metadata.acfr_platform_label:
+        unfilled.append("metadata.acfr_platform_label")
+
+    platform_identity = descriptor.platform.identity
+    if platform_identity is None:
+        unfilled.append("platform.identity")
+    else:
+        unfilled.extend(
+            f"platform.identity.{field}"
+            for field in (
+                "platform_label",
+                "platform_class",
+                "platform_operator",
+            )
+            if not getattr(platform_identity, field)
+        )
+
+    unfilled.extend(_sensor_gaps(descriptor.platform.sensors, "platform"))
+
+    vessel_identity = descriptor.vessel.identity
+    if vessel_identity is None:
+        unfilled.append("vessel.identity")
+    elif not vessel_identity.vessel_name:
+        unfilled.append("vessel.identity.vessel_name")
+
+    unfilled.extend(_sensor_gaps(descriptor.vessel.sensors, "vessel"))
+
+    return unfilled
+
+
+def _summarize_deployment(
+    descriptor: DeploymentDescriptor,
+) -> DeploymentSummary:
+    """Build the per-deployment detail for one descriptor."""
+    return DeploymentSummary(
+        deployment_label=descriptor.deployment_label,
+        deployment_datetime=descriptor.deployment_datetime,
+        campaign_label=descriptor.metadata.acfr_campaign_label,
+        file_counts={
+            section: len(getattr(descriptor.files, section))
+            for section in DeploymentFileSection.model_fields
+        },
+        topics=list(descriptor.telemetry.topics),
+        platform_sensor_keys=[
+            sensor.key for sensor in descriptor.platform.sensors
+        ],
+        vessel_sensor_keys=[sensor.key for sensor in descriptor.vessel.sensors],
+        unfilled_fields=collect_unfilled_fields(descriptor),
+    )
+
+
+def summarize_descriptors(
+    descriptors: list[DeploymentDescriptor],
+) -> DescriptorSummary:
+    """
+    Aggregate a set of deployment descriptors into a summary.
+
+    An un-enriched set has every curated slot unfilled, which degenerates into
+    one gap per field listing every deployment. That case is reported as
+    unenriched instead, and carries no curation gaps.
+
+    Arguments
+    ---------
+    descriptors: Deployment descriptors to summarize.
+
+    Returns
+    -------
+    The computed summary, including per-deployment detail.
+
+    Raises
+    ------
+    ValueError: If no descriptors were given.
+    """
+    if not descriptors:
+        raise ValueError("cannot summarize an empty set of descriptors")
+
+    deployments: list[DeploymentSummary] = [
+        _summarize_deployment(descriptor) for descriptor in descriptors
+    ]
+
+    campaign_counts: Counter[CampaignLabel] = Counter(
+        deployment.campaign_label for deployment in deployments
+    )
+    topic_counts: Counter[TopicName] = Counter(
+        topic for deployment in deployments for topic in deployment.topics
+    )
+    section_coverage: dict[SectionName, int] = {
+        section: sum(
+            1
+            for deployment in deployments
+            if deployment.file_counts[section] > 0
+        )
+        for section in DeploymentFileSection.model_fields
+    }
+
+    latitudes: list[float] = [
+        descriptor.metadata.origin_latitude for descriptor in descriptors
+    ]
+    longitudes: list[float] = [
+        descriptor.metadata.origin_longitude for descriptor in descriptors
+    ]
+
+    enriched: bool = any(
+        descriptor.platform.identity is not None for descriptor in descriptors
+    )
+
+    return DescriptorSummary(
+        deployment_count=len(descriptors),
+        campaign_counts=_sort_counts(campaign_counts),
+        earliest_datetime=min(
+            deployment.deployment_datetime for deployment in deployments
+        ),
+        latest_datetime=max(
+            deployment.deployment_datetime for deployment in deployments
+        ),
+        extent=GeographicExtent(
+            min_latitude=min(latitudes),
+            max_latitude=max(latitudes),
+            min_longitude=min(longitudes),
+            max_longitude=max(longitudes),
+        ),
+        section_coverage=section_coverage,
+        topic_counts=_sort_counts(topic_counts),
+        enriched=enriched,
+        curation_gaps=collect_curation_gaps(deployments) if enriched else [],
+        deployments=deployments,
+    )
+
+
+def collect_curation_gaps(
+    deployments: list[DeploymentSummary],
+) -> list[CurationGap]:
+    """
+    Group the per-deployment unfilled slots into one gap per field.
+
+    Arguments
+    ---------
+    deployments: Per-deployment summaries to group.
+
+    Returns
+    -------
+    Gaps ordered by descending deployment count, then by field name.
+    """
+    labels_by_field: dict[FieldName, list[str]] = {}
+    for deployment in deployments:
+        for field_name in deployment.unfilled_fields:
+            labels_by_field.setdefault(field_name, []).append(
+                deployment.deployment_label
+            )
+
+    return [
+        CurationGap(field_name=field_name, deployment_labels=labels)
+        for field_name, labels in sorted(
+            labels_by_field.items(), key=lambda item: (-len(item[1]), item[0])
+        )
+    ]

--- a/src/afft/tasks/deployment_descriptor/__init__.py
+++ b/src/afft/tasks/deployment_descriptor/__init__.py
@@ -14,6 +14,14 @@ from .runner import (
     describe_deployment as describe_deployment,
     run_describe_deployment as run_describe_deployment,
 )
+from .summary_runner import (
+    log_summary as log_summary,
+    run_summarize_descriptor as run_summarize_descriptor,
+)
+from .summary_types import (
+    SummarizeDescriptorCommand as SummarizeDescriptorCommand,
+    SummarizeDescriptorResult as SummarizeDescriptorResult,
+)
 from .types import (
     DeploymentFailure as DeploymentFailure,
     DeploymentWarning as DeploymentWarning,

--- a/src/afft/tasks/deployment_descriptor/summary_runner.py
+++ b/src/afft/tasks/deployment_descriptor/summary_runner.py
@@ -1,0 +1,157 @@
+"""Runner for the summarize descriptors task."""
+
+from rich.console import Console
+from rich.table import Table
+
+from afft.deployment import (
+    DeploymentDescriptor,
+    DescriptorSummary,
+    read_deployment_descriptors,
+    summarize_descriptors,
+    write_summary_report,
+)
+from afft.utils.log import logger
+
+from .summary_types import (
+    SummarizeDescriptorCommand,
+    SummarizeDescriptorResult,
+)
+
+
+def _count_table(title: str, name_header: str, counts: dict[str, int]) -> Table:
+    """Build a two-column table of names and counts."""
+    table = Table(title=title, title_justify="left")
+    table.add_column(name_header)
+    table.add_column("Deployments", justify="right")
+    for name, count in counts.items():
+        table.add_row(name, str(count))
+    return table
+
+
+def log_summary(summary: DescriptorSummary, verbose: bool) -> None:
+    """
+    Print the brief per-file aggregate summary to the terminal.
+
+    Arguments
+    ---------
+    summary: The computed summary.
+    verbose: List the offending deployment labels for each curation gap.
+    """
+    console = Console()
+    extent = summary.extent
+
+    overview = Table(title="Overview", title_justify="left", show_header=False)
+    overview.add_column("Field")
+    overview.add_column("Value")
+    overview.add_row("Deployments", str(summary.deployment_count))
+    overview.add_row("Campaigns", str(len(summary.campaign_counts)))
+    overview.add_row("Earliest", summary.earliest_datetime.isoformat())
+    overview.add_row("Latest", summary.latest_datetime.isoformat())
+    overview.add_row(
+        "Latitude", f"{extent.min_latitude} to {extent.max_latitude}"
+    )
+    overview.add_row(
+        "Longitude", f"{extent.min_longitude} to {extent.max_longitude}"
+    )
+    overview.add_row("Enriched", "yes" if summary.enriched else "no")
+    console.print(overview)
+
+    console.print(
+        _count_table("Campaigns", "Campaign", summary.campaign_counts)
+    )
+
+    coverage = Table(title="File coverage", title_justify="left")
+    coverage.add_column("Section")
+    coverage.add_column("Deployments", justify="right")
+    coverage.add_column("Missing", justify="right")
+    for section, count in summary.section_coverage.items():
+        coverage.add_row(
+            section, str(count), str(summary.deployment_count - count)
+        )
+    console.print(coverage)
+
+    console.print(
+        _count_table("Telemetry topics", "Topic", summary.topic_counts)
+    )
+
+    if not summary.enriched:
+        console.print(
+            "The descriptors are not enriched, so every curated slot is "
+            "unfilled."
+        )
+        return
+
+    if not summary.curation_gaps:
+        console.print("No unfilled curated slots.")
+        return
+
+    gaps = Table(title="Curation gaps", title_justify="left")
+    gaps.add_column("Field")
+    gaps.add_column("Deployments", justify="right")
+    for gap in summary.curation_gaps:
+        gaps.add_row(gap.field_name, str(gap.count))
+    console.print(gaps)
+
+    if verbose:
+        for gap in summary.curation_gaps:
+            console.print(f"{gap.field_name}:")
+            for label in gap.deployment_labels:
+                console.print(f"  {label}")
+
+
+def run_summarize_descriptor(
+    command: SummarizeDescriptorCommand,
+) -> SummarizeDescriptorResult:
+    """
+    Summarize a deployment descriptor file, printing the aggregates or writing
+    a detailed report.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The computed summary and the path written, if any.
+
+    Raises
+    ------
+    FileNotFoundError: If the input file or the output directory is missing.
+    ValueError: If the input file holds no deployments.
+    """
+    if not command.input_file.exists():
+        raise FileNotFoundError(
+            f"input file does not exist: {command.input_file}"
+        )
+    if command.output_file and not command.output_file.parent.exists():
+        raise FileNotFoundError(
+            f"output directory does not exist: {command.output_file.parent}"
+        )
+
+    logger.info("-------------------------------------")
+    logger.info("Summarize Deployment Descriptors")
+    logger.info(f"  input file:  {command.input_file}")
+    logger.info(f"  output file: {command.output_file}")
+    logger.info(f"  verbose:     {command.verbose}")
+    logger.info("-------------------------------------")
+
+    descriptors: list[DeploymentDescriptor] = read_deployment_descriptors(
+        command.input_file
+    )
+    if not descriptors:
+        raise ValueError(f"no deployments in {command.input_file}")
+
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+
+    if command.output_file:
+        write_summary_report(command.output_file, summary)
+        logger.info(
+            f"wrote a report for {summary.deployment_count} deployment(s) "
+            f"to {command.output_file}"
+        )
+    else:
+        log_summary(summary, command.verbose)
+
+    return SummarizeDescriptorResult(
+        summary=summary, output_file=command.output_file
+    )

--- a/src/afft/tasks/deployment_descriptor/summary_types.py
+++ b/src/afft/tasks/deployment_descriptor/summary_types.py
@@ -1,0 +1,43 @@
+"""Data types for the summarize descriptors task."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from afft.deployment import DescriptorSummary
+
+
+class SummarizeDescriptorCommand(BaseModel):
+    """
+    Command for summarizing the deployments in a descriptor file.
+
+    Attributes
+    ----------
+    input_file: Path to the deployment descriptors TOML file.
+    output_file: Path to write the detailed report as Markdown; ``None``
+        prints the brief summary to the terminal instead.
+    verbose: List the offending deployment labels in the terminal summary.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    output_file: Path | None = None
+    verbose: bool = False
+
+
+class SummarizeDescriptorResult(BaseModel):
+    """
+    Result of the summarize descriptors task.
+
+    Attributes
+    ----------
+    summary: The computed summary.
+    output_file: Path the report was written to; ``None`` if the summary was
+        only logged.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    summary: DescriptorSummary
+    output_file: Path | None

--- a/tests/test_summarize_descriptors.py
+++ b/tests/test_summarize_descriptors.py
@@ -1,0 +1,401 @@
+"""Tests for the summarize descriptors task and its CLI."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.deployment import (
+    DeploymentDescriptor,
+    DeploymentFileSection,
+    DeploymentMetadata,
+    DeploymentPlatformSection,
+    DeploymentSystemSection,
+    DeploymentTelemetrySection,
+    DeploymentVesselSection,
+    DescriptorSummary,
+    PlatformIdentity,
+    PlatformSensor,
+    SensorExtrinsics,
+    SensorIdentity,
+    VesselIdentity,
+    collect_unfilled_fields,
+    summarize_descriptors,
+    write_deployment_descriptors,
+    write_summary_report,
+)
+from afft.tasks.deployment_descriptor import (
+    SummarizeDescriptorCommand,
+    SummarizeDescriptorResult,
+    run_summarize_descriptor,
+)
+
+
+def _extrinsics() -> SensorExtrinsics:
+    """Builds a filled mounting pose."""
+    return SensorExtrinsics(
+        locx=0.1, locy=0.2, locz=0.3, rotx=0.0, roty=0.0, rotz=0.0
+    )
+
+
+def _identity(vendor: str = "Teledyne RDI") -> SensorIdentity:
+    """Builds a sensor identity, optionally with an empty vendor."""
+    return SensorIdentity(
+        label="Doppler velocity log",
+        vendor=vendor,
+        product="Work Horse Navigator",
+        type="dvl",
+    )
+
+
+def _build_descriptor(
+    label: str,
+    moment: datetime,
+    campaign: str,
+    latitude: float = -28.8,
+    longitude: float = 113.9,
+    topics: tuple[str, ...] = ("RDI", "GPS_RMC"),
+    platform_label: str = "auv-sirius",
+    platform: DeploymentPlatformSection | None = None,
+    vessel: DeploymentVesselSection | None = None,
+) -> DeploymentDescriptor:
+    """Builds a descriptor carrying only the fields the summarizer reads."""
+    return DeploymentDescriptor(
+        deployment_label=label,
+        deployment_datetime=moment,
+        metadata=DeploymentMetadata(
+            acfr_deployment_label=label,
+            acfr_campaign_label=campaign,
+            acfr_platform_label=platform_label,
+            origin_latitude=latitude,
+            origin_longitude=longitude,
+            magnetic_variation=-1.16,
+        ),
+        files=DeploymentFileSection(
+            raw_messages=["messages/a.RAW.auv"],
+            usbl_logs=["usbl/log-1.txt"],
+        ),
+        telemetry=DeploymentTelemetrySection(topics=list(topics)),
+        platform=platform if platform else _enriched_platform(),
+        system=DeploymentSystemSection(
+            vehicle_name="SEABED",
+            vehicle_config="NORM_CFG",
+            log_directory="/files1/Log",
+            logged_streams=["RAW"],
+        ),
+        vessel=vessel if vessel else _enriched_vessel(),
+    )
+
+
+def _enriched_platform() -> DeploymentPlatformSection:
+    """Builds a fully enriched platform section."""
+    return DeploymentPlatformSection(
+        identity=PlatformIdentity(
+            platform_label="AUV Sirius",
+            platform_class="SEABED",
+            platform_operator="ACFR",
+        ),
+        sensors=[
+            PlatformSensor(
+                key="RDI", identity=_identity(), extrinsics=_extrinsics()
+            )
+        ],
+    )
+
+
+def _enriched_vessel() -> DeploymentVesselSection:
+    """Builds a fully enriched vessel section."""
+    return DeploymentVesselSection(
+        identity=VesselIdentity(vessel_name="RV Linnaeus"), sensors=[]
+    )
+
+
+def _unenriched_platform() -> DeploymentPlatformSection:
+    """Builds a platform section as `describe` leaves it."""
+    return DeploymentPlatformSection(
+        identity=None, sensors=[PlatformSensor(key="RDI")]
+    )
+
+
+def test_summarize_aggregates_across_deployments() -> None:
+    """Counts, ranges, extent, and coverage aggregate over the whole file."""
+    descriptors: list[DeploymentDescriptor] = [
+        _build_descriptor(
+            "aaa_20100428_020202",
+            datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+            "WA201004",
+            latitude=-28.0,
+            longitude=113.0,
+            topics=("RDI", "GPS_RMC"),
+        ),
+        _build_descriptor(
+            "bbb_20110415_020103",
+            datetime(2011, 4, 15, 2, 1, 3, tzinfo=timezone.utc),
+            "WA201104",
+            latitude=-30.0,
+            longitude=115.0,
+            topics=("RDI",),
+        ),
+    ]
+
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+
+    assert summary.deployment_count == 2
+    assert summary.campaign_counts == {"WA201004": 1, "WA201104": 1}
+    assert summary.earliest_datetime.year == 2010
+    assert summary.latest_datetime.year == 2011
+    assert summary.extent.min_latitude == -30.0
+    assert summary.extent.max_latitude == -28.0
+    assert summary.extent.min_longitude == 113.0
+    assert summary.extent.max_longitude == 115.0
+    assert summary.topic_counts == {"RDI": 2, "GPS_RMC": 1}
+    assert summary.section_coverage["raw_messages"] == 2
+    assert summary.section_coverage["camera_poses"] == 0
+    assert summary.enriched
+    assert not summary.curation_gaps
+    assert len(summary.deployments) == 2
+
+
+def test_summarize_orders_counts_by_descending_count_then_name() -> None:
+    """Ordering is deterministic so report diffs stay quiet."""
+    descriptors: list[DeploymentDescriptor] = [
+        _build_descriptor(
+            "aaa_20100428_020202",
+            datetime(2010, 4, 28, tzinfo=timezone.utc),
+            "WA201004",
+            topics=("ZZZ", "AAA", "RDI"),
+        ),
+        _build_descriptor(
+            "bbb_20110415_020103",
+            datetime(2011, 4, 15, tzinfo=timezone.utc),
+            "WA201004",
+            topics=("RDI",),
+        ),
+    ]
+
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+
+    assert list(summary.topic_counts) == ["RDI", "AAA", "ZZZ"]
+
+
+def test_summarize_reports_unenriched_descriptors() -> None:
+    """An un-enriched set is flagged rather than listed gap by gap."""
+    descriptors: list[DeploymentDescriptor] = [
+        _build_descriptor(
+            "aaa_20100428_020202",
+            datetime(2010, 4, 28, tzinfo=timezone.utc),
+            "WA201004",
+            platform_label="",
+            platform=_unenriched_platform(),
+            vessel=DeploymentVesselSection(),
+        )
+    ]
+
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+
+    assert not summary.enriched
+    assert not summary.curation_gaps
+    assert summary.deployments[0].unfilled_fields
+
+
+def test_summarize_groups_partially_filled_rosters() -> None:
+    """Gaps group by field and carry the deployments they affect."""
+    partial = DeploymentPlatformSection(
+        identity=PlatformIdentity(
+            platform_label="AUV Sirius",
+            platform_class="SEABED",
+            platform_operator="",
+        ),
+        sensors=[
+            PlatformSensor(
+                key="RDI", identity=_identity(vendor=""), extrinsics=None
+            ),
+            PlatformSensor(key="OAS", identity=None, extrinsics=_extrinsics()),
+        ],
+    )
+    descriptors: list[DeploymentDescriptor] = [
+        _build_descriptor(
+            "aaa_20100428_020202",
+            datetime(2010, 4, 28, tzinfo=timezone.utc),
+            "WA201004",
+            platform=partial,
+        ),
+        _build_descriptor(
+            "bbb_20110415_020103",
+            datetime(2011, 4, 15, tzinfo=timezone.utc),
+            "WA201104",
+        ),
+    ]
+
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+    gaps: dict[str, list[str]] = {
+        gap.field_name: gap.deployment_labels for gap in summary.curation_gaps
+    }
+
+    assert summary.enriched
+    assert gaps["platform.identity.platform_operator"] == [
+        "aaa_20100428_020202"
+    ]
+    assert gaps["platform.sensors[RDI].identity.vendor"] == [
+        "aaa_20100428_020202"
+    ]
+    assert gaps["platform.sensors[RDI].extrinsics"] == ["aaa_20100428_020202"]
+    assert gaps["platform.sensors[OAS].identity"] == ["aaa_20100428_020202"]
+    assert "platform.sensors[OAS].extrinsics" not in gaps
+
+
+def test_collect_unfilled_fields_reports_empty_platform_label() -> None:
+    """An empty ACFR platform label counts as an unfilled slot."""
+    descriptor: DeploymentDescriptor = _build_descriptor(
+        "aaa_20100428_020202",
+        datetime(2010, 4, 28, tzinfo=timezone.utc),
+        "WA201004",
+        platform_label="",
+    )
+
+    assert "metadata.acfr_platform_label" in collect_unfilled_fields(descriptor)
+
+
+def test_summarize_rejects_an_empty_set() -> None:
+    """Summarizing nothing is a programming error, not an empty summary."""
+    with pytest.raises(ValueError):
+        summarize_descriptors([])
+
+
+def test_write_summary_report_is_stable(tmp_path: Path) -> None:
+    """The same summary renders byte-identical reports."""
+    descriptors: list[DeploymentDescriptor] = [
+        _build_descriptor(
+            "aaa_20100428_020202",
+            datetime(2010, 4, 28, tzinfo=timezone.utc),
+            "WA201004",
+        )
+    ]
+    summary: DescriptorSummary = summarize_descriptors(descriptors)
+
+    first: Path = tmp_path / "first.md"
+    second: Path = tmp_path / "second.md"
+    write_summary_report(first, summary)
+    write_summary_report(second, summarize_descriptors(descriptors))
+
+    assert first.read_text() == second.read_text()
+    assert first.read_text().startswith("# Deployment Descriptor Summary")
+    assert "| Campaign | Deployments |" in first.read_text()
+
+
+def test_run_summarize_writes_a_report(tmp_path: Path) -> None:
+    """With an output path the task writes Markdown and reports the path."""
+    input_file: Path = tmp_path / "descriptors.toml"
+    output_file: Path = tmp_path / "summary.md"
+    write_deployment_descriptors(
+        input_file,
+        [
+            _build_descriptor(
+                "aaa_20100428_020202",
+                datetime(2010, 4, 28, tzinfo=timezone.utc),
+                "WA201004",
+            )
+        ],
+    )
+
+    result: SummarizeDescriptorResult = run_summarize_descriptor(
+        SummarizeDescriptorCommand(
+            input_file=input_file, output_file=output_file
+        )
+    )
+
+    assert result.output_file == output_file
+    assert output_file.exists()
+    assert result.summary.deployment_count == 1
+
+
+def test_run_summarize_rejects_a_missing_input(tmp_path: Path) -> None:
+    """A missing input file fails before anything is read."""
+    with pytest.raises(FileNotFoundError):
+        run_summarize_descriptor(
+            SummarizeDescriptorCommand(input_file=tmp_path / "missing.toml")
+        )
+
+
+def test_run_summarize_rejects_a_missing_output_directory(
+    tmp_path: Path,
+) -> None:
+    """A missing output directory fails before the input is read."""
+    input_file: Path = tmp_path / "descriptors.toml"
+    write_deployment_descriptors(
+        input_file,
+        [
+            _build_descriptor(
+                "aaa_20100428_020202",
+                datetime(2010, 4, 28, tzinfo=timezone.utc),
+                "WA201004",
+            )
+        ],
+    )
+
+    with pytest.raises(FileNotFoundError):
+        run_summarize_descriptor(
+            SummarizeDescriptorCommand(
+                input_file=input_file,
+                output_file=tmp_path / "missing" / "summary.md",
+            )
+        )
+
+
+def test_cli_summarize_exits_zero_with_gaps(tmp_path: Path) -> None:
+    """Curation gaps are output, not failure, so the command exits zero."""
+    input_file: Path = tmp_path / "descriptors.toml"
+    write_deployment_descriptors(
+        input_file,
+        [
+            _build_descriptor(
+                "aaa_20100428_020202",
+                datetime(2010, 4, 28, tzinfo=timezone.utc),
+                "WA201004",
+                platform_label="",
+            )
+        ],
+    )
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        ["deployment", "summarize", "--input", str(input_file), "--verbose"],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_summarize_writes_a_report(tmp_path: Path) -> None:
+    """The CLI passes the output path through to the exporter."""
+    input_file: Path = tmp_path / "descriptors.toml"
+    output_file: Path = tmp_path / "summary.md"
+    write_deployment_descriptors(
+        input_file,
+        [
+            _build_descriptor(
+                "aaa_20100428_020202",
+                datetime(2010, 4, 28, tzinfo=timezone.utc),
+                "WA201004",
+            )
+        ],
+    )
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            "deployment",
+            "summarize",
+            "--input",
+            str(input_file),
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert output_file.exists()


### PR DESCRIPTION
Closes #191.

Adds `afft deployment summarize`, which aggregates a deployment descriptors file: deployment counts, campaigns, datetime range, geographic extent, file-section coverage, telemetry topic frequency, and the curated slots enrichment left unfilled.

Without `--output` the aggregates are printed to the terminal with `rich`; with it, a detailed per-deployment report is written as Markdown. `--verbose` lists the deployments affected by each curation gap. The command always exits zero — gaps are the output, not a failure.

Aggregation and Markdown rendering live in `afft.deployment` beside the other descriptor serialization; the task orchestrates. An un-enriched file is reported as such rather than emitting one gap per field across every deployment.

No new dependencies.