### PR TITLE
Add bash scripts to collect Squidle media records and images.

### DIFF
--- a/scripts/shell/collect_squidle_media_desktop.sh
+++ b/scripts/shell/collect_squidle_media_desktop.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$(realpath -m ${SCRIPT_DIR}/../../config)"
+
+OUTPUT_DIR="/data/exos_01/acfr_squidle_collections"
+
+
+echo "Script dir: ${SCRIPT_DIR}"
+echo "Config dir: ${CONFIG_DIR}"
+
+
+uv run afft tasks collect-squidle-media \
+  --deployments-file "${CONFIG_DIR}/acfr_deployments.toml" \
+  --output-dir "${OUTPUT_DIR}"

--- a/scripts/shell/collect_squidle_media_laptop.sh
+++ b/scripts/shell/collect_squidle_media_laptop.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$(realpath -m ${SCRIPT_DIR}/../../config)"
+
+OUTPUT_DIR="${HOME}/data/acfr_squidle_collections"
+
+
+echo "Script dir: ${SCRIPT_DIR}"
+echo "Config dir: ${CONFIG_DIR}"
+
+
+uv run afft tasks collect-squidle-media \
+  --deployments-file "${CONFIG_DIR}/acfr_deployments.toml" \
+  --output-dir "${OUTPUT_DIR}"


### PR DESCRIPTION
Add bash scripts to invoke the Squidle media collector with directories configured for laptop and desktop.