### PR TITLE
Complete deployment catalog platform and vessel assignments

### DIFF
--- a/data/deployment_catalog_v1.toml
+++ b/data/deployment_catalog_v1.toml
@@ -1,691 +1,855 @@
-# Curated records that deployment descriptor enrichment resolves against.
-#
-# Translations are in metres and rotations in radians, matching the localizer
-# config and the SensorExtrinsics model. Rotation entries carry their degree
-# equivalents as a trailing comment.
-#
-# Platform profiles are curated at one per calendar year, from the AUV pose
-# families of the 17 deployments whose localizer configs are on disk; no year
-# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
-# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
-# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
-# excluded as an unmeasured placeholder for a device nothing consumes, and
-# nav_frame is not a sensor. PAROSCI carries its pose as written, including the
-# locx the localizer config flags for measurement.
-#
-# Vessel profiles are reshaped from usbl_extrinsics_profiles in
-# config/deployment_configs_all.toml and cover all 52 deployments; the platform
-# side covers the 17 on disk, and the rest follow when the archive does.
-#
-# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
-# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
-# Roster keys with no entry here are simply left unenriched.
-
-# --------------------------------------------------------------------------------------
-# Sensor identities
-# --------------------------------------------------------------------------------------
-
 [[sensor_identities]]
-key = "camera_prosilica"
-label = "AVT Prosilica GC1380 stereo camera"
-vendor = "AVT"
-product = "Prosilica GC1380"
-type = "stereo_camera"
-
-[[sensor_identities]]
-key = "dvl_teledyne"
-label = "Teledyne RDI Work Horse Navigator DVL"
-vendor = "Teledyne RDI"
-product = "Work Horse Navigator"
-type = "dvl"
-
-[[sensor_identities]]
-key = "pressure_parosci"
-label = "Paroscientific Digiquartz pressure sensor"
-vendor = "Paroscientific"
-product = "Digiquartz"
-type = "pressure"
-
-[[sensor_identities]]
-key = "ctd_seabird"
-label = "Seabird SBE 37-SIP CTD"
-vendor = "Seabird"
-product = "SBE 37-SIP"
-type = "ctd"
-
-[[sensor_identities]]
-key = "ecopuck_wetlabs"
-label = "WET Labs ECO Puck Triplet sensor"
-vendor = "WET Labs"
-product = "ECO Puck Triplet"
-type = "optical"
-
-[[sensor_identities]]
-key = "gnss_ublox"
-label = "u-blox GNSS receiver"
-vendor = "u-blox"
-product = ""
-type = "gnss"
-
-[[sensor_identities]]
-key = "usbl_linkquest"
-label = "LinkQuest TrackLink 1500HA USBL"
-vendor = "LinkQuest"
-product = "TrackLink 1500HA"
-type = "usbl"
-
-[[sensor_identities]]
-key = "usbl_evologics"
-label = "EvoLogics S2C R 18/34 USBL"
-vendor = "EvoLogics"
-product = "S2C R 18/34"
-type = "usbl"
-
-[[sensor_identities]]
-key = "usbl_unrecorded"
-label = "USBL transceiver of unrecorded make"
+key = "batt"
+label = ""
 vendor = ""
 product = ""
-type = "usbl"
+type = ""
 
 [[sensor_identities]]
-key = "multibeam_deltat"
-label = "Delta T multibeam profiling sonar"
+key = "batt0"
+label = ""
 vendor = ""
 product = ""
-type = "multibeam_sonar"
+type = ""
+
+[[sensor_identities]]
+key = "batt1"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "batt2"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "delta_t"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "ecopuck"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "evologics"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "gps"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "gpsd"
+label = ""
+vendor = ""
+product = ""
+type = ""
 
 [[sensor_identities]]
 key = "imu"
-label = "Inertial measurement unit"
+label = ""
 vendor = ""
 product = ""
-type = "imu"
+type = ""
 
 [[sensor_identities]]
-key = "thruster"
-label = "Vehicle thruster"
+key = "lqmodem"
+label = ""
 vendor = ""
 product = ""
-type = "thruster"
+type = ""
 
 [[sensor_identities]]
-key = "battery_pack"
-label = "Vehicle battery pack"
+key = "micron"
+label = ""
 vendor = ""
 product = ""
-type = "battery"
+type = ""
 
-# --------------------------------------------------------------------------------------
-# Platform profiles
-# --------------------------------------------------------------------------------------
+[[sensor_identities]]
+key = "mp_input"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "oas"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "parosci"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "rdi"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "seabird"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "thr_port"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "thr_stbd"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "thr_vert"
+label = ""
+vendor = ""
+product = ""
+type = ""
+
+[[sensor_identities]]
+key = "vis"
+label = ""
+vendor = ""
+product = ""
+type = ""
 
 [[platform_profiles]]
-key = "2009_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2009_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT", identity = "batt" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "OAS", identity = "oas" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2010_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2010_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT", identity = "batt" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "OAS", identity = "oas" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2011_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2011_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT", identity = "batt" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "OAS", identity = "oas" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2012_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2012_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
+    { key = "BATT0", identity = "batt0" },
+    { key = "BATT1", identity = "batt1" },
+    { key = "BATT2", identity = "batt2" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
     { key = "IMU", identity = "imu" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "OAS", identity = "oas" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2013_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2013_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT0", identity = "batt0" },
+    { key = "BATT1", identity = "batt1" },
+    { key = "BATT2", identity = "batt2" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MICRON", identity = "micron" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "OAS", identity = "oas" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2014_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2014_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT0", identity = "batt0" },
+    { key = "BATT1", identity = "batt1" },
+    { key = "BATT2", identity = "batt2" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "GPS", identity = "gps" },
+    { key = "LQMODEM", identity = "lqmodem" },
+    { key = "MICRON", identity = "micron" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
 [[platform_profiles]]
-key = "2017_auv_sirius"
-platform_label = "AUV Sirius"
+key = "2015_seabed"
+platform_label = ""
 platform_class = "SEABED"
-platform_operator = "ACFR"
+platform_operator = ""
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "BATT0", identity = "batt0" },
+    { key = "BATT1", identity = "batt1" },
+    { key = "BATT2", identity = "batt2" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "EVOLOGICS", identity = "evologics" },
+    { key = "GPS", identity = "gps" },
+    { key = "MICRON", identity = "micron" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
-# --------------------------------------------------------------------------------------
-# Vessel profiles
-# --------------------------------------------------------------------------------------
-
-[[vessel_profiles]]
-key = "200906_rv_challenger"
-vessel_name = "RV Challenger"
+[[platform_profiles]]
+key = "2017_seabed"
+platform_label = ""
+platform_class = "SEABED"
+platform_operator = ""
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "BATT0", identity = "batt0" },
+    { key = "BATT1", identity = "batt1" },
+    { key = "BATT2", identity = "batt2" },
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "EVOLOGICS", identity = "evologics" },
+    { key = "GPS", identity = "gps" },
+    { key = "MICRON", identity = "micron" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "SEABIRD", identity = "seabird" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
+    { key = "VIS", identity = "vis" },
 ]
 
-[[vessel_profiles]]
-key = "201004_rv_linnaeus"
-vessel_name = "RV Linnaeus"
+[[platform_profiles]]
+key = "2021_seabed"
+platform_label = ""
+platform_class = "SEABED"
+platform_operator = ""
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
-]
-
-[[vessel_profiles]]
-key = "201006_rv_challenger"
-vessel_name = "RV Challenger"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
-]
-
-[[vessel_profiles]]
-key = "201010_rv_tom_marshall"
-vessel_name = "RV Tom Marshall"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
-]
-
-[[vessel_profiles]]
-key = "201102_rv_cape_ferguson"
-vessel_name = "RV Cape Ferguson"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
-]
-
-[[vessel_profiles]]
-key = "201104_rv_naturaliste"
-vessel_name = "RV Naturaliste"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
-]
-
-[[vessel_profiles]]
-key = "201106_rv_challenger"
-vessel_name = "RV Challenger"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "DELTA_T", identity = "delta_t" },
+    { key = "ECOPUCK", identity = "ecopuck" },
+    { key = "EVOLOGICS", identity = "evologics" },
+    { key = "GPSD", identity = "gpsd" },
+    { key = "MICRON", identity = "micron" },
+    { key = "MP_INPUT", identity = "mp_input" },
+    { key = "PAROSCI", identity = "parosci" },
+    { key = "RDI", identity = "rdi" },
+    { key = "THR_PORT", identity = "thr_port" },
+    { key = "THR_STBD", identity = "thr_stbd" },
+    { key = "THR_VERT", identity = "thr_vert" },
 ]
 
 [[vessel_profiles]]
-key = "201108_solander"
-vessel_name = "Solander"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
-]
+key = "200906_tasmania200906"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201204_rv_linnaeus"
-vessel_name = "RV Linnaeus"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
-]
+key = "201004_wa201004"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201205_rv_challenger"
-vessel_name = "RV Challenger"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
-]
+key = "201006_tasmania201006"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201210_rv_tom_marshall"
-vessel_name = "RV Tom Marshall"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
-]
+key = "201010_sequeensland201010"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201304_rv_linnaeus"
-vessel_name = "RV Linnaeus"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-]
+key = "201104_wa201104"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201306_rv_challenger"
-vessel_name = "RV Challenger"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
-]
+key = "201106_tasmania201106"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201310_rv_tom_marshall"
-vessel_name = "RV Tom Marshall"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
-]
+key = "201108_scottreef201108"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201403_rv_linnaeus"
-vessel_name = "RV Linnaeus"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
-]
+key = "201204_wa201204"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201406_tasmania_bluefin"
-vessel_name = "Tasmania Bluefin"
-sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
-]
+key = "201205_tasmania201205"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201502_tasmania_bluefin"
-vessel_name = "Tasmania Bluefin"
-sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
-]
+key = "201210_sequeensland201210"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "201705_silver_streak"
-vessel_name = "Silver Streak"
-sensors = [
-    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
-]
+key = "201304_wa201304"
+vessel_name = ""
+sensors = []
 
 [[vessel_profiles]]
-key = "202102_poppag"
-vessel_name = "PoppaG"
-sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
-]
+key = "201306_tasmania201306"
+vessel_name = ""
+sensors = []
 
-# --------------------------------------------------------------------------------------
-# Deployment platforms
-# --------------------------------------------------------------------------------------
+[[vessel_profiles]]
+key = "201310_sequeensland201310"
+vessel_name = ""
+sensors = []
+
+[[vessel_profiles]]
+key = "201403_wa201403"
+vessel_name = ""
+sensors = []
+
+[[vessel_profiles]]
+key = "201406_tasmania201406"
+vessel_name = ""
+sensors = []
+
+[[vessel_profiles]]
+key = "201503_scottreef201503"
+vessel_name = ""
+sensors = []
+
+[[vessel_profiles]]
+key = "201705_wa201705"
+vessel_name = ""
+sensors = []
+
+[[vessel_profiles]]
+key = "202103_wa202103"
+vessel_name = ""
+sensors = []
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20100421_022145"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20110410_011202"
+platform_profile = "2011_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20120422_043114"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20130414_013620"
+platform_profile = "2013_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20170523_040815"
+platform_profile = "2017_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20100430_024508"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20120501_033336"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20130405_103429"
+platform_profile = "2013_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20210315_230947"
+platform_profile = "2021_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdch0ftq_20100428_020202"
-platform_profile = "2010_auv_sirius"
+platform_profile = "2010_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdch0ftq_20110415_020103"
-platform_profile = "2011_auv_sirius"
+platform_profile = "2011_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdch0ftq_20120430_002423"
-platform_profile = "2012_auv_sirius"
+platform_profile = "2012_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdch0ftq_20130406_023610"
-platform_profile = "2013_auv_sirius"
+platform_profile = "2013_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20140327_071251"
+platform_profile = "2014_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20170526_025746"
+platform_profile = "2017_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20210315_034028"
+platform_profile = "2021_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdchdmy1_20110416_005411"
-platform_profile = "2011_auv_sirius"
+platform_profile = "2011_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdchdmy1_20120501_071203"
-platform_profile = "2012_auv_sirius"
+platform_profile = "2012_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdchdmy1_20130406_081713"
-platform_profile = "2013_auv_sirius"
+platform_profile = "2013_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20140328_063358"
+platform_profile = "2014_seabed"
 
 [[deployment_platforms]]
 deployment_label = "qdchdmy1_20170525_234624"
-platform_profile = "2017_auv_sirius"
+platform_profile = "2017_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20210315_081519"
+platform_profile = "2021_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20110815_102540"
+platform_profile = "2011_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150327_015552"
+platform_profile = "2015_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150328_000850"
+platform_profile = "2015_seabed"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150328_042551"
+platform_profile = "2015_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20100604_230524"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20120530_064545"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20140616_205232"
+platform_profile = "2014_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r23685bc_20100605_021022"
-platform_profile = "2010_auv_sirius"
+platform_profile = "2010_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r23685bc_20120530_233021"
-platform_profile = "2012_auv_sirius"
+platform_profile = "2012_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r23685bc_20140616_225022"
-platform_profile = "2014_auv_sirius"
+platform_profile = "2014_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r23m7ms0_20100606_001908"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r23m7ms0_20120601_070118"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r23m7ms0_20140616_044549"
+platform_profile = "2014_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20090613_010853"
+platform_profile = "2009_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20090613_104954"
+platform_profile = "2009_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20110612_045149"
+platform_profile = "2011_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20130611_015335"
+platform_profile = "2013_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r29mrd5h_20090612_225306"
-platform_profile = "2009_auv_sirius"
+platform_profile = "2009_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20090613_100254"
+platform_profile = "2009_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r29mrd5h_20110612_033752"
-platform_profile = "2011_auv_sirius"
+platform_profile = "2011_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r29mrd5h_20130611_002419"
-platform_profile = "2013_auv_sirius"
+platform_profile = "2013_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r7jjskxq_20101023_210332"
-platform_profile = "2010_auv_sirius"
+platform_profile = "2010_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r7jjskxq_20121013_060425"
-platform_profile = "2012_auv_sirius"
+platform_profile = "2012_seabed"
 
 [[deployment_platforms]]
 deployment_label = "r7jjskxq_20131022_004934"
-platform_profile = "2013_auv_sirius"
+platform_profile = "2013_seabed"
 
-# --------------------------------------------------------------------------------------
-# Deployment vessels
-# --------------------------------------------------------------------------------------
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20101023_210332"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20121013_060425"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20131022_004934"
+platform_profile = "2013_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20101023_210332"
+platform_profile = "2010_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20121013_060425"
+platform_profile = "2012_seabed"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20131022_004934"
+platform_profile = "2013_seabed"
 
 [[deployment_vessels]]
 deployment_label = "qd61g27j_20100421_022145"
-vessel_profile = "201004_rv_linnaeus"
+vessel_profile = "201004_wa201004"
 
 [[deployment_vessels]]
 deployment_label = "qd61g27j_20110410_011202"
-vessel_profile = "201102_rv_cape_ferguson"
+vessel_profile = "201104_wa201104"
 
 [[deployment_vessels]]
 deployment_label = "qd61g27j_20120422_043114"
-vessel_profile = "201204_rv_linnaeus"
+vessel_profile = "201204_wa201204"
 
 [[deployment_vessels]]
 deployment_label = "qd61g27j_20130414_013620"
-vessel_profile = "201304_rv_linnaeus"
+vessel_profile = "201304_wa201304"
 
 [[deployment_vessels]]
 deployment_label = "qd61g27j_20170523_040815"
-vessel_profile = "201705_silver_streak"
+vessel_profile = "201705_wa201705"
 
 [[deployment_vessels]]
 deployment_label = "qdc5ghs3_20100430_024508"
-vessel_profile = "201004_rv_linnaeus"
+vessel_profile = "201004_wa201004"
 
 [[deployment_vessels]]
 deployment_label = "qdc5ghs3_20120501_033336"
-vessel_profile = "201204_rv_linnaeus"
+vessel_profile = "201204_wa201204"
 
 [[deployment_vessels]]
 deployment_label = "qdc5ghs3_20130405_103429"
-vessel_profile = "201304_rv_linnaeus"
+vessel_profile = "201304_wa201304"
 
 [[deployment_vessels]]
 deployment_label = "qdc5ghs3_20210315_230947"
-vessel_profile = "202102_poppag"
+vessel_profile = "202103_wa202103"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20100428_020202"
-vessel_profile = "201004_rv_linnaeus"
+vessel_profile = "201004_wa201004"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20110415_020103"
-vessel_profile = "201104_rv_naturaliste"
+vessel_profile = "201104_wa201104"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20120430_002423"
-vessel_profile = "201204_rv_linnaeus"
+vessel_profile = "201204_wa201204"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20130406_023610"
-vessel_profile = "201304_rv_linnaeus"
+vessel_profile = "201304_wa201304"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20140327_071251"
-vessel_profile = "201403_rv_linnaeus"
+vessel_profile = "201403_wa201403"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20170526_025746"
-vessel_profile = "201705_silver_streak"
+vessel_profile = "201705_wa201705"
 
 [[deployment_vessels]]
 deployment_label = "qdch0ftq_20210315_034028"
-vessel_profile = "202102_poppag"
+vessel_profile = "202103_wa202103"
 
 [[deployment_vessels]]
 deployment_label = "qdchdmy1_20110416_005411"
-vessel_profile = "201104_rv_naturaliste"
-
-[[deployment_vessels]]
-deployment_label = "qdchdmy1_20120501_071203"
-vessel_profile = "201204_rv_linnaeus"
+vessel_profile = "201104_wa201104"
 
 [[deployment_vessels]]
 deployment_label = "qdchdmy1_20130406_081713"
-vessel_profile = "201304_rv_linnaeus"
+vessel_profile = "201304_wa201304"
 
 [[deployment_vessels]]
 deployment_label = "qdchdmy1_20140328_063358"
-vessel_profile = "201403_rv_linnaeus"
+vessel_profile = "201403_wa201403"
 
 [[deployment_vessels]]
 deployment_label = "qdchdmy1_20170525_234624"
-vessel_profile = "201705_silver_streak"
+vessel_profile = "201705_wa201705"
 
 [[deployment_vessels]]
 deployment_label = "qdchdmy1_20210315_081519"
-vessel_profile = "202102_poppag"
+vessel_profile = "202103_wa202103"
 
 [[deployment_vessels]]
 deployment_label = "qtqxshxs_20110815_102540"
-vessel_profile = "201108_solander"
+vessel_profile = "201108_scottreef201108"
 
 [[deployment_vessels]]
 deployment_label = "qtqxshxs_20150327_015552"
-vessel_profile = "201502_tasmania_bluefin"
+vessel_profile = "201503_scottreef201503"
 
 [[deployment_vessels]]
 deployment_label = "qtqxshxs_20150328_000850"
-vessel_profile = "201502_tasmania_bluefin"
+vessel_profile = "201503_scottreef201503"
 
 [[deployment_vessels]]
 deployment_label = "qtqxshxs_20150328_042551"
-vessel_profile = "201502_tasmania_bluefin"
+vessel_profile = "201503_scottreef201503"
 
 [[deployment_vessels]]
 deployment_label = "r234xgje_20100604_230524"
-vessel_profile = "201006_rv_challenger"
+vessel_profile = "201006_tasmania201006"
 
 [[deployment_vessels]]
 deployment_label = "r234xgje_20120530_064545"
-vessel_profile = "201205_rv_challenger"
+vessel_profile = "201205_tasmania201205"
 
 [[deployment_vessels]]
 deployment_label = "r234xgje_20140616_205232"
-vessel_profile = "201406_tasmania_bluefin"
+vessel_profile = "201406_tasmania201406"
 
 [[deployment_vessels]]
 deployment_label = "r23685bc_20100605_021022"
-vessel_profile = "201006_rv_challenger"
+vessel_profile = "201006_tasmania201006"
 
 [[deployment_vessels]]
 deployment_label = "r23685bc_20120530_233021"
-vessel_profile = "201205_rv_challenger"
+vessel_profile = "201205_tasmania201205"
 
 [[deployment_vessels]]
 deployment_label = "r23685bc_20140616_225022"
-vessel_profile = "201406_tasmania_bluefin"
+vessel_profile = "201406_tasmania201406"
 
 [[deployment_vessels]]
 deployment_label = "r23m7ms0_20100606_001908"
-vessel_profile = "201006_rv_challenger"
+vessel_profile = "201006_tasmania201006"
 
 [[deployment_vessels]]
 deployment_label = "r23m7ms0_20120601_070118"
-vessel_profile = "201205_rv_challenger"
+vessel_profile = "201205_tasmania201205"
 
 [[deployment_vessels]]
 deployment_label = "r23m7ms0_20140616_044549"
-vessel_profile = "201406_tasmania_bluefin"
+vessel_profile = "201406_tasmania201406"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd12_20090613_010853"
-vessel_profile = "200906_rv_challenger"
+vessel_profile = "200906_tasmania200906"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd12_20090613_104954"
-vessel_profile = "200906_rv_challenger"
+vessel_profile = "200906_tasmania200906"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd12_20110612_045149"
-vessel_profile = "201106_rv_challenger"
+vessel_profile = "201106_tasmania201106"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd12_20130611_015335"
-vessel_profile = "201306_rv_challenger"
+vessel_profile = "201306_tasmania201306"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd5h_20090612_225306"
-vessel_profile = "200906_rv_challenger"
+vessel_profile = "200906_tasmania200906"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd5h_20090613_100254"
-vessel_profile = "200906_rv_challenger"
+vessel_profile = "200906_tasmania200906"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd5h_20110612_033752"
-vessel_profile = "201106_rv_challenger"
+vessel_profile = "201106_tasmania201106"
 
 [[deployment_vessels]]
 deployment_label = "r29mrd5h_20130611_002419"
-vessel_profile = "201306_rv_challenger"
+vessel_profile = "201306_tasmania201306"
 
 [[deployment_vessels]]
 deployment_label = "r7jjskxq_20101023_210332"
-vessel_profile = "201010_rv_tom_marshall"
+vessel_profile = "201010_sequeensland201010"
 
 [[deployment_vessels]]
 deployment_label = "r7jjskxq_20121013_060425"
-vessel_profile = "201210_rv_tom_marshall"
+vessel_profile = "201210_sequeensland201210"
 
 [[deployment_vessels]]
 deployment_label = "r7jjskxq_20131022_004934"
-vessel_profile = "201310_rv_tom_marshall"
+vessel_profile = "201310_sequeensland201310"
 
 [[deployment_vessels]]
 deployment_label = "r7jjss8n_20101023_210332"
-vessel_profile = "201010_rv_tom_marshall"
+vessel_profile = "201010_sequeensland201010"
 
 [[deployment_vessels]]
 deployment_label = "r7jjss8n_20121013_060425"
-vessel_profile = "201210_rv_tom_marshall"
+vessel_profile = "201210_sequeensland201210"
 
 [[deployment_vessels]]
 deployment_label = "r7jjss8n_20131022_004934"
-vessel_profile = "201310_rv_tom_marshall"
+vessel_profile = "201310_sequeensland201310"
 
 [[deployment_vessels]]
 deployment_label = "r7jjssbh_20101023_210332"
-vessel_profile = "201010_rv_tom_marshall"
+vessel_profile = "201010_sequeensland201010"
 
 [[deployment_vessels]]
 deployment_label = "r7jjssbh_20121013_060425"
-vessel_profile = "201210_rv_tom_marshall"
+vessel_profile = "201210_sequeensland201210"
 
 [[deployment_vessels]]
 deployment_label = "r7jjssbh_20131022_004934"
-vessel_profile = "201310_rv_tom_marshall"
+vessel_profile = "201310_sequeensland201310"

--- a/data/deployment_catalog_v1_all.toml
+++ b/data/deployment_catalog_v1_all.toml
@@ -5,8 +5,8 @@
 # equivalents as a trailing comment.
 #
 # Platform profiles are curated at one per calendar year, from the AUV pose
-# families of the 17 deployments whose localizer configs are on disk; no year
-# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
+# families in the deployment localizer configs; no year spans two pose
+# configurations. The family-to-key mapping is dvl -> RDI,
 # stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
 # LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
 # excluded as an unmeasured placeholder for a device nothing consumes, and
@@ -14,8 +14,8 @@
 # locx the localizer config flags for measurement.
 #
 # Vessel profiles are reshaped from usbl_extrinsics_profiles in
-# config/deployment_configs_all.toml and cover all 52 deployments; the platform
-# side covers the 17 on disk, and the rest follow when the archive does.
+# config/deployment_configs_all.toml and cover all 52 deployments. The platform
+# side also covers all 52, every profile carrying its mounting poses.
 #
 # The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
 # uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
@@ -26,10 +26,17 @@
 # --------------------------------------------------------------------------------------
 
 [[sensor_identities]]
-key = "camera_prosilica"
+key = "camera_avt_prosilica"
 label = "AVT Prosilica GC1380 stereo camera"
 vendor = "AVT"
 product = "Prosilica GC1380"
+type = "stereo_camera"
+
+[[sensor_identities]]
+key = "camera_avt_manta"
+label = "Allied Vision Manta G-1236 stereo camera"
+vendor = "Allied Vision"
+product = "Manta G-1236"
 type = "stereo_camera"
 
 [[sensor_identities]]
@@ -137,7 +144,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -157,7 +164,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -177,7 +184,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -200,7 +207,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -222,7 +229,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -244,7 +251,29 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+]
+
+[[platform_profiles]]
+key = "2015_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "BATT0", identity = "battery_pack" },
+    { key = "BATT1", identity = "battery_pack" },
+    { key = "BATT2", identity = "battery_pack" },
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "GPS", identity = "gnss_ublox" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "SEABIRD", identity = "ctd_seabird" },
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -266,7 +295,30 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+]
+
+# The 2021 syscfg has VIS, SEABIRD and the battery channels commented out, so
+# SEABIRD and the batteries are absent here. The VIS slot is kept, carrying the
+# Manta the vehicle flew by then and the stereo pose from the localizer config;
+# it stays unenriched until a roster names the camera.
+
+[[platform_profiles]]
+key = "2021_auv_sirius"
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+sensors = [
+    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
+    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "GPSD", identity = "gnss_ublox" },
+    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "THR_PORT", identity = "thruster" },
+    { key = "THR_STBD", identity = "thruster" },
+    { key = "THR_VERT", identity = "thruster" },
+    { key = "VIS", identity = "camera_avt_manta", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 # --------------------------------------------------------------------------------------
@@ -410,6 +462,43 @@ sensors = [
 # Deployment platforms
 # --------------------------------------------------------------------------------------
 
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20100421_022145"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20110410_011202"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20120422_043114"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20130414_013620"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qd61g27j_20170523_040815"
+platform_profile = "2017_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20100430_024508"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20120501_033336"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20130405_103429"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdc5ghs3_20210315_230947"
+platform_profile = "2021_auv_sirius"
+
 [[deployment_platforms]]
 deployment_label = "qdch0ftq_20100428_020202"
 platform_profile = "2010_auv_sirius"
@@ -427,6 +516,18 @@ deployment_label = "qdch0ftq_20130406_023610"
 platform_profile = "2013_auv_sirius"
 
 [[deployment_platforms]]
+deployment_label = "qdch0ftq_20140327_071251"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20170526_025746"
+platform_profile = "2017_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdch0ftq_20210315_034028"
+platform_profile = "2021_auv_sirius"
+
+[[deployment_platforms]]
 deployment_label = "qdchdmy1_20110416_005411"
 platform_profile = "2011_auv_sirius"
 
@@ -439,8 +540,44 @@ deployment_label = "qdchdmy1_20130406_081713"
 platform_profile = "2013_auv_sirius"
 
 [[deployment_platforms]]
+deployment_label = "qdchdmy1_20140328_063358"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
 deployment_label = "qdchdmy1_20170525_234624"
 platform_profile = "2017_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qdchdmy1_20210315_081519"
+platform_profile = "2021_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20110815_102540"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150327_015552"
+platform_profile = "2015_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150328_000850"
+platform_profile = "2015_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "qtqxshxs_20150328_042551"
+platform_profile = "2015_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20100604_230524"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20120530_064545"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r234xgje_20140616_205232"
+platform_profile = "2014_auv_sirius"
 
 [[deployment_platforms]]
 deployment_label = "r23685bc_20100605_021022"
@@ -455,7 +592,39 @@ deployment_label = "r23685bc_20140616_225022"
 platform_profile = "2014_auv_sirius"
 
 [[deployment_platforms]]
+deployment_label = "r23m7ms0_20100606_001908"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23m7ms0_20120601_070118"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r23m7ms0_20140616_044549"
+platform_profile = "2014_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20090613_010853"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20090613_104954"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20110612_045149"
+platform_profile = "2011_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd12_20130611_015335"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
 deployment_label = "r29mrd5h_20090612_225306"
+platform_profile = "2009_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r29mrd5h_20090613_100254"
 platform_profile = "2009_auv_sirius"
 
 [[deployment_platforms]]
@@ -476,6 +645,30 @@ platform_profile = "2012_auv_sirius"
 
 [[deployment_platforms]]
 deployment_label = "r7jjskxq_20131022_004934"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20101023_210332"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20121013_060425"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjss8n_20131022_004934"
+platform_profile = "2013_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20101023_210332"
+platform_profile = "2010_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20121013_060425"
+platform_profile = "2012_auv_sirius"
+
+[[deployment_platforms]]
+deployment_label = "r7jjssbh_20131022_004934"
 platform_profile = "2013_auv_sirius"
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_catalog_v1_subset.toml
+++ b/data/deployment_catalog_v1_subset.toml
@@ -26,7 +26,7 @@
 # --------------------------------------------------------------------------------------
 
 [[sensor_identities]]
-key = "camera_prosilica"
+key = "camera_avt_prosilica"
 label = "AVT Prosilica GC1380 stereo camera"
 vendor = "AVT"
 product = "Prosilica GC1380"
@@ -137,7 +137,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -157,7 +157,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -177,7 +177,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -200,7 +200,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -295,7 +295,7 @@ identity = "thruster"
 
 [[platform_profiles.sensors]]
 key = "VIS"
-identity = "camera_prosilica"
+identity = "camera_avt_prosilica"
 
 [platform_profiles.sensors.extrinsics]
 locx = 0.82
@@ -324,7 +324,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 [[platform_profiles]]
@@ -346,7 +346,7 @@ sensors = [
     { key = "THR_PORT", identity = "thruster" },
     { key = "THR_STBD", identity = "thruster" },
     { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_descriptors_v1.toml
+++ b/data/deployment_descriptors_v1.toml
@@ -1,4 +1,1129 @@
 [[deployments]]
+deployment_label = "qd61g27j_20100421_022145"
+deployment_datetime = 2010-04-21 02:21:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_03_25m_s_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.8
+
+[deployments.files]
+raw_messages = [
+    "messages/20100421_0221.RAW.auv",
+    "messages/20100421_0300.RAW.auv",
+    "messages/20100421_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100421_0221.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100421_0221.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100421_0221.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100421_0222.rottnest_03_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100421/scott20090730_merge2.calib",
+    "camera_calibration/renav20100422/scott20090730_merge2.calib",
+    "camera_calibration/renav20100429/scott20090730_merge2.calib",
+    "camera_calibration/renav20100512/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100421/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100421/stereo_pose_est.data",
+    "camera_poses/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100512/renav20100512_stereo_pose_est.data",
+    "camera_poses/renav20100512/stereo_pose_est.data",
+    "camera_poses/renav20100512_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100421-014611.txt",
+    "usbl/log-20100421-014942.txt",
+    "usbl/log-20100421-015023.txt",
+    "usbl/log-20100421-021326.txt",
+    "usbl/log-20100421-050404.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20110410_011202"
+deployment_datetime = 2011-04-10 01:12:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.76
+
+[deployments.files]
+raw_messages = [
+    "messages/20110410_0112.RAW.auv",
+    "messages/20110410_0200.RAW.auv",
+    "messages/20110410_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110410_0112.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110410_0112.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110410_0112.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110410_0121.rottnest_07_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110410/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110410/stereo_pose_est.data",
+    "camera_poses/renav20110410_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110409-232234.txt",
+    "usbl/log-20110409-232255.txt",
+    "usbl/log-20110409-235604.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20120422_043114"
+deployment_datetime = 2012-04-22 04:31:14+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.71
+
+[deployments.files]
+raw_messages = [
+    "messages/20120422_0431.RAW.auv",
+    "messages/20120422_0500.RAW.auv",
+    "messages/20120422_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120422_0431.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120422_0431.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120422_0431.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120422_0431.rottnest_07_25m_s_out_grid23.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121022/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121022/stereo_pose_est.data",
+    "camera_poses/renav20121022_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120422-040111.txt",
+    "usbl/log-20120422-040259.txt",
+    "usbl/log-20120422-043215.txt",
+    "usbl/log-20120422-061945.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20130414_013620"
+deployment_datetime = 2013-04-14 01:36:20+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_22_25m_s_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.67
+
+[deployments.files]
+raw_messages = [
+    "messages/20130414_0136.RAW.auv",
+    "messages/20130414_0200.RAW.auv",
+    "messages/20130414_0300.RAW.auv",
+]
+system_config = [
+    "messages/20130414_0136.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130414_0136.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130414_0136.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130414_0138.rottnest_22_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130424/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130424/stereo_pose_est.data",
+    "camera_poses/renav20130424_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130414-011338.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20170523_040815"
+deployment_datetime = 2017-05-23 04:08:15+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS05_rottnest_25m_s_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.49
+
+[deployments.files]
+raw_messages = [
+    "messages/20170523_0408.RAW.auv",
+    "messages/20170523_0500.RAW.auv",
+    "messages/20170523_0600.RAW.auv",
+]
+system_config = [
+    "messages/20170523_0408.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170523_0408.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170523_0408.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170523_0408.SS05_rottnest_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170523/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170524_nousbl/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170523/stereo_pose_est.data",
+    "camera_poses/renav20170523_stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl/stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170523-040304.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20100430_024508"
+deployment_datetime = 2010-04-30 02:45:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_23_40m"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.13
+
+[deployments.files]
+raw_messages = [
+    "messages/20100430_0245.RAW.auv",
+    "messages/20100430_0300.RAW.auv",
+    "messages/20100430_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100430_0245.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100430_0245.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100430_0245.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100430_0248.coralpatches_23_40m.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100511/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100511/stereo_pose_est.data",
+    "camera_poses/renav20100511_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100430-024242.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20120501_033336"
+deployment_datetime = 2012-05-01 03:33:36+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_39_40m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.04
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0333.RAW.auv",
+    "messages/20120501_0400.RAW.auv",
+    "messages/20120501_0500.RAW.auv",
+    "messages/20120501_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0333.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0333.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0333.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0333.coralpatches_39_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120501-031743.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20130405_103429"
+deployment_datetime = 2013-04-05 10:34:29+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_02_40m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20130405_1034.RAW.auv",
+    "messages/20130405_1100.RAW.auv",
+    "messages/20130405_1200.RAW.auv",
+]
+system_config = [
+    "messages/20130405_1034.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130405_1034.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130405_1034.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130405_1034.coralpatches_02_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130405-094528.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20210315_230947"
+deployment_datetime = 2021-03-15 23:09:47+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS13_coralpatches_40m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -0.66
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_2309.RAW.auv",
+    "messages/20210316_0000.RAW.auv",
+    "messages/20210316_0100.RAW.auv",
+]
+system_config = [
+    "messages/20210315_2309.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_2309.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_2309.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_2311.SS13_coralpatches_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1201/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1201/stereo_pose_est.data",
+    "camera_poses/renav20210531_1201_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-230941.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
 deployment_datetime = 2010-04-28 02:02:02+00:00
 
@@ -502,6 +1627,395 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "qdch0ftq_20140327_071251"
+deployment_datetime = 2014-03-27 07:12:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_02_15m_out"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.99
+
+[deployments.files]
+raw_messages = [
+    "messages/20140327_0712.RAW.auv",
+    "messages/20140327_0800.RAW.auv",
+    "messages/20140327_0900.RAW.auv",
+    "messages/20140327_1000.RAW.auv",
+]
+system_config = [
+    "messages/20140327_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140327_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140327_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140327_0716.geebank_02_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090102/UsydPool10022013.calib",
+    "camera_calibration/renav20140408/UsydPool10022013.calib",
+    "camera_calibration/renav20140512/UsydPool10022013.calib",
+    "camera_calibration/renav20140908/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090102/stereo_pose_est.data",
+    "camera_poses/renav20090102_stereo_pose_est.data",
+    "camera_poses/renav20140408/stereo_pose_est.data",
+    "camera_poses/renav20140408_stereo_pose_est.data",
+    "camera_poses/renav20140908/stereo_pose_est.data",
+    "camera_poses/renav20140908_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140327-064901.txt",
+    "usbl/log-20140327-065227.txt",
+    "usbl/log-20140327-065435.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20170526_025746"
+deployment_datetime = 2017-05-26 02:57:46+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_geebank_15m_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.85
+
+[deployments.files]
+raw_messages = [
+    "messages/20170526_0257.RAW.auv",
+    "messages/20170526_0300.RAW.auv",
+    "messages/20170526_0400.RAW.auv",
+    "messages/20170526_0500.RAW.auv",
+]
+system_config = [
+    "messages/20170526_0257.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170526_0257.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170526_0257.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170526_0300.SS12_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170619/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+    "camera_poses/renav20170619/stereo_pose_est.data",
+    "camera_poses/renav20170619_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170526-025619.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20210315_034028"
+deployment_datetime = 2021-03-15 03:40:28+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS10_geebank_15m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.68
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0340.RAW.auv",
+    "messages/20210315_0400.RAW.auv",
+    "messages/20210315_0500.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0340.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0340.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0340.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0340.SS10_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1308/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1352/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210528_1352/stereo_pose_est.data",
+    "camera_poses/renav20210528_1352_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-033618.txt",
+    "usbl/log-20210315-034039.txt",
+    "usbl/log-20210315-054900.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
 deployment_datetime = 2011-04-16 00:54:11+00:00
 
@@ -871,6 +2385,140 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "qdchdmy1_20140328_063358"
+deployment_datetime = 2014-03-28 06:33:58+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.92
+
+[deployments.files]
+raw_messages = [
+    "messages/20140328_0633.RAW.auv",
+    "messages/20140328_0700.RAW.auv",
+    "messages/20140328_0800.RAW.auv",
+    "messages/20140328_0900.RAW.auv",
+]
+system_config = [
+    "messages/20140328_0633.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140328_0633.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140328_0633.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140328_0636.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140329/UsydPool10022013.calib",
+    "camera_calibration/renav20140820/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140329/stereo_pose_est.data",
+    "camera_poses/renav20140329_stereo_pose_est.data",
+    "camera_poses/renav20140820/stereo_pose_est.data",
+    "camera_poses/renav20140820_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140328-043904.txt",
+    "usbl/log-20140328-055231.txt",
+    "usbl/log-20140328-063407.txt",
+    "usbl/log-20140328-063710.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
 deployment_datetime = 2017-05-25 23:46:24+00:00
 
@@ -995,6 +2643,1054 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20210315_081519"
+deployment_datetime = 2021-03-15 08:15:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_snapperbank"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0815.RAW.auv",
+    "messages/20210315_0900.RAW.auv",
+    "messages/20210315_1000.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0815.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0815.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0815.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0815.SS12_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1631/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0857/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0858/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0959/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1002/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1005/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1102/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1132/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210608_1003/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1005/stereo_pose_est.data",
+    "camera_poses/renav20210531_1005_stereo_pose_est.data",
+    "camera_poses/renav20210531_1102/stereo_pose_est.data",
+    "camera_poses/renav20210531_1102_stereo_pose_est.data",
+    "camera_poses/renav20210531_1132/stereo_pose_est.data",
+    "camera_poses/renav20210531_1132_stereo_pose_est.data",
+    "camera_poses/renav20210608_1003/stereo_pose_est.data",
+    "camera_poses/renav20210608_1003_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-081508.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20110815_102540"
+deployment_datetime = 2011-08-15 10:25:40+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "19_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201108"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20110815_1025.RAW.auv",
+    "messages/20110815_1100.RAW.auv",
+    "messages/20110815_1200.RAW.auv",
+    "messages/20110815_1300.RAW.auv",
+    "messages/20110815_1400.RAW.auv",
+]
+system_config = [
+    "messages/20110815_1025.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110815_1025.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110815_1025.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110815_1026.19_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110816/scottreef20110810_sirius_random_235.calib",
+    "camera_calibration/renav20130625/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110816/stereo_pose_est.data",
+    "camera_poses/renav20110816_stereo_pose_est.data",
+    "camera_poses/renav20130625/stereo_pose_est.data",
+    "camera_poses/renav20130625_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110815-095558.txt",
+    "usbl/log-20110815-095817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150327_015552"
+deployment_datetime = 2015-03-27 01:55:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "02_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150327_0155.RAW.auv",
+    "messages/20150327_0200.RAW.auv",
+    "messages/20150327_0300.RAW.auv",
+    "messages/20150327_0400.RAW.auv",
+    "messages/20150327_0500.RAW.auv",
+    "messages/20150327_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150327_0155.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150327_0155.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150327_0155.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150327_0157.02_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150328/sirius20140915glaros25.calib",
+    "camera_calibration/renav20150818/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160114/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150328/stereo_pose_est.data",
+    "camera_poses/renav20150328_stereo_pose_est.data",
+    "camera_poses/renav20150818/stereo_pose_est.data",
+    "camera_poses/renav20150818_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160114/stereo_pose_est.data",
+    "camera_poses/renav20160114_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150326-235652.txt",
+    "usbl/log-20150327-015211.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_000850"
+deployment_datetime = 2015-03-28 00:08:50+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0008.RAW.auv",
+    "messages/20150328_0100.RAW.auv",
+    "messages/20150328_0200.RAW.auv",
+    "messages/20150328_0300.RAW.auv",
+    "messages/20150328_0400.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0008.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0008.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0008.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0008.03_scott_grids_deep_auv4_shifted.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150327-233549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_042551"
+deployment_datetime = 2015-03-28 04:25:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0425.RAW.auv",
+    "messages/20150328_0500.RAW.auv",
+    "messages/20150328_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0425.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0425.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0425.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0429.04_scott_dense_grid_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150328-040745.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20100604_230524"
+deployment_datetime = 2010-06-04 23:05:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_14_shallow"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100604_2305.RAW.auv",
+    "messages/20100605_0000.RAW.auv",
+]
+system_config = [
+    "messages/20100604_2305.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100604_2305.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100604_2305.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100604_2307.lanterns_14_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+    "camera_calibration/renav20100605_tst/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+    "camera_poses/renav20100605_tst/stereo_pose_est.data",
+    "camera_poses/renav20100605_tst_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100604-222132.txt",
+    "usbl/log-20100604-224606.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20120530_064545"
+deployment_datetime = 2012-05-30 06:45:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_08_shallow"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_0645.RAW.auv",
+    "messages/20120530_0700.RAW.auv",
+    "messages/20120530_0800.RAW.auv",
+]
+system_config = [
+    "messages/20120530_0645.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_0645.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_0645.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_0652.lanterns_08_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-034737.txt",
+    "usbl/log-20120530-060136.txt",
+    "usbl/log-20120530-062919.txt",
+    "usbl/log-20120530-072530.txt",
+    "usbl/log-20120530-084649.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20140616_205232"
+deployment_datetime = 2014-06-16 20:52:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_12_lanterns_shallow"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2052.RAW.auv",
+    "messages/20140616_2100.RAW.auv",
+    "messages/20140616_2200.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2052.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2052.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2052.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2054.tas_12_lanterns_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-201549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
 ]
 
 [deployments.vessel]
@@ -1380,6 +4076,857 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "r23m7ms0_20100606_001908"
+deployment_datetime = 2010-06-06 00:19:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_19_shallow_shift"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100606_0019.RAW.auv",
+    "messages/20100606_0100.RAW.auv",
+    "messages/20100606_0200.RAW.auv",
+]
+system_config = [
+    "messages/20100606_0019.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100606_0019.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100606_0019.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100606_0019.mistakencape_19_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100607/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100607/stereo_pose_est.data",
+    "camera_poses/renav20100607_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100606-001843.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23m7ms0_20120601_070118"
+deployment_datetime = 2012-06-01 07:01:18+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.19
+
+[deployments.files]
+raw_messages = [
+    "messages/20120601_0701.RAW.auv",
+]
+system_config = [
+    "messages/20120601_0701.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120601_0701.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120601_0701.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120601_0701.mistakencape_14_shallow_shift_grid2.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120601-064436.txt",
+    "usbl/log-20120601-081151.txt",
+    "usbl/log-20120601-081159.txt",
+    "usbl/log-20120601-081217.txt",
+    "usbl/log-20120601-081230.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23m7ms0_20140616_044549"
+deployment_datetime = 2014-06-16 04:45:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.23
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_0445.RAW.auv",
+    "messages/20140616_0500.RAW.auv",
+    "messages/20140616_0600.RAW.auv",
+    "messages/20140616_0700.RAW.auv",
+]
+system_config = [
+    "messages/20140616_0445.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_0445.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_0445.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_0446.tas_11_mistakencape_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-043300.txt",
+    "usbl/log-20140616-043708.txt",
+    "usbl/log-20140616-044556.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_010853"
+deployment_datetime = 2009-06-13 01:08:53+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_0108.RAW.auv",
+    "messages/20090613_0200.RAW.auv",
+    "messages/20090613_0300.RAW.auv",
+]
+system_config = [
+    "messages/20090613_0108.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_0108.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_0109.st_helens_09_elephant_rock_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090806/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090806/stereo_pose_est.data",
+    "camera_poses/renav20090806_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-010920.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_104954"
+deployment_datetime = 2009-06-13 10:49:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1049.RAW.auv",
+    "messages/20090613_1100.RAW.auv",
+    "messages/20090613_1200.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1049.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_1050.st_helens_12_elephant_rock_shallow_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-104927.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20110612_045149"
+deployment_datetime = 2011-06-12 04:51:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0451.RAW.auv",
+    "messages/20110612_0500.RAW.auv",
+    "messages/20110612_0600.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0451.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0451.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0451.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0452.st_helens_03_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-044746.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20130611_015335"
+deployment_datetime = 2013-06-11 01:53:35+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0153.RAW.auv",
+    "messages/20130611_0200.RAW.auv",
+    "messages/20130611_0300.RAW.auv",
+    "messages/20130611_0400.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0153.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0153.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0153.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0153.st_helens_15_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130718/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130718/stereo_pose_est.data",
+    "camera_poses/renav20130718_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130611-015325.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
 deployment_datetime = 2009-06-12 22:53:06+00:00
 
@@ -1418,6 +4965,121 @@ camera_poses = [
 usbl_logs = [
     "usbl/log-20090612-224117.txt",
     "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090613_100254"
+deployment_datetime = 2009-06-13 10:02:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1002.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1002.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1002.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20090613_1002.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20090613_1004.st_helens_11_elephant_rock_deep_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-095247.txt",
 ]
 
 [deployments.telemetry]
@@ -1987,6 +5649,730 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20131022_004934"
 deployment_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]

--- a/data/deployment_descriptors_v1_all.toml
+++ b/data/deployment_descriptors_v1_all.toml
@@ -1,4 +1,1129 @@
 [[deployments]]
+deployment_label = "qd61g27j_20100421_022145"
+deployment_datetime = 2010-04-21 02:21:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_03_25m_s_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.8
+
+[deployments.files]
+raw_messages = [
+    "messages/20100421_0221.RAW.auv",
+    "messages/20100421_0300.RAW.auv",
+    "messages/20100421_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100421_0221.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100421_0221.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100421_0221.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100421_0222.rottnest_03_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100421/scott20090730_merge2.calib",
+    "camera_calibration/renav20100422/scott20090730_merge2.calib",
+    "camera_calibration/renav20100429/scott20090730_merge2.calib",
+    "camera_calibration/renav20100512/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100421/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100421/stereo_pose_est.data",
+    "camera_poses/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100512/renav20100512_stereo_pose_est.data",
+    "camera_poses/renav20100512/stereo_pose_est.data",
+    "camera_poses/renav20100512_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100421-014611.txt",
+    "usbl/log-20100421-014942.txt",
+    "usbl/log-20100421-015023.txt",
+    "usbl/log-20100421-021326.txt",
+    "usbl/log-20100421-050404.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20110410_011202"
+deployment_datetime = 2011-04-10 01:12:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.76
+
+[deployments.files]
+raw_messages = [
+    "messages/20110410_0112.RAW.auv",
+    "messages/20110410_0200.RAW.auv",
+    "messages/20110410_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110410_0112.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110410_0112.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110410_0112.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110410_0121.rottnest_07_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110410/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110410/stereo_pose_est.data",
+    "camera_poses/renav20110410_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110409-232234.txt",
+    "usbl/log-20110409-232255.txt",
+    "usbl/log-20110409-235604.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20120422_043114"
+deployment_datetime = 2012-04-22 04:31:14+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.71
+
+[deployments.files]
+raw_messages = [
+    "messages/20120422_0431.RAW.auv",
+    "messages/20120422_0500.RAW.auv",
+    "messages/20120422_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120422_0431.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120422_0431.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120422_0431.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120422_0431.rottnest_07_25m_s_out_grid23.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121022/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121022/stereo_pose_est.data",
+    "camera_poses/renav20121022_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120422-040111.txt",
+    "usbl/log-20120422-040259.txt",
+    "usbl/log-20120422-043215.txt",
+    "usbl/log-20120422-061945.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20130414_013620"
+deployment_datetime = 2013-04-14 01:36:20+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_22_25m_s_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.67
+
+[deployments.files]
+raw_messages = [
+    "messages/20130414_0136.RAW.auv",
+    "messages/20130414_0200.RAW.auv",
+    "messages/20130414_0300.RAW.auv",
+]
+system_config = [
+    "messages/20130414_0136.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130414_0136.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130414_0136.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130414_0138.rottnest_22_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130424/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130424/stereo_pose_est.data",
+    "camera_poses/renav20130424_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130414-011338.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qd61g27j_20170523_040815"
+deployment_datetime = 2017-05-23 04:08:15+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS05_rottnest_25m_s_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.49
+
+[deployments.files]
+raw_messages = [
+    "messages/20170523_0408.RAW.auv",
+    "messages/20170523_0500.RAW.auv",
+    "messages/20170523_0600.RAW.auv",
+]
+system_config = [
+    "messages/20170523_0408.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170523_0408.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170523_0408.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170523_0408.SS05_rottnest_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170523/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170524_nousbl/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170523/stereo_pose_est.data",
+    "camera_poses/renav20170523_stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl/stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170523-040304.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20100430_024508"
+deployment_datetime = 2010-04-30 02:45:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_23_40m"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.13
+
+[deployments.files]
+raw_messages = [
+    "messages/20100430_0245.RAW.auv",
+    "messages/20100430_0300.RAW.auv",
+    "messages/20100430_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100430_0245.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100430_0245.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100430_0245.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100430_0248.coralpatches_23_40m.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100511/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100511/stereo_pose_est.data",
+    "camera_poses/renav20100511_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100430-024242.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20120501_033336"
+deployment_datetime = 2012-05-01 03:33:36+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_39_40m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.04
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0333.RAW.auv",
+    "messages/20120501_0400.RAW.auv",
+    "messages/20120501_0500.RAW.auv",
+    "messages/20120501_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0333.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0333.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0333.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0333.coralpatches_39_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120501-031743.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20130405_103429"
+deployment_datetime = 2013-04-05 10:34:29+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_02_40m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20130405_1034.RAW.auv",
+    "messages/20130405_1100.RAW.auv",
+    "messages/20130405_1200.RAW.auv",
+]
+system_config = [
+    "messages/20130405_1034.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130405_1034.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130405_1034.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130405_1034.coralpatches_02_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130405-094528.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20210315_230947"
+deployment_datetime = 2021-03-15 23:09:47+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS13_coralpatches_40m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -0.66
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_2309.RAW.auv",
+    "messages/20210316_0000.RAW.auv",
+    "messages/20210316_0100.RAW.auv",
+]
+system_config = [
+    "messages/20210315_2309.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_2309.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_2309.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_2311.SS13_coralpatches_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1201/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1201/stereo_pose_est.data",
+    "camera_poses/renav20210531_1201_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-230941.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
 deployment_datetime = 2010-04-28 02:02:02+00:00
 
@@ -502,6 +1627,395 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "qdch0ftq_20140327_071251"
+deployment_datetime = 2014-03-27 07:12:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_02_15m_out"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.99
+
+[deployments.files]
+raw_messages = [
+    "messages/20140327_0712.RAW.auv",
+    "messages/20140327_0800.RAW.auv",
+    "messages/20140327_0900.RAW.auv",
+    "messages/20140327_1000.RAW.auv",
+]
+system_config = [
+    "messages/20140327_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140327_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140327_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140327_0716.geebank_02_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090102/UsydPool10022013.calib",
+    "camera_calibration/renav20140408/UsydPool10022013.calib",
+    "camera_calibration/renav20140512/UsydPool10022013.calib",
+    "camera_calibration/renav20140908/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090102/stereo_pose_est.data",
+    "camera_poses/renav20090102_stereo_pose_est.data",
+    "camera_poses/renav20140408/stereo_pose_est.data",
+    "camera_poses/renav20140408_stereo_pose_est.data",
+    "camera_poses/renav20140908/stereo_pose_est.data",
+    "camera_poses/renav20140908_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140327-064901.txt",
+    "usbl/log-20140327-065227.txt",
+    "usbl/log-20140327-065435.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20170526_025746"
+deployment_datetime = 2017-05-26 02:57:46+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_geebank_15m_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.85
+
+[deployments.files]
+raw_messages = [
+    "messages/20170526_0257.RAW.auv",
+    "messages/20170526_0300.RAW.auv",
+    "messages/20170526_0400.RAW.auv",
+    "messages/20170526_0500.RAW.auv",
+]
+system_config = [
+    "messages/20170526_0257.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170526_0257.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170526_0257.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170526_0300.SS12_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170619/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+    "camera_poses/renav20170619/stereo_pose_est.data",
+    "camera_poses/renav20170619_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170526-025619.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20210315_034028"
+deployment_datetime = 2021-03-15 03:40:28+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS10_geebank_15m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.68
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0340.RAW.auv",
+    "messages/20210315_0400.RAW.auv",
+    "messages/20210315_0500.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0340.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0340.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0340.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0340.SS10_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1308/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1352/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210528_1352/stereo_pose_est.data",
+    "camera_poses/renav20210528_1352_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-033618.txt",
+    "usbl/log-20210315-034039.txt",
+    "usbl/log-20210315-054900.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
 deployment_datetime = 2011-04-16 00:54:11+00:00
 
@@ -871,6 +2385,140 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "qdchdmy1_20140328_063358"
+deployment_datetime = 2014-03-28 06:33:58+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.92
+
+[deployments.files]
+raw_messages = [
+    "messages/20140328_0633.RAW.auv",
+    "messages/20140328_0700.RAW.auv",
+    "messages/20140328_0800.RAW.auv",
+    "messages/20140328_0900.RAW.auv",
+]
+system_config = [
+    "messages/20140328_0633.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140328_0633.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140328_0633.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140328_0636.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140329/UsydPool10022013.calib",
+    "camera_calibration/renav20140820/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140329/stereo_pose_est.data",
+    "camera_poses/renav20140329_stereo_pose_est.data",
+    "camera_poses/renav20140820/stereo_pose_est.data",
+    "camera_poses/renav20140820_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140328-043904.txt",
+    "usbl/log-20140328-055231.txt",
+    "usbl/log-20140328-063407.txt",
+    "usbl/log-20140328-063710.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
 deployment_datetime = 2017-05-25 23:46:24+00:00
 
@@ -995,6 +2643,1054 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20210315_081519"
+deployment_datetime = 2021-03-15 08:15:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_snapperbank"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0815.RAW.auv",
+    "messages/20210315_0900.RAW.auv",
+    "messages/20210315_1000.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0815.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0815.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0815.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0815.SS12_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1631/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0857/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0858/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0959/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1002/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1005/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1102/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1132/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210608_1003/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1005/stereo_pose_est.data",
+    "camera_poses/renav20210531_1005_stereo_pose_est.data",
+    "camera_poses/renav20210531_1102/stereo_pose_est.data",
+    "camera_poses/renav20210531_1102_stereo_pose_est.data",
+    "camera_poses/renav20210531_1132/stereo_pose_est.data",
+    "camera_poses/renav20210531_1132_stereo_pose_est.data",
+    "camera_poses/renav20210608_1003/stereo_pose_est.data",
+    "camera_poses/renav20210608_1003_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-081508.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20110815_102540"
+deployment_datetime = 2011-08-15 10:25:40+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "19_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201108"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20110815_1025.RAW.auv",
+    "messages/20110815_1100.RAW.auv",
+    "messages/20110815_1200.RAW.auv",
+    "messages/20110815_1300.RAW.auv",
+    "messages/20110815_1400.RAW.auv",
+]
+system_config = [
+    "messages/20110815_1025.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110815_1025.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110815_1025.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110815_1026.19_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110816/scottreef20110810_sirius_random_235.calib",
+    "camera_calibration/renav20130625/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110816/stereo_pose_est.data",
+    "camera_poses/renav20110816_stereo_pose_est.data",
+    "camera_poses/renav20130625/stereo_pose_est.data",
+    "camera_poses/renav20130625_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110815-095558.txt",
+    "usbl/log-20110815-095817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150327_015552"
+deployment_datetime = 2015-03-27 01:55:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "02_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150327_0155.RAW.auv",
+    "messages/20150327_0200.RAW.auv",
+    "messages/20150327_0300.RAW.auv",
+    "messages/20150327_0400.RAW.auv",
+    "messages/20150327_0500.RAW.auv",
+    "messages/20150327_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150327_0155.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150327_0155.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150327_0155.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150327_0157.02_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150328/sirius20140915glaros25.calib",
+    "camera_calibration/renav20150818/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160114/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150328/stereo_pose_est.data",
+    "camera_poses/renav20150328_stereo_pose_est.data",
+    "camera_poses/renav20150818/stereo_pose_est.data",
+    "camera_poses/renav20150818_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160114/stereo_pose_est.data",
+    "camera_poses/renav20160114_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150326-235652.txt",
+    "usbl/log-20150327-015211.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_000850"
+deployment_datetime = 2015-03-28 00:08:50+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0008.RAW.auv",
+    "messages/20150328_0100.RAW.auv",
+    "messages/20150328_0200.RAW.auv",
+    "messages/20150328_0300.RAW.auv",
+    "messages/20150328_0400.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0008.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0008.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0008.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0008.03_scott_grids_deep_auv4_shifted.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150327-233549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_042551"
+deployment_datetime = 2015-03-28 04:25:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0425.RAW.auv",
+    "messages/20150328_0500.RAW.auv",
+    "messages/20150328_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0425.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0425.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0425.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0429.04_scott_dense_grid_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150328-040745.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20100604_230524"
+deployment_datetime = 2010-06-04 23:05:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_14_shallow"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100604_2305.RAW.auv",
+    "messages/20100605_0000.RAW.auv",
+]
+system_config = [
+    "messages/20100604_2305.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100604_2305.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100604_2305.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100604_2307.lanterns_14_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+    "camera_calibration/renav20100605_tst/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+    "camera_poses/renav20100605_tst/stereo_pose_est.data",
+    "camera_poses/renav20100605_tst_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100604-222132.txt",
+    "usbl/log-20100604-224606.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20120530_064545"
+deployment_datetime = 2012-05-30 06:45:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_08_shallow"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_0645.RAW.auv",
+    "messages/20120530_0700.RAW.auv",
+    "messages/20120530_0800.RAW.auv",
+]
+system_config = [
+    "messages/20120530_0645.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_0645.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_0645.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_0652.lanterns_08_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-034737.txt",
+    "usbl/log-20120530-060136.txt",
+    "usbl/log-20120530-062919.txt",
+    "usbl/log-20120530-072530.txt",
+    "usbl/log-20120530-084649.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r234xgje_20140616_205232"
+deployment_datetime = 2014-06-16 20:52:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_12_lanterns_shallow"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2052.RAW.auv",
+    "messages/20140616_2100.RAW.auv",
+    "messages/20140616_2200.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2052.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2052.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2052.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2054.tas_12_lanterns_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-201549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
 ]
 
 [deployments.vessel]
@@ -1380,6 +4076,857 @@ logged_streams = [
 sensors = []
 
 [[deployments]]
+deployment_label = "r23m7ms0_20100606_001908"
+deployment_datetime = 2010-06-06 00:19:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_19_shallow_shift"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100606_0019.RAW.auv",
+    "messages/20100606_0100.RAW.auv",
+    "messages/20100606_0200.RAW.auv",
+]
+system_config = [
+    "messages/20100606_0019.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100606_0019.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100606_0019.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100606_0019.mistakencape_19_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100607/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100607/stereo_pose_est.data",
+    "camera_poses/renav20100607_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100606-001843.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23m7ms0_20120601_070118"
+deployment_datetime = 2012-06-01 07:01:18+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.19
+
+[deployments.files]
+raw_messages = [
+    "messages/20120601_0701.RAW.auv",
+]
+system_config = [
+    "messages/20120601_0701.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120601_0701.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120601_0701.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120601_0701.mistakencape_14_shallow_shift_grid2.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120601-064436.txt",
+    "usbl/log-20120601-081151.txt",
+    "usbl/log-20120601-081159.txt",
+    "usbl/log-20120601-081217.txt",
+    "usbl/log-20120601-081230.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23m7ms0_20140616_044549"
+deployment_datetime = 2014-06-16 04:45:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.23
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_0445.RAW.auv",
+    "messages/20140616_0500.RAW.auv",
+    "messages/20140616_0600.RAW.auv",
+    "messages/20140616_0700.RAW.auv",
+]
+system_config = [
+    "messages/20140616_0445.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_0445.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_0445.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_0446.tas_11_mistakencape_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-043300.txt",
+    "usbl/log-20140616-043708.txt",
+    "usbl/log-20140616-044556.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_010853"
+deployment_datetime = 2009-06-13 01:08:53+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_0108.RAW.auv",
+    "messages/20090613_0200.RAW.auv",
+    "messages/20090613_0300.RAW.auv",
+]
+system_config = [
+    "messages/20090613_0108.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_0108.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_0109.st_helens_09_elephant_rock_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090806/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090806/stereo_pose_est.data",
+    "camera_poses/renav20090806_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-010920.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_104954"
+deployment_datetime = 2009-06-13 10:49:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1049.RAW.auv",
+    "messages/20090613_1100.RAW.auv",
+    "messages/20090613_1200.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1049.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_1050.st_helens_12_elephant_rock_shallow_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-104927.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20110612_045149"
+deployment_datetime = 2011-06-12 04:51:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0451.RAW.auv",
+    "messages/20110612_0500.RAW.auv",
+    "messages/20110612_0600.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0451.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0451.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0451.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0452.st_helens_03_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-044746.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd12_20130611_015335"
+deployment_datetime = 2013-06-11 01:53:35+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0153.RAW.auv",
+    "messages/20130611_0200.RAW.auv",
+    "messages/20130611_0300.RAW.auv",
+    "messages/20130611_0400.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0153.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0153.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0153.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0153.st_helens_15_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130718/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130718/stereo_pose_est.data",
+    "camera_poses/renav20130718_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130611-015325.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
 deployment_datetime = 2009-06-12 22:53:06+00:00
 
@@ -1418,6 +4965,121 @@ camera_poses = [
 usbl_logs = [
     "usbl/log-20090612-224117.txt",
     "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090613_100254"
+deployment_datetime = 2009-06-13 10:02:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1002.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1002.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1002.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20090613_1002.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20090613_1004.st_helens_11_elephant_rock_deep_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-095247.txt",
 ]
 
 [deployments.telemetry]
@@ -1987,6 +5649,730 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjss8n_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjssbh_20131022_004934"
 deployment_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]

--- a/data/deployment_descriptors_v1_all_enriched.toml
+++ b/data/deployment_descriptors_v1_all_enriched.toml
@@ -1,0 +1,11602 @@
+[[deployments]]
+deployment_label = "qd61g27j_20100421_022145"
+deployment_datetime = 2010-04-21 02:21:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_03_25m_s_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.8
+
+[deployments.files]
+raw_messages = [
+    "messages/20100421_0221.RAW.auv",
+    "messages/20100421_0300.RAW.auv",
+    "messages/20100421_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100421_0221.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100421_0221.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100421_0221.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100421_0222.rottnest_03_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100421/scott20090730_merge2.calib",
+    "camera_calibration/renav20100422/scott20090730_merge2.calib",
+    "camera_calibration/renav20100429/scott20090730_merge2.calib",
+    "camera_calibration/renav20100512/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100421/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100421/stereo_pose_est.data",
+    "camera_poses/renav20100421_stereo_pose_est.data",
+    "camera_poses/renav20100512/renav20100512_stereo_pose_est.data",
+    "camera_poses/renav20100512/stereo_pose_est.data",
+    "camera_poses/renav20100512_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100421-014611.txt",
+    "usbl/log-20100421-014942.txt",
+    "usbl/log-20100421-015023.txt",
+    "usbl/log-20100421-021326.txt",
+    "usbl/log-20100421-050404.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.715
+extrinsics.locy = -1.258
+extrinsics.locz = 1.352
+extrinsics.rotx = 0.3316
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qd61g27j_20110410_011202"
+deployment_datetime = 2011-04-10 01:12:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.76
+
+[deployments.files]
+raw_messages = [
+    "messages/20110410_0112.RAW.auv",
+    "messages/20110410_0200.RAW.auv",
+    "messages/20110410_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110410_0112.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110410_0112.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110410_0112.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110410_0121.rottnest_07_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110410/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110410/stereo_pose_est.data",
+    "camera_poses/renav20110410_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110409-232234.txt",
+    "usbl/log-20110409-232255.txt",
+    "usbl/log-20110409-235604.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Cape Ferguson"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -2.69
+extrinsics.locy = -0.221
+extrinsics.locz = 5.555
+extrinsics.rotx = 0.5389
+extrinsics.roty = -0.0016
+extrinsics.rotz = -0.0106
+
+[[deployments]]
+deployment_label = "qd61g27j_20120422_043114"
+deployment_datetime = 2012-04-22 04:31:14+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.71
+
+[deployments.files]
+raw_messages = [
+    "messages/20120422_0431.RAW.auv",
+    "messages/20120422_0500.RAW.auv",
+    "messages/20120422_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120422_0431.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120422_0431.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120422_0431.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120422_0431.rottnest_07_25m_s_out_grid23.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121022/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121022/stereo_pose_est.data",
+    "camera_poses/renav20121022_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120422-040111.txt",
+    "usbl/log-20120422-040259.txt",
+    "usbl/log-20120422-043215.txt",
+    "usbl/log-20120422-061945.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qd61g27j_20130414_013620"
+deployment_datetime = 2013-04-14 01:36:20+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "rottnest_22_25m_s_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.67
+
+[deployments.files]
+raw_messages = [
+    "messages/20130414_0136.RAW.auv",
+    "messages/20130414_0200.RAW.auv",
+    "messages/20130414_0300.RAW.auv",
+]
+system_config = [
+    "messages/20130414_0136.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130414_0136.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130414_0136.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130414_0138.rottnest_22_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130424/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130424/stereo_pose_est.data",
+    "camera_poses/renav20130424_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130414-011338.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qd61g27j_20170523_040815"
+deployment_datetime = 2017-05-23 04:08:15+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS05_rottnest_25m_s_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -32.03434
+origin_longitude = 115.4598
+magnetic_variation = -1.49
+
+[deployments.files]
+raw_messages = [
+    "messages/20170523_0408.RAW.auv",
+    "messages/20170523_0500.RAW.auv",
+    "messages/20170523_0600.RAW.auv",
+]
+system_config = [
+    "messages/20170523_0408.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170523_0408.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170523_0408.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170523_0408.SS05_rottnest_25m_s_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170523/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170524_nousbl/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170523/stereo_pose_est.data",
+    "camera_poses/renav20170523_stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl/stereo_pose_est.data",
+    "camera_poses/renav20170524_nousbl_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170523-040304.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Silver Streak"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = -4.793
+extrinsics.locy = 4.302
+extrinsics.locz = 4.043
+extrinsics.rotx = -0.0067
+extrinsics.roty = 0.0032
+extrinsics.rotz = 0.4713
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20100430_024508"
+deployment_datetime = 2010-04-30 02:45:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_23_40m"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.13
+
+[deployments.files]
+raw_messages = [
+    "messages/20100430_0245.RAW.auv",
+    "messages/20100430_0300.RAW.auv",
+    "messages/20100430_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100430_0245.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100430_0245.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100430_0245.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100430_0248.coralpatches_23_40m.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100511/scott20090730_merge2.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100511/stereo_pose_est.data",
+    "camera_poses/renav20100511_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100430-024242.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.715
+extrinsics.locy = -1.258
+extrinsics.locz = 1.352
+extrinsics.rotx = 0.3316
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20120501_033336"
+deployment_datetime = 2012-05-01 03:33:36+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_39_40m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.04
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0333.RAW.auv",
+    "messages/20120501_0400.RAW.auv",
+    "messages/20120501_0500.RAW.auv",
+    "messages/20120501_0600.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0333.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0333.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0333.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0333.coralpatches_39_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120501-031743.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20130405_103429"
+deployment_datetime = 2013-04-05 10:34:29+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "coralpatches_02_40m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -1.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20130405_1034.RAW.auv",
+    "messages/20130405_1100.RAW.auv",
+    "messages/20130405_1200.RAW.auv",
+]
+system_config = [
+    "messages/20130405_1034.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130405_1034.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130405_1034.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130405_1034.coralpatches_02_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130405-094528.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdc5ghs3_20210315_230947"
+deployment_datetime = 2021-03-15 23:09:47+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS13_coralpatches_40m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.84619
+origin_longitude = 114.04531
+magnetic_variation = -0.66
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_2309.RAW.auv",
+    "messages/20210316_0000.RAW.auv",
+    "messages/20210316_0100.RAW.auv",
+]
+system_config = [
+    "messages/20210315_2309.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_2309.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_2309.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_2311.SS13_coralpatches_40m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1201/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1201/stereo_pose_est.data",
+    "camera_poses/renav20210531_1201_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-230941.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "PoppaG"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -9.4
+extrinsics.locy = -3.72
+extrinsics.locz = 7.49
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.23
+extrinsics.rotz = -0.21
+
+[[deployments]]
+deployment_label = "qdch0ftq_20100428_020202"
+deployment_datetime = 2010-04-28 02:02:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_16_15m_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100428_0202.RAW.auv",
+    "messages/20100428_0300.RAW.auv",
+    "messages/20100428_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100428_0202.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100428_0202.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100428_0202.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100428_0208.geebank_16_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100428/scott20090730_merge2.calib",
+    "camera_calibration/renav20120603/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100428/stereo_pose_est.data",
+    "camera_poses/renav20100428_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100428-011723.txt",
+    "usbl/log-20100428-012839.txt",
+    "usbl/log-20100428-035621.txt",
+    "usbl/log-20100428-040229.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.715
+extrinsics.locy = -1.258
+extrinsics.locz = 1.352
+extrinsics.rotx = 0.3316
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdch0ftq_20110415_020103"
+deployment_datetime = 2011-04-15 02:01:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_24_15m_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.12
+
+[deployments.files]
+raw_messages = [
+    "messages/20110415_0201.RAW.auv",
+    "messages/20110415_0300.RAW.auv",
+    "messages/20110415_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110415_0201.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110415_0201.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110415_0201.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110415_0201.geebank_24_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110415/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20110612/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20111223/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110415/stereo_pose_est.data",
+    "camera_poses/renav20110415_stereo_pose_est.data",
+    "camera_poses/renav20111223/stereo_pose_est.data",
+    "camera_poses/renav20111223_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110414-080014.txt",
+    "usbl/log-20110414-080157.txt",
+    "usbl/log-20110415-014036.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Naturaliste"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.21
+extrinsics.locy = -3.34
+extrinsics.locz = 3.14
+extrinsics.rotx = 0.525
+extrinsics.roty = -0.0007
+extrinsics.rotz = 0.0375
+
+[[deployments]]
+deployment_label = "qdch0ftq_20120430_002423"
+deployment_datetime = 2012-04-30 00:24:23+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_34_15m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.07
+
+[deployments.files]
+raw_messages = [
+    "messages/20120430_0024.RAW.auv",
+    "messages/20120430_0100.RAW.auv",
+    "messages/20120430_0200.RAW.auv",
+    "messages/20120430_0300.RAW.auv",
+]
+system_config = [
+    "messages/20120430_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120430_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120430_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120430_0026.geebank_34_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120429-233948.txt",
+    "usbl/log-20120429-234022.txt",
+    "usbl/log-20120430-002623.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qdch0ftq_20130406_023610"
+deployment_datetime = 2013-04-06 02:36:10+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_03_15m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.03
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0236.RAW.auv",
+    "messages/20130406_0300.RAW.auv",
+    "messages/20130406_0400.RAW.auv",
+    "messages/20130406_0500.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0236.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0236.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0236.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0236.geebank_03_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-010454.txt",
+    "usbl/log-20130406-011204.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdch0ftq_20140327_071251"
+deployment_datetime = 2014-03-27 07:12:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_02_15m_out"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.99
+
+[deployments.files]
+raw_messages = [
+    "messages/20140327_0712.RAW.auv",
+    "messages/20140327_0800.RAW.auv",
+    "messages/20140327_0900.RAW.auv",
+    "messages/20140327_1000.RAW.auv",
+]
+system_config = [
+    "messages/20140327_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140327_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140327_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140327_0716.geebank_02_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090102/UsydPool10022013.calib",
+    "camera_calibration/renav20140408/UsydPool10022013.calib",
+    "camera_calibration/renav20140512/UsydPool10022013.calib",
+    "camera_calibration/renav20140908/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090102/stereo_pose_est.data",
+    "camera_poses/renav20090102_stereo_pose_est.data",
+    "camera_poses/renav20140408/stereo_pose_est.data",
+    "camera_poses/renav20140408_stereo_pose_est.data",
+    "camera_poses/renav20140908/stereo_pose_est.data",
+    "camera_poses/renav20140908_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140327-064901.txt",
+    "usbl/log-20140327-065227.txt",
+    "usbl/log-20140327-065435.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.26
+extrinsics.locy = 0.704
+extrinsics.locz = 2.195
+extrinsics.rotx = 0.0254
+extrinsics.roty = -0.0126
+extrinsics.rotz = -0.0685
+
+[[deployments]]
+deployment_label = "qdch0ftq_20170526_025746"
+deployment_datetime = 2017-05-26 02:57:46+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_geebank_15m_out"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.85
+
+[deployments.files]
+raw_messages = [
+    "messages/20170526_0257.RAW.auv",
+    "messages/20170526_0300.RAW.auv",
+    "messages/20170526_0400.RAW.auv",
+    "messages/20170526_0500.RAW.auv",
+]
+system_config = [
+    "messages/20170526_0257.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170526_0257.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170526_0257.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170526_0300.SS12_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+    "camera_calibration/renav20170619/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+    "camera_poses/renav20170619/stereo_pose_est.data",
+    "camera_poses/renav20170619_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170526-025619.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Silver Streak"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = -4.793
+extrinsics.locy = 4.302
+extrinsics.locz = 4.043
+extrinsics.rotx = -0.0067
+extrinsics.roty = 0.0032
+extrinsics.rotz = 0.4713
+
+[[deployments]]
+deployment_label = "qdch0ftq_20210315_034028"
+deployment_datetime = 2021-03-15 03:40:28+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS10_geebank_15m_out"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -0.68
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0340.RAW.auv",
+    "messages/20210315_0400.RAW.auv",
+    "messages/20210315_0500.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0340.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0340.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0340.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0340.SS10_geebank_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1308/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1352/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210528_1352/stereo_pose_est.data",
+    "camera_poses/renav20210528_1352_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-033618.txt",
+    "usbl/log-20210315-034039.txt",
+    "usbl/log-20210315-054900.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "PoppaG"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -9.4
+extrinsics.locy = -3.72
+extrinsics.locz = 7.49
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.23
+extrinsics.rotz = -0.21
+
+[[deployments]]
+deployment_label = "qdchdmy1_20110416_005411"
+deployment_datetime = 2011-04-16 00:54:11+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_27"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.05
+
+[deployments.files]
+raw_messages = [
+    "messages/20110416_0054.RAW.auv",
+    "messages/20110416_0100.RAW.auv",
+    "messages/20110416_0200.RAW.auv",
+    "messages/20110416_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110416_0054.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110416_0054.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110416_0054.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110416_0054.snapperbank_27.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110416/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110416/stereo_pose_est.data",
+    "camera_poses/renav20110416_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110416-002340.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Naturaliste"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.21
+extrinsics.locy = -3.34
+extrinsics.locz = 3.14
+extrinsics.rotx = 0.525
+extrinsics.roty = -0.0007
+extrinsics.rotz = 0.0375
+
+[[deployments]]
+deployment_label = "qdchdmy1_20120501_071203"
+deployment_datetime = 2012-05-01 07:12:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_37"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.01
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0712.RAW.auv",
+    "messages/20120501_0800.RAW.auv",
+    "messages/20120501_0900.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0713.snapperbank_37.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = []
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qdchdmy1_20130406_081713"
+deployment_datetime = 2013-04-06 08:17:13+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.97
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0817.RAW.auv",
+    "messages/20130406_0900.RAW.auv",
+    "messages/20130406_1000.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0817.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0817.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0817.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0817.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-073750.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdchdmy1_20140328_063358"
+deployment_datetime = 2014-03-28 06:33:58+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201403"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.92
+
+[deployments.files]
+raw_messages = [
+    "messages/20140328_0633.RAW.auv",
+    "messages/20140328_0700.RAW.auv",
+    "messages/20140328_0800.RAW.auv",
+    "messages/20140328_0900.RAW.auv",
+]
+system_config = [
+    "messages/20140328_0633.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140328_0633.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140328_0633.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140328_0636.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140329/UsydPool10022013.calib",
+    "camera_calibration/renav20140820/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140329/stereo_pose_est.data",
+    "camera_poses/renav20140329_stereo_pose_est.data",
+    "camera_poses/renav20140820/stereo_pose_est.data",
+    "camera_poses/renav20140820_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140328-043904.txt",
+    "usbl/log-20140328-055231.txt",
+    "usbl/log-20140328-063407.txt",
+    "usbl/log-20140328-063710.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.26
+extrinsics.locy = 0.704
+extrinsics.locz = 2.195
+extrinsics.rotx = 0.0254
+extrinsics.roty = -0.0126
+extrinsics.rotz = -0.0685
+
+[[deployments]]
+deployment_label = "qdchdmy1_20170525_234624"
+deployment_datetime = 2017-05-25 23:46:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS11_snapperbank"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.79
+
+[deployments.files]
+raw_messages = [
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170526_0100.RAW.auv",
+    "messages/20170526_0200.RAW.auv",
+]
+system_config = [
+    "messages/20170525_2346.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170525_2346.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170525_2346.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Silver Streak"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = -4.793
+extrinsics.locy = 4.302
+extrinsics.locz = 4.043
+extrinsics.rotx = -0.0067
+extrinsics.roty = 0.0032
+extrinsics.rotz = 0.4713
+
+[[deployments]]
+deployment_label = "qdchdmy1_20210315_081519"
+deployment_datetime = 2021-03-15 08:15:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS12_snapperbank"
+acfr_campaign_label = "WA202103"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20210315_0815.RAW.auv",
+    "messages/20210315_0900.RAW.auv",
+    "messages/20210315_1000.RAW.auv",
+]
+system_config = [
+    "messages/20210315_0815.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20210315_0815.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20210315_0815.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20210315_0815.SS12_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20210527_1118/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210527_2017/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1033/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210528_1631/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0857/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0858/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_0959/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1002/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1005/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1102/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210531_1132/20210222_scam_usyd_pool_checker.calib",
+    "camera_calibration/renav20210608_1003/20210222_scam_usyd_pool_checker.calib",
+]
+camera_poses = [
+    "camera_poses/renav20210531_1005/stereo_pose_est.data",
+    "camera_poses/renav20210531_1005_stereo_pose_est.data",
+    "camera_poses/renav20210531_1102/stereo_pose_est.data",
+    "camera_poses/renav20210531_1102_stereo_pose_est.data",
+    "camera_poses/renav20210531_1132/stereo_pose_est.data",
+    "camera_poses/renav20210531_1132_stereo_pose_est.data",
+    "camera_poses/renav20210608_1003/stereo_pose_est.data",
+    "camera_poses/renav20210608_1003_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20210315-081508.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "AANDERAA_4319",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_SECTOR",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPSD"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "PoppaG"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -9.4
+extrinsics.locy = -3.72
+extrinsics.locz = 7.49
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.23
+extrinsics.rotz = -0.21
+
+[[deployments]]
+deployment_label = "qtqxshxs_20110815_102540"
+deployment_datetime = 2011-08-15 10:25:40+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "19_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201108"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20110815_1025.RAW.auv",
+    "messages/20110815_1100.RAW.auv",
+    "messages/20110815_1200.RAW.auv",
+    "messages/20110815_1300.RAW.auv",
+    "messages/20110815_1400.RAW.auv",
+]
+system_config = [
+    "messages/20110815_1025.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110815_1025.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110815_1025.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110815_1026.19_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110816/scottreef20110810_sirius_random_235.calib",
+    "camera_calibration/renav20130625/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110816/stereo_pose_est.data",
+    "camera_poses/renav20110816_stereo_pose_est.data",
+    "camera_poses/renav20130625/stereo_pose_est.data",
+    "camera_poses/renav20130625_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110815-095558.txt",
+    "usbl/log-20110815-095817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Solander"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -19.057
+extrinsics.locy = 3.18
+extrinsics.locz = 4.88
+extrinsics.rotx = -0.5117
+extrinsics.roty = 0.041
+extrinsics.rotz = -0.0609
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150327_015552"
+deployment_datetime = 2015-03-27 01:55:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "02_scott_grids_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150327_0155.RAW.auv",
+    "messages/20150327_0200.RAW.auv",
+    "messages/20150327_0300.RAW.auv",
+    "messages/20150327_0400.RAW.auv",
+    "messages/20150327_0500.RAW.auv",
+    "messages/20150327_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150327_0155.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150327_0155.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150327_0155.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150327_0157.02_scott_grids_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150328/sirius20140915glaros25.calib",
+    "camera_calibration/renav20150818/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160114/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150328/stereo_pose_est.data",
+    "camera_poses/renav20150328_stereo_pose_est.data",
+    "camera_poses/renav20150818/stereo_pose_est.data",
+    "camera_poses/renav20150818_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160114/stereo_pose_est.data",
+    "camera_poses/renav20160114_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150326-235652.txt",
+    "usbl/log-20150327-015211.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -11.062
+extrinsics.locy = -6.656
+extrinsics.locz = 9.998
+extrinsics.rotx = 0.0159
+extrinsics.roty = 0.0195
+extrinsics.rotz = -0.0464
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_000850"
+deployment_datetime = 2015-03-28 00:08:50+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0008.RAW.auv",
+    "messages/20150328_0100.RAW.auv",
+    "messages/20150328_0200.RAW.auv",
+    "messages/20150328_0300.RAW.auv",
+    "messages/20150328_0400.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0008.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0008.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0008.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0008.03_scott_grids_deep_auv4_shifted.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150327-233549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -11.062
+extrinsics.locy = -6.656
+extrinsics.locz = 9.998
+extrinsics.rotx = 0.0159
+extrinsics.roty = 0.0195
+extrinsics.rotz = -0.0464
+
+[[deployments]]
+deployment_label = "qtqxshxs_20150328_042551"
+deployment_datetime = 2015-03-28 04:25:51+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
+acfr_campaign_label = "ScottReef201503"
+acfr_platform_label = ""
+origin_latitude = -14.082605
+origin_longitude = 121.78713
+magnetic_variation = 2.32
+
+[deployments.files]
+raw_messages = [
+    "messages/20150328_0425.RAW.auv",
+    "messages/20150328_0500.RAW.auv",
+    "messages/20150328_0600.RAW.auv",
+]
+system_config = [
+    "messages/20150328_0425.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20150328_0425.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20150328_0425.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20150328_0429.04_scott_dense_grid_deep_auv4.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20150329/sirius20140915glaros25.calib",
+    "camera_calibration/renav20151111/sirius20140915glaros25.calib",
+    "camera_calibration/renav20160205/sirius20140915glaros25.calib",
+]
+camera_poses = [
+    "camera_poses/renav20150329/stereo_pose_est.data",
+    "camera_poses/renav20150329_stereo_pose_est.data",
+    "camera_poses/renav20151111/stereo_pose_est.data",
+    "camera_poses/renav20151111_stereo_pose_est.data",
+    "camera_poses/renav20160205/stereo_pose_est.data",
+    "camera_poses/renav20160205_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20150328-040745.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_RMC",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "USBL transceiver of unrecorded make"
+identity.vendor = ""
+identity.product = ""
+identity.type = "usbl"
+extrinsics.locx = -11.062
+extrinsics.locy = -6.656
+extrinsics.locz = 9.998
+extrinsics.rotx = 0.0159
+extrinsics.roty = 0.0195
+extrinsics.rotz = -0.0464
+
+[[deployments]]
+deployment_label = "r234xgje_20100604_230524"
+deployment_datetime = 2010-06-04 23:05:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_14_shallow"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100604_2305.RAW.auv",
+    "messages/20100605_0000.RAW.auv",
+]
+system_config = [
+    "messages/20100604_2305.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100604_2305.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100604_2305.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100604_2307.lanterns_14_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+    "camera_calibration/renav20100605_tst/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+    "camera_poses/renav20100605_tst/stereo_pose_est.data",
+    "camera_poses/renav20100605_tst_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100604-222132.txt",
+    "usbl/log-20100604-224606.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.21
+extrinsics.locy = 2.97
+extrinsics.locz = 2.27
+extrinsics.rotx = -0.5058
+extrinsics.roty = -0.0042
+extrinsics.rotz = 0.3138
+
+[[deployments]]
+deployment_label = "r234xgje_20120530_064545"
+deployment_datetime = 2012-05-30 06:45:45+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_08_shallow"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_0645.RAW.auv",
+    "messages/20120530_0700.RAW.auv",
+    "messages/20120530_0800.RAW.auv",
+]
+system_config = [
+    "messages/20120530_0645.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_0645.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_0645.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_0652.lanterns_08_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-034737.txt",
+    "usbl/log-20120530-060136.txt",
+    "usbl/log-20120530-062919.txt",
+    "usbl/log-20120530-072530.txt",
+    "usbl/log-20120530-084649.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 3.497
+extrinsics.locy = 3.23
+extrinsics.locz = 3.679
+extrinsics.rotx = -0.4283
+extrinsics.roty = -0.0429
+extrinsics.rotz = 0.1861
+
+[[deployments]]
+deployment_label = "r234xgje_20140616_205232"
+deployment_datetime = 2014-06-16 20:52:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_12_lanterns_shallow"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2052.RAW.auv",
+    "messages/20140616_2100.RAW.auv",
+    "messages/20140616_2200.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2052.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2052.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2052.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2054.tas_12_lanterns_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-201549.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -11.916
+extrinsics.locy = 4.761
+extrinsics.locz = 10.752
+extrinsics.rotx = -0.5026
+extrinsics.roty = -0.0103
+extrinsics.rotz = -0.0327
+
+[[deployments]]
+deployment_label = "r23685bc_20100605_021022"
+deployment_datetime = 2010-06-05 02:10:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_15_deep"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100605_0210.RAW.auv",
+    "messages/20100605_0300.RAW.auv",
+    "messages/20100605_0400.RAW.auv",
+    "messages/20100605_0500.RAW.auv",
+]
+system_config = [
+    "messages/20100605_0210.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100605_0210.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100605_0210.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100605_0211.lanterns_15_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100605-005939.txt",
+    "usbl/log-20100605-014520.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.21
+extrinsics.locy = 2.97
+extrinsics.locz = 2.27
+extrinsics.rotx = -0.5058
+extrinsics.roty = -0.0042
+extrinsics.rotz = 0.3138
+
+[[deployments]]
+deployment_label = "r23685bc_20120530_233021"
+deployment_datetime = 2012-05-30 23:30:21+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_10_deep"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_2330.RAW.auv",
+    "messages/20120531_0000.RAW.auv",
+    "messages/20120531_0100.RAW.auv",
+    "messages/20120531_0200.RAW.auv",
+]
+system_config = [
+    "messages/20120530_2330.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_2330.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_2330.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_2332.lanterns_10_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-231147.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 3.497
+extrinsics.locy = 3.23
+extrinsics.locz = 3.679
+extrinsics.rotx = -0.4283
+extrinsics.roty = -0.0429
+extrinsics.rotz = 0.1861
+
+[[deployments]]
+deployment_label = "r23685bc_20140616_225022"
+deployment_datetime = 2014-06-16 22:50:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_13_lanterns_deep"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2250.RAW.auv",
+    "messages/20140616_2300.RAW.auv",
+    "messages/20140617_0000.RAW.auv",
+    "messages/20140617_0100.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2250.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2250.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2250.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2250.tas_13_lanterns_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140618/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140618/stereo_pose_est.data",
+    "camera_poses/renav20140618_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-225027.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -11.916
+extrinsics.locy = 4.761
+extrinsics.locz = 10.752
+extrinsics.rotx = -0.5026
+extrinsics.roty = -0.0103
+extrinsics.rotz = -0.0327
+
+[[deployments]]
+deployment_label = "r23m7ms0_20100606_001908"
+deployment_datetime = 2010-06-06 00:19:08+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_19_shallow_shift"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100606_0019.RAW.auv",
+    "messages/20100606_0100.RAW.auv",
+    "messages/20100606_0200.RAW.auv",
+]
+system_config = [
+    "messages/20100606_0019.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100606_0019.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100606_0019.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100606_0019.mistakencape_19_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100607/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100607/stereo_pose_est.data",
+    "camera_poses/renav20100607_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100606-001843.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.21
+extrinsics.locy = 2.97
+extrinsics.locz = 2.27
+extrinsics.rotx = -0.5058
+extrinsics.roty = -0.0042
+extrinsics.rotz = 0.3138
+
+[[deployments]]
+deployment_label = "r23m7ms0_20120601_070118"
+deployment_datetime = 2012-06-01 07:01:18+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.19
+
+[deployments.files]
+raw_messages = [
+    "messages/20120601_0701.RAW.auv",
+]
+system_config = [
+    "messages/20120601_0701.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120601_0701.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120601_0701.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120601_0701.mistakencape_14_shallow_shift_grid2.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120601-064436.txt",
+    "usbl/log-20120601-081151.txt",
+    "usbl/log-20120601-081159.txt",
+    "usbl/log-20120601-081217.txt",
+    "usbl/log-20120601-081230.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 3.497
+extrinsics.locy = 3.23
+extrinsics.locz = 3.679
+extrinsics.rotx = -0.4283
+extrinsics.roty = -0.0429
+extrinsics.rotz = 0.1861
+
+[[deployments]]
+deployment_label = "r23m7ms0_20140616_044549"
+deployment_datetime = 2014-06-16 04:45:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -42.639
+origin_longitude = 148.1522
+magnetic_variation = 15.23
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_0445.RAW.auv",
+    "messages/20140616_0500.RAW.auv",
+    "messages/20140616_0600.RAW.auv",
+    "messages/20140616_0700.RAW.auv",
+]
+system_config = [
+    "messages/20140616_0445.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_0445.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_0445.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_0446.tas_11_mistakencape_shallow_shift.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140617/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140617/stereo_pose_est.data",
+    "camera_poses/renav20140617_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-043300.txt",
+    "usbl/log-20140616-043708.txt",
+    "usbl/log-20140616-044556.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -11.916
+extrinsics.locy = 4.761
+extrinsics.locz = 10.752
+extrinsics.rotx = -0.5026
+extrinsics.roty = -0.0103
+extrinsics.rotz = -0.0327
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_010853"
+deployment_datetime = 2009-06-13 01:08:53+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_0108.RAW.auv",
+    "messages/20090613_0200.RAW.auv",
+    "messages/20090613_0300.RAW.auv",
+]
+system_config = [
+    "messages/20090613_0108.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_0108.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_0109.st_helens_09_elephant_rock_shallow.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090806/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090806/stereo_pose_est.data",
+    "camera_poses/renav20090806_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-010920.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.55
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 0.53
+extrinsics.locy = 4.33
+extrinsics.locz = 3.29
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "r29mrd12_20090613_104954"
+deployment_datetime = 2009-06-13 10:49:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1049.RAW.auv",
+    "messages/20090613_1100.RAW.auv",
+    "messages/20090613_1200.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1049.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090613_1050.st_helens_12_elephant_rock_shallow_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-104927.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.55
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 0.53
+extrinsics.locy = 4.33
+extrinsics.locz = 3.29
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "r29mrd12_20110612_045149"
+deployment_datetime = 2011-06-12 04:51:49+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0451.RAW.auv",
+    "messages/20110612_0500.RAW.auv",
+    "messages/20110612_0600.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0451.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0451.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0451.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0452.st_helens_03_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-044746.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.404
+extrinsics.locy = 4.412
+extrinsics.locz = 4.534
+extrinsics.rotx = -0.5409
+extrinsics.roty = -0.0605
+extrinsics.rotz = -0.24
+
+[[deployments]]
+deployment_label = "r29mrd12_20130611_015335"
+deployment_datetime = 2013-06-11 01:53:35+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.253708
+origin_longitude = 148.338934
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0153.RAW.auv",
+    "messages/20130611_0200.RAW.auv",
+    "messages/20130611_0300.RAW.auv",
+    "messages/20130611_0400.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0153.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0153.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0153.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0153.st_helens_15_elephant_rock_shallow_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130718/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130718/stereo_pose_est.data",
+    "camera_poses/renav20130718_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130611-015325.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 7.615
+extrinsics.locy = 6.329
+extrinsics.locz = 4.529
+extrinsics.rotx = -0.4283
+extrinsics.roty = 0.0176
+extrinsics.rotz = -0.2815
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090612_225306"
+deployment_datetime = 2009-06-12 22:53:06+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_07_elephant_rock_deep"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090612_2253.RAW.auv",
+    "messages/20090612_2300.RAW.auv",
+    "messages/20090613_0000.RAW.auv",
+]
+system_config = [
+    "messages/20090612_2253.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090612_2253.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090612_2254.st_helens_07_elephant_rock_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+    "camera_calibration/renav20120228/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090612-224117.txt",
+    "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.55
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 0.53
+extrinsics.locy = 4.33
+extrinsics.locz = 3.29
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090613_100254"
+deployment_datetime = 2009-06-13 10:02:54+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 15.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20090613_1002.RAW.auv",
+]
+system_config = [
+    "messages/20090613_1002.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090613_1002.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20090613_1002.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20090613_1004.st_helens_11_elephant_rock_deep_night.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090613-095247.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.55
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 0.53
+extrinsics.locy = 4.33
+extrinsics.locz = 3.29
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "r29mrd5h_20110612_033752"
+deployment_datetime = 2011-06-12 03:37:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0337.RAW.auv",
+    "messages/20110612_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0337.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0337.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0337.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0338.st_helens_01_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-032957.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.404
+extrinsics.locy = 4.412
+extrinsics.locz = 4.534
+extrinsics.rotx = -0.5409
+extrinsics.roty = -0.0605
+extrinsics.rotz = -0.24
+
+[[deployments]]
+deployment_label = "r29mrd5h_20130611_002419"
+deployment_datetime = 2013-06-11 00:24:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0024.RAW.auv",
+    "messages/20130611_0100.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0026.st_helens_13_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130612/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130612/stereo_pose_est.data",
+    "camera_poses/renav20130612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130610-233945.txt",
+    "usbl/log-20130610-234950.txt",
+    "usbl/log-20130610-235109.txt",
+    "usbl/log-20130611-000201.txt",
+    "usbl/log-20130611-001308.txt",
+    "usbl/log-20130611-002331.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 7.615
+extrinsics.locy = 6.329
+extrinsics.locz = 4.529
+extrinsics.rotx = -0.4283
+extrinsics.roty = 0.0176
+extrinsics.rotz = -0.2815
+
+[[deployments]]
+deployment_label = "r7jjskxq_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -4.46
+extrinsics.locy = -4.826
+extrinsics.locz = 2.48
+extrinsics.rotx = 0.5084
+extrinsics.roty = -0.0622
+extrinsics.rotz = -0.0509
+
+[[deployments]]
+deployment_label = "r7jjskxq_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.723
+extrinsics.locy = -5.235
+extrinsics.locz = 1.769
+extrinsics.rotx = 0.5553
+extrinsics.roty = -0.0036
+extrinsics.rotz = -0.0511
+
+[[deployments]]
+deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.541
+extrinsics.locy = -5.364
+extrinsics.locz = 3.224
+extrinsics.rotx = 0.5678
+extrinsics.roty = 0.0022
+extrinsics.rotz = 0.2499
+
+[[deployments]]
+deployment_label = "r7jjss8n_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -4.46
+extrinsics.locy = -4.826
+extrinsics.locz = 2.48
+extrinsics.rotx = 0.5084
+extrinsics.roty = -0.0622
+extrinsics.rotz = -0.0509
+
+[[deployments]]
+deployment_label = "r7jjss8n_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.723
+extrinsics.locy = -5.235
+extrinsics.locz = 1.769
+extrinsics.rotx = 0.5553
+extrinsics.roty = -0.0036
+extrinsics.rotz = -0.0511
+
+[[deployments]]
+deployment_label = "r7jjss8n_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.541
+extrinsics.locy = -5.364
+extrinsics.locz = 3.224
+extrinsics.rotx = 0.5678
+extrinsics.roty = 0.0022
+extrinsics.rotz = 0.2499
+
+[[deployments]]
+deployment_label = "r7jjssbh_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -4.46
+extrinsics.locy = -4.826
+extrinsics.locz = 2.48
+extrinsics.rotx = 0.5084
+extrinsics.roty = -0.0622
+extrinsics.rotz = -0.0509
+
+[[deployments]]
+deployment_label = "r7jjssbh_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.723
+extrinsics.locy = -5.235
+extrinsics.locz = 1.769
+extrinsics.rotx = 0.5553
+extrinsics.roty = -0.0036
+extrinsics.rotz = -0.0511
+
+[[deployments]]
+deployment_label = "r7jjssbh_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.541
+extrinsics.locy = -5.364
+extrinsics.locz = 3.224
+extrinsics.rotx = 0.5678
+extrinsics.roty = 0.0022
+extrinsics.rotz = 0.2499

--- a/data/deployment_descriptors_v1_subset.toml
+++ b/data/deployment_descriptors_v1_subset.toml
@@ -1,0 +1,2106 @@
+[[deployments]]
+deployment_label = "qdch0ftq_20100428_020202"
+deployment_datetime = 2010-04-28 02:02:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_16_15m_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100428_0202.RAW.auv",
+    "messages/20100428_0300.RAW.auv",
+    "messages/20100428_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100428_0202.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100428_0202.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100428_0202.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100428_0208.geebank_16_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100428/scott20090730_merge2.calib",
+    "camera_calibration/renav20120603/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100428/stereo_pose_est.data",
+    "camera_poses/renav20100428_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100428-011723.txt",
+    "usbl/log-20100428-012839.txt",
+    "usbl/log-20100428-035621.txt",
+    "usbl/log-20100428-040229.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20110415_020103"
+deployment_datetime = 2011-04-15 02:01:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_24_15m_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.12
+
+[deployments.files]
+raw_messages = [
+    "messages/20110415_0201.RAW.auv",
+    "messages/20110415_0300.RAW.auv",
+    "messages/20110415_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110415_0201.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110415_0201.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110415_0201.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110415_0201.geebank_24_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110415/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20110612/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20111223/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110415/stereo_pose_est.data",
+    "camera_poses/renav20110415_stereo_pose_est.data",
+    "camera_poses/renav20111223/stereo_pose_est.data",
+    "camera_poses/renav20111223_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110414-080014.txt",
+    "usbl/log-20110414-080157.txt",
+    "usbl/log-20110415-014036.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20120430_002423"
+deployment_datetime = 2012-04-30 00:24:23+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_34_15m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.07
+
+[deployments.files]
+raw_messages = [
+    "messages/20120430_0024.RAW.auv",
+    "messages/20120430_0100.RAW.auv",
+    "messages/20120430_0200.RAW.auv",
+    "messages/20120430_0300.RAW.auv",
+]
+system_config = [
+    "messages/20120430_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120430_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120430_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120430_0026.geebank_34_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120429-233948.txt",
+    "usbl/log-20120429-234022.txt",
+    "usbl/log-20120430-002623.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdch0ftq_20130406_023610"
+deployment_datetime = 2013-04-06 02:36:10+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_03_15m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.03
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0236.RAW.auv",
+    "messages/20130406_0300.RAW.auv",
+    "messages/20130406_0400.RAW.auv",
+    "messages/20130406_0500.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0236.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0236.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0236.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0236.geebank_03_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-010454.txt",
+    "usbl/log-20130406-011204.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20110416_005411"
+deployment_datetime = 2011-04-16 00:54:11+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_27"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.05
+
+[deployments.files]
+raw_messages = [
+    "messages/20110416_0054.RAW.auv",
+    "messages/20110416_0100.RAW.auv",
+    "messages/20110416_0200.RAW.auv",
+    "messages/20110416_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110416_0054.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110416_0054.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110416_0054.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110416_0054.snapperbank_27.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110416/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110416/stereo_pose_est.data",
+    "camera_poses/renav20110416_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110416-002340.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20120501_071203"
+deployment_datetime = 2012-05-01 07:12:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_37"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.01
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0712.RAW.auv",
+    "messages/20120501_0800.RAW.auv",
+    "messages/20120501_0900.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0713.snapperbank_37.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = []
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20130406_081713"
+deployment_datetime = 2013-04-06 08:17:13+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.97
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0817.RAW.auv",
+    "messages/20130406_0900.RAW.auv",
+    "messages/20130406_1000.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0817.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0817.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0817.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0817.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-073750.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "qdchdmy1_20170525_234624"
+deployment_datetime = 2017-05-25 23:46:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS11_snapperbank"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.79
+
+[deployments.files]
+raw_messages = [
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170526_0100.RAW.auv",
+    "messages/20170526_0200.RAW.auv",
+]
+system_config = [
+    "messages/20170525_2346.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170525_2346.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170525_2346.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23685bc_20100605_021022"
+deployment_datetime = 2010-06-05 02:10:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_15_deep"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100605_0210.RAW.auv",
+    "messages/20100605_0300.RAW.auv",
+    "messages/20100605_0400.RAW.auv",
+    "messages/20100605_0500.RAW.auv",
+]
+system_config = [
+    "messages/20100605_0210.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100605_0210.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100605_0210.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100605_0211.lanterns_15_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100605-005939.txt",
+    "usbl/log-20100605-014520.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23685bc_20120530_233021"
+deployment_datetime = 2012-05-30 23:30:21+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_10_deep"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_2330.RAW.auv",
+    "messages/20120531_0000.RAW.auv",
+    "messages/20120531_0100.RAW.auv",
+    "messages/20120531_0200.RAW.auv",
+]
+system_config = [
+    "messages/20120530_2330.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_2330.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_2330.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_2332.lanterns_10_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-231147.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r23685bc_20140616_225022"
+deployment_datetime = 2014-06-16 22:50:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_13_lanterns_deep"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2250.RAW.auv",
+    "messages/20140616_2300.RAW.auv",
+    "messages/20140617_0000.RAW.auv",
+    "messages/20140617_0100.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2250.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2250.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2250.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2250.tas_13_lanterns_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140618/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140618/stereo_pose_est.data",
+    "camera_poses/renav20140618_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-225027.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090612_225306"
+deployment_datetime = 2009-06-12 22:53:06+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_07_elephant_rock_deep"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090612_2253.RAW.auv",
+    "messages/20090612_2300.RAW.auv",
+    "messages/20090613_0000.RAW.auv",
+]
+system_config = [
+    "messages/20090612_2253.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090612_2253.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090612_2254.st_helens_07_elephant_rock_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+    "camera_calibration/renav20120228/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090612-224117.txt",
+    "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd5h_20110612_033752"
+deployment_datetime = 2011-06-12 03:37:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0337.RAW.auv",
+    "messages/20110612_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0337.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0337.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0337.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0338.st_helens_01_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-032957.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r29mrd5h_20130611_002419"
+deployment_datetime = 2013-06-11 00:24:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0024.RAW.auv",
+    "messages/20130611_0100.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0026.st_helens_13_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130612/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130612/stereo_pose_est.data",
+    "camera_poses/renav20130612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130610-233945.txt",
+    "usbl/log-20130610-234950.txt",
+    "usbl/log-20130610-235109.txt",
+    "usbl/log-20130611-000201.txt",
+    "usbl/log-20130611-001308.txt",
+    "usbl/log-20130611-002331.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjskxq_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjskxq_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []
+
+[[deployments]]
+deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+sensors = []

--- a/data/deployment_descriptors_v1_subset_enriched.toml
+++ b/data/deployment_descriptors_v1_subset_enriched.toml
@@ -1,0 +1,3788 @@
+[[deployments]]
+deployment_label = "qdch0ftq_20100428_020202"
+deployment_datetime = 2010-04-28 02:02:02+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_16_15m_out"
+acfr_campaign_label = "WA201004"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20100428_0202.RAW.auv",
+    "messages/20100428_0300.RAW.auv",
+    "messages/20100428_0400.RAW.auv",
+]
+system_config = [
+    "messages/20100428_0202.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100428_0202.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100428_0202.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100428_0208.geebank_16_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100428/scott20090730_merge2.calib",
+    "camera_calibration/renav20120603/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100428/stereo_pose_est.data",
+    "camera_poses/renav20100428_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100428-011723.txt",
+    "usbl/log-20100428-012839.txt",
+    "usbl/log-20100428-035621.txt",
+    "usbl/log-20100428-040229.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.715
+extrinsics.locy = -1.258
+extrinsics.locz = 1.352
+extrinsics.rotx = 0.3316
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdch0ftq_20110415_020103"
+deployment_datetime = 2011-04-15 02:01:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_24_15m_out"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.12
+
+[deployments.files]
+raw_messages = [
+    "messages/20110415_0201.RAW.auv",
+    "messages/20110415_0300.RAW.auv",
+    "messages/20110415_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110415_0201.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110415_0201.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110415_0201.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110415_0201.geebank_24_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110415/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20110612/usyd20110401opencv100big.calib",
+    "camera_calibration/renav20111223/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110415/stereo_pose_est.data",
+    "camera_poses/renav20110415_stereo_pose_est.data",
+    "camera_poses/renav20111223/stereo_pose_est.data",
+    "camera_poses/renav20111223_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110414-080014.txt",
+    "usbl/log-20110414-080157.txt",
+    "usbl/log-20110415-014036.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Naturaliste"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.21
+extrinsics.locy = -3.34
+extrinsics.locz = 3.14
+extrinsics.rotx = 0.525
+extrinsics.roty = -0.0007
+extrinsics.rotz = 0.0375
+
+[[deployments]]
+deployment_label = "qdch0ftq_20120430_002423"
+deployment_datetime = 2012-04-30 00:24:23+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_34_15m_out"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.07
+
+[deployments.files]
+raw_messages = [
+    "messages/20120430_0024.RAW.auv",
+    "messages/20120430_0100.RAW.auv",
+    "messages/20120430_0200.RAW.auv",
+    "messages/20120430_0300.RAW.auv",
+]
+system_config = [
+    "messages/20120430_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120430_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120430_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120430_0026.geebank_34_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120429-233948.txt",
+    "usbl/log-20120429-234022.txt",
+    "usbl/log-20120430-002623.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qdch0ftq_20130406_023610"
+deployment_datetime = 2013-04-06 02:36:10+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "geebank_03_15m_out"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.81372
+origin_longitude = 113.94725
+magnetic_variation = -1.03
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0236.RAW.auv",
+    "messages/20130406_0300.RAW.auv",
+    "messages/20130406_0400.RAW.auv",
+    "messages/20130406_0500.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0236.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0236.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0236.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0236.geebank_03_15m_out.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-010454.txt",
+    "usbl/log-20130406-011204.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdchdmy1_20110416_005411"
+deployment_datetime = 2011-04-16 00:54:11+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_27"
+acfr_campaign_label = "WA201104"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.05
+
+[deployments.files]
+raw_messages = [
+    "messages/20110416_0054.RAW.auv",
+    "messages/20110416_0100.RAW.auv",
+    "messages/20110416_0200.RAW.auv",
+    "messages/20110416_0300.RAW.auv",
+]
+system_config = [
+    "messages/20110416_0054.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110416_0054.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110416_0054.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110416_0054.snapperbank_27.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110416/usyd20110401opencv100big.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110416/stereo_pose_est.data",
+    "camera_poses/renav20110416_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110416-002340.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Naturaliste"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.21
+extrinsics.locy = -3.34
+extrinsics.locz = 3.14
+extrinsics.rotx = 0.525
+extrinsics.roty = -0.0007
+extrinsics.rotz = 0.0375
+
+[[deployments]]
+deployment_label = "qdchdmy1_20120501_071203"
+deployment_datetime = 2012-05-01 07:12:03+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_37"
+acfr_campaign_label = "WA201204"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -1.01
+
+[deployments.files]
+raw_messages = [
+    "messages/20120501_0712.RAW.auv",
+    "messages/20120501_0800.RAW.auv",
+    "messages/20120501_0900.RAW.auv",
+]
+system_config = [
+    "messages/20120501_0712.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120501_0712.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120501_0712.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120501_0713.snapperbank_37.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = []
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -6.156
+extrinsics.locy = -1.477
+extrinsics.locz = 1.567
+extrinsics.rotx = 0.3529
+extrinsics.roty = 0.001
+extrinsics.rotz = 0.2548
+
+[[deployments]]
+deployment_label = "qdchdmy1_20130406_081713"
+deployment_datetime = 2013-04-06 08:17:13+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "snapperbank_05"
+acfr_campaign_label = "WA201304"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.97
+
+[deployments.files]
+raw_messages = [
+    "messages/20130406_0817.RAW.auv",
+    "messages/20130406_0900.RAW.auv",
+    "messages/20130406_1000.RAW.auv",
+]
+system_config = [
+    "messages/20130406_0817.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130406_0817.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130406_0817.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130406_0817.snapperbank_05.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130422/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130422/stereo_pose_est.data",
+    "camera_poses/renav20130422_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130406-073750.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Linnaeus"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.18
+extrinsics.locy = 0.7
+extrinsics.locz = 2.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "qdchdmy1_20170525_234624"
+deployment_datetime = 2017-05-25 23:46:24+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "SS11_snapperbank"
+acfr_campaign_label = "WA201705"
+acfr_platform_label = ""
+origin_latitude = -28.7066
+origin_longitude = 114.0115
+magnetic_variation = -0.79
+
+[deployments.files]
+raw_messages = [
+    "messages/20170525_2346.RAW.auv",
+    "messages/20170526_0000.RAW.auv",
+    "messages/20170526_0100.RAW.auv",
+    "messages/20170526_0200.RAW.auv",
+]
+system_config = [
+    "messages/20170525_2346.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20170525_2346.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20170525_2346.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20170525_2347.SS11_snapperbank.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20170526/usyd_pool_20170118.calib",
+]
+camera_poses = [
+    "camera_poses/renav20170526/stereo_pose_est.data",
+    "camera_poses/renav20170526_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20170525-234333.txt",
+    "usbl/log-20170525-234701.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "EVOLOGICS_FIX",
+    "GPS_GSV",
+    "GPS_RMC",
+    "MICRON_RETURNS",
+    "MICRON_TRACE",
+    "PAROSCI",
+    "RDI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[[deployments.platform.sensors]]
+key = "EVOLOGICS"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+    "MICRON",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Silver Streak"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
+identity.type = "usbl"
+extrinsics.locx = -4.793
+extrinsics.locy = 4.302
+extrinsics.locz = 4.043
+extrinsics.rotx = -0.0067
+extrinsics.roty = 0.0032
+extrinsics.rotz = 0.4713
+
+[[deployments]]
+deployment_label = "r23685bc_20100605_021022"
+deployment_datetime = 2010-06-05 02:10:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_15_deep"
+acfr_campaign_label = "Tasmania201006"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.34
+
+[deployments.files]
+raw_messages = [
+    "messages/20100605_0210.RAW.auv",
+    "messages/20100605_0300.RAW.auv",
+    "messages/20100605_0400.RAW.auv",
+    "messages/20100605_0500.RAW.auv",
+]
+system_config = [
+    "messages/20100605_0210.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20100605_0210.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20100605_0210.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20100605_0211.lanterns_15_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20100605/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20100605/stereo_pose_est.data",
+    "camera_poses/renav20100605_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20100605-005939.txt",
+    "usbl/log-20100605-014520.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.21
+extrinsics.locy = 2.97
+extrinsics.locz = 2.27
+extrinsics.rotx = -0.5058
+extrinsics.roty = -0.0042
+extrinsics.rotz = 0.3138
+
+[[deployments]]
+deployment_label = "r23685bc_20120530_233021"
+deployment_datetime = 2012-05-30 23:30:21+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "lanterns_10_deep"
+acfr_campaign_label = "Tasmania201205"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.38
+
+[deployments.files]
+raw_messages = [
+    "messages/20120530_2330.RAW.auv",
+    "messages/20120531_0000.RAW.auv",
+    "messages/20120531_0100.RAW.auv",
+    "messages/20120531_0200.RAW.auv",
+]
+system_config = [
+    "messages/20120530_2330.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20120530_2330.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20120530_2330.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20120530_2332.lanterns_10_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121023/camera_20120207_field12.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121023/stereo_pose_est.data",
+    "camera_poses/renav20121023_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20120530-231147.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "IMU"
+identity.label = "Inertial measurement unit"
+identity.vendor = ""
+identity.product = ""
+identity.type = "imu"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 3.497
+extrinsics.locy = 3.23
+extrinsics.locz = 3.679
+extrinsics.rotx = -0.4283
+extrinsics.roty = -0.0429
+extrinsics.rotz = 0.1861
+
+[[deployments]]
+deployment_label = "r23685bc_20140616_225022"
+deployment_datetime = 2014-06-16 22:50:22+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "tas_13_lanterns_deep"
+acfr_campaign_label = "Tasmania201406"
+acfr_platform_label = ""
+origin_latitude = -43.1475
+origin_longitude = 148.0046
+magnetic_variation = 15.42
+
+[deployments.files]
+raw_messages = [
+    "messages/20140616_2250.RAW.auv",
+    "messages/20140616_2300.RAW.auv",
+    "messages/20140617_0000.RAW.auv",
+    "messages/20140617_0100.RAW.auv",
+]
+system_config = [
+    "messages/20140616_2250.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20140616_2250.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20140616_2250.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20140616_2250.tas_13_lanterns_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140618/USyd20140508.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140618/stereo_pose_est.data",
+    "camera_poses/renav20140618_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20140616-225027.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "Tasmania Bluefin"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -11.916
+extrinsics.locy = 4.761
+extrinsics.locz = 10.752
+extrinsics.rotx = -0.5026
+extrinsics.roty = -0.0103
+extrinsics.rotz = -0.0327
+
+[[deployments]]
+deployment_label = "r29mrd5h_20090612_225306"
+deployment_datetime = 2009-06-12 22:53:06+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_07_elephant_rock_deep"
+acfr_campaign_label = "Tasmania200906"
+acfr_platform_label = ""
+origin_latitude = 0.0
+origin_longitude = 0.0
+magnetic_variation = 0.0
+
+[deployments.files]
+raw_messages = [
+    "messages/20090612_2253.RAW.auv",
+    "messages/20090612_2300.RAW.auv",
+    "messages/20090613_0000.RAW.auv",
+]
+system_config = [
+    "messages/20090612_2253.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20090612_2253.SEABED.localiser.cfg",
+]
+magvar_config = []
+mission_log = [
+    "messages/20090612_2254.st_helens_07_elephant_rock_deep.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20090810/ng2_20070606.calib",
+    "camera_calibration/renav20120228/bundlestereo.calib",
+]
+camera_poses = [
+    "camera_poses/renav20090810/stereo_pose_est.data",
+    "camera_poses/renav20090810_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20090612-224117.txt",
+    "usbl/log-20090612-224817.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.55
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 0.53
+extrinsics.locy = 4.33
+extrinsics.locz = 3.29
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments]]
+deployment_label = "r29mrd5h_20110612_033752"
+deployment_datetime = 2011-06-12 03:37:52+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201106"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.59
+
+[deployments.files]
+raw_messages = [
+    "messages/20110612_0337.RAW.auv",
+    "messages/20110612_0400.RAW.auv",
+]
+system_config = [
+    "messages/20110612_0337.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20110612_0337.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20110612_0337.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20110612_0338.st_helens_01_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20110612/usyd_pool20110607and3.calib",
+]
+camera_poses = [
+    "camera_poses/renav20110612/stereo_pose_est.data",
+    "camera_poses/renav20110612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20110612-032957.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 1.404
+extrinsics.locy = 4.412
+extrinsics.locz = 4.534
+extrinsics.rotx = -0.5409
+extrinsics.roty = -0.0605
+extrinsics.rotz = -0.24
+
+[[deployments]]
+deployment_label = "r29mrd5h_20130611_002419"
+deployment_datetime = 2013-06-11 00:24:19+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
+acfr_campaign_label = "Tasmania201306"
+acfr_platform_label = ""
+origin_latitude = -41.252879
+origin_longitude = 148.341567
+magnetic_variation = 14.62
+
+[deployments.files]
+raw_messages = [
+    "messages/20130611_0024.RAW.auv",
+    "messages/20130611_0100.RAW.auv",
+]
+system_config = [
+    "messages/20130611_0024.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20130611_0024.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20130611_0024.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20130611_0026.st_helens_13_elephant_rock_deep_repeat.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20130612/UsydPool10022013.calib",
+]
+camera_poses = [
+    "camera_poses/renav20130612/stereo_pose_est.data",
+    "camera_poses/renav20130612_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20130610-233945.txt",
+    "usbl/log-20130610-234950.txt",
+    "usbl/log-20130610-235109.txt",
+    "usbl/log-20130611-000201.txt",
+    "usbl/log-20130611-001308.txt",
+    "usbl/log-20130611-002331.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Challenger"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = 7.615
+extrinsics.locy = 6.329
+extrinsics.locz = 4.529
+extrinsics.rotx = -0.4283
+extrinsics.roty = 0.0176
+extrinsics.rotz = -0.2815
+
+[[deployments]]
+deployment_label = "r7jjskxq_20101023_210332"
+deployment_datetime = 2010-10-23 21:03:32+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_10_shallow_grids"
+acfr_campaign_label = "SEQueensland201010"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.15
+
+[deployments.files]
+raw_messages = [
+    "messages/20101023_2103.RAW.auv",
+    "messages/20101023_2200.RAW.auv",
+    "messages/20101023_2300.RAW.auv",
+]
+system_config = [
+    "messages/20101023_2103.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20101023_2103.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20101023_2103.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20101023_2104.hendersonSth_10_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20101024/ng2_scaled_baseline.calib",
+]
+camera_poses = [
+    "camera_poses/renav20101024/stereo_pose_est.data",
+    "camera_poses/renav20101024_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20101023-204151.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/files1/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -4.46
+extrinsics.locy = -4.826
+extrinsics.locz = 2.48
+extrinsics.rotx = 0.5084
+extrinsics.roty = -0.0622
+extrinsics.rotz = -0.0509
+
+[[deployments]]
+deployment_label = "r7jjskxq_20121013_060425"
+deployment_datetime = 2012-10-13 06:04:25+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_07_shallow_grids"
+acfr_campaign_label = "SEQueensland201210"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20121013_0604.RAW.auv",
+    "messages/20121013_0700.RAW.auv",
+    "messages/20121013_0800.RAW.auv",
+]
+system_config = [
+    "messages/20121013_0604.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20121013_0604.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20121013_0604.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20121013_0604.hendersonSth_07_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20121014/SolitaryIs201208.calib",
+]
+camera_poses = [
+    "camera_poses/renav20121014/stereo_pose_est.data",
+    "camera_poses/renav20121014_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20121013-060330.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS_GSV",
+    "GPS_RMC",
+    "LQMODEM",
+    "OAS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "ECOPUCK"
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "OAS"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.723
+extrinsics.locy = -5.235
+extrinsics.locz = 1.769
+extrinsics.rotx = 0.5553
+extrinsics.roty = -0.0036
+extrinsics.rotz = -0.0511
+
+[[deployments]]
+deployment_label = "r7jjskxq_20131022_004934"
+deployment_datetime = 2013-10-22 00:49:34+00:00
+
+[deployments.metadata]
+acfr_deployment_label = "hendersonSth_03_shallow_grids"
+acfr_campaign_label = "SEQueensland201310"
+acfr_platform_label = ""
+origin_latitude = -27.130126
+origin_longitude = 153.475063
+magnetic_variation = 11.16
+
+[deployments.files]
+raw_messages = [
+    "messages/20131022_0049.RAW.auv",
+    "messages/20131022_0100.RAW.auv",
+    "messages/20131022_0200.RAW.auv",
+]
+system_config = [
+    "messages/20131022_0049.SEABED.syscfg",
+]
+localizer_config = [
+    "messages/20131022_0049.SEABED.localiser.cfg",
+]
+magvar_config = [
+    "messages/20131022_0049.magnetic_variation.cfg",
+]
+mission_log = [
+    "messages/20131022_0050.hendersonSth_03_shallow_grids.dat.log",
+]
+camera_calibrations = [
+    "camera_calibration/renav20140520/SEQueenslan201310poolcalibration.calib",
+]
+camera_poses = [
+    "camera_poses/renav20140520/stereo_pose_est.data",
+    "camera_poses/renav20140520_stereo_pose_est.data",
+]
+usbl_logs = [
+    "usbl/log-20131022-004921.txt",
+]
+
+[deployments.telemetry]
+topics = [
+    "GPS_RMC",
+    "LQMODEM",
+    "MICRON",
+    "MICRON_RETURNS",
+    "PAROSCI",
+    "RDI",
+    "SEABIRD",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "VIS",
+]
+
+[deployments.platform]
+
+[deployments.platform.identity]
+platform_label = "AUV Sirius"
+platform_class = "SEABED"
+platform_operator = "ACFR"
+
+[[deployments.platform.sensors]]
+key = "DELTA_T"
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "MP_INPUT"
+
+[[deployments.platform.sensors]]
+key = "VIS"
+identity.label = "AVT Prosilica GC1380 stereo camera"
+identity.vendor = "AVT"
+identity.product = "Prosilica GC1380"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
+
+[[deployments.platform.sensors]]
+key = "RDI"
+identity.label = "Teledyne RDI Work Horse Navigator DVL"
+identity.vendor = "Teledyne RDI"
+identity.product = "Work Horse Navigator"
+identity.type = "dvl"
+extrinsics.locx = 0.0
+extrinsics.locy = 0.0
+extrinsics.locz = 0.0
+extrinsics.rotx = 0.0
+extrinsics.roty = 3.1416
+extrinsics.rotz = -1.5708
+
+[[deployments.platform.sensors]]
+key = "PAROSCI"
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "THR_PORT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "THR_VERT"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "BATT0"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT1"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "BATT2"
+identity.label = "Vehicle battery pack"
+identity.vendor = ""
+identity.product = ""
+identity.type = "battery"
+
+[[deployments.platform.sensors]]
+key = "LQMODEM"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -1.27
+extrinsics.locy = 0.0
+extrinsics.locz = -0.9
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "GPS"
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "THR_STBD"
+identity.label = "Vehicle thruster"
+identity.vendor = ""
+identity.product = ""
+identity.type = "thruster"
+
+[[deployments.platform.sensors]]
+key = "SEABIRD"
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "MICRON"
+
+[deployments.system]
+vehicle_name = "SEABED"
+vehicle_config = "NORM_CFG"
+log_directory = "/media/data/Log"
+logged_streams = [
+    "SYSLOG",
+    "RAW",
+    "CTL",
+    "AUV",
+    "MSG",
+    "RDI",
+    "IMU",
+]
+
+[deployments.vessel]
+
+[deployments.vessel.identity]
+vessel_name = "RV Tom Marshall"
+
+[[deployments.vessel.sensors]]
+key = "USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
+extrinsics.locx = -5.541
+extrinsics.locy = -5.364
+extrinsics.locz = 3.224
+extrinsics.rotx = 0.5678
+extrinsics.roty = 0.0022
+extrinsics.rotz = 0.2499


### PR DESCRIPTION
Completes the platform side of `deployment_catalog_v1_all.toml`, which previously assigned only 17 of the 52 deployments.

## Changes

- Add `2015_auv_sirius` and `2021_auv_sirius` platform profiles. Their sensor slots come from the observed rosters, and their mounting poses from the deployment localizer configs, which carry the same pose set as 2017.
- Assign all 52 deployments to a platform profile, ordered by deployment label. The vessel assignments already covered all 52.
- Add the `camera_avt_manta` sensor identity for the Allied Vision Manta G-1236 the vehicle flew by 2021.
- Rename `camera_prosilica` to `camera_avt_prosilica` and `camera_manta` to `camera_avt_manta` in `deployment_catalog_v1_all.toml` and `deployment_catalog_v1_subset.toml`.
- Update the catalog header comments, which described the platform side as covering only the 17 deployments with configs on disk.

## Notes

The 2021 syscfg has `VIS`, `SEABIRD` and the battery channels commented out, so those keys are absent from the 2021 rosters. The `VIS` slot is kept in the profile with the Manta identity and the stereo pose, but stays unenriched until a roster names the camera.

`GPSD` in the 2021 rosters is mapped to the existing `gnss_ublox` identity.

`tests/test_deployment_enrichment.py` still uses `camera_prosilica` in its fixtures. The tests build their own catalog, so they are unaffected by the rename.

## Verification

All descriptor and catalog files in `data/` parse through `read_deployment_descriptors` and `read_deployment_catalog`. Every deployment resolves to an existing profile on both sides, with no dangling identity references. `afft deployment enrich` runs clean over all 52 deployments.