### PR TITLE
Add task and CLI command to summarize the deployment catalog

### DIFF
--- a/src/afft/cli/deployment/actions.py
+++ b/src/afft/cli/deployment/actions.py
@@ -5,7 +5,9 @@ from pathlib import Path
 from afft.deployment import EnrichmentSection
 from afft.tasks.deployment_catalog import (
     ScaffoldCatalogCommand,
+    SummarizeCatalogCommand,
     run_scaffold_catalog,
+    run_summarize_catalog,
 )
 from afft.tasks.deployment_descriptor import (
     DescribeDeploymentCommand,
@@ -99,3 +101,19 @@ def dispatch_summarize_descriptor(
         verbose=verbose,
     )
     run_summarize_descriptor(command)
+
+
+def dispatch_summarize_catalog(
+    input_file: str | Path,
+    verbose: bool = False,
+) -> None:
+    """
+    Summarize a curated deployment catalog.
+
+    Always exits zero: curation gaps are the summary's output, not a failure of
+    the run.
+    """
+    command = SummarizeCatalogCommand(
+        input_file=Path(input_file), verbose=verbose
+    )
+    run_summarize_catalog(command)

--- a/src/afft/cli/deployment/commands.py
+++ b/src/afft/cli/deployment/commands.py
@@ -8,6 +8,7 @@ from .actions import (
     dispatch_describe_deployment,
     dispatch_enrich_descriptor,
     dispatch_scaffold_catalog,
+    dispatch_summarize_catalog,
     dispatch_summarize_descriptor,
 )
 
@@ -180,3 +181,30 @@ def summarize(
     one, writes a detailed per-deployment report as Markdown.
     """
     dispatch_summarize_descriptor(input_file, output_file, verbose)
+
+
+@deployment_group.command()
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the curated deployment catalog TOML file",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="list the records affected by each curation gap",
+)
+def summarize_catalog(
+    input_file: str,
+    verbose: bool,
+) -> None:
+    """Summarize a curated deployment catalog.
+
+    Prints curation progress to the terminal — record counts, profile
+    assignment coverage, records nothing references, and the curated fields
+    still left empty.
+    """
+    dispatch_summarize_catalog(input_file, verbose)

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -14,6 +14,15 @@ from .catalog_io import (
     read_deployment_catalog as read_deployment_catalog,
     write_deployment_catalog as write_deployment_catalog,
 )
+from .catalog_summary import (
+    AssignmentCoverage as AssignmentCoverage,
+    CatalogCurationGap as CatalogCurationGap,
+    CatalogSummary as CatalogSummary,
+    ProfileAssignment as ProfileAssignment,
+    collect_catalog_curation_gaps as collect_catalog_curation_gaps,
+    collect_unreferenced_sensors as collect_unreferenced_sensors,
+    summarize_catalog as summarize_catalog,
+)
 from .descriptor_types import (
     DeploymentDescriptor as DeploymentDescriptor,
     DeploymentFileSection as DeploymentFileSection,

--- a/src/afft/deployment/catalog_summary.py
+++ b/src/afft/deployment/catalog_summary.py
@@ -1,0 +1,333 @@
+"""Aggregate views over a curated deployment catalog."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .catalog_types import (
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensorIdentity,
+    CatalogVesselProfile,
+    DeploymentCatalog,
+)
+
+type FieldName = str
+type ProfileKey = str
+type RecordKey = str
+type CatalogRecord = (
+    CatalogSensorIdentity | CatalogPlatformProfile | CatalogVesselProfile
+)
+
+
+class ProfileAssignment(BaseModel):
+    """
+    A profile and the deployments assigned to it.
+
+    Attributes
+    ----------
+    profile_key: Key of the assigned profile.
+    deployment_labels: Labels of the deployments assigned the profile, in
+        alphabetical order.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    profile_key: ProfileKey
+    deployment_labels: list[str]
+
+    @property
+    def count(self) -> int:
+        """Number of deployments assigned the profile."""
+        return len(self.deployment_labels)
+
+
+class AssignmentCoverage(BaseModel):
+    """
+    Profile assignment coverage across the deployments the catalog names.
+
+    A catalog knows a deployment only through its assignment tables, so the
+    deployments covered are those named by either table.
+
+    Attributes
+    ----------
+    deployment_labels: Labels named by either assignment table, in alphabetical
+        order.
+    platform_only: Labels assigned a platform profile but no vessel profile.
+    vessel_only: Labels assigned a vessel profile but no platform profile.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_labels: list[str]
+    platform_only: list[str]
+    vessel_only: list[str]
+
+    @property
+    def deployment_count(self) -> int:
+        """Number of deployments the catalog names."""
+        return len(self.deployment_labels)
+
+    @property
+    def with_platform(self) -> int:
+        """Number of deployments assigned a platform profile."""
+        return self.deployment_count - len(self.vessel_only)
+
+    @property
+    def with_vessel(self) -> int:
+        """Number of deployments assigned a vessel profile."""
+        return self.deployment_count - len(self.platform_only)
+
+
+class CatalogCurationGap(BaseModel):
+    """
+    A curated slot left unfilled across one or more catalog records.
+
+    Attributes
+    ----------
+    field_name: Dotted path of the unfilled field, e.g.
+        ``"platform_profiles.platform_label"``.
+    record_keys: Keys of the records the slot is unfilled for.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    field_name: FieldName
+    record_keys: list[RecordKey]
+
+    @property
+    def count(self) -> int:
+        """Number of records the slot is unfilled for."""
+        return len(self.record_keys)
+
+
+class CatalogSummary(BaseModel):
+    """
+    Aggregate summary of a curated deployment catalog file.
+
+    Attributes
+    ----------
+    sensor_identity_count: Number of sensor identity records.
+    platform_profile_count: Number of platform profile records.
+    vessel_profile_count: Number of vessel profile records.
+    coverage: Profile assignment coverage across the named deployments.
+    platform_assignments: Every platform profile and its assigned deployments.
+    vessel_assignments: Every vessel profile and its assigned deployments.
+    unreferenced_sensors: Keys of the sensor identities no profile sensor
+        references.
+    curation_gaps: Unfilled curated slots, per field.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_identity_count: int
+    platform_profile_count: int
+    vessel_profile_count: int
+    coverage: AssignmentCoverage
+    platform_assignments: list[ProfileAssignment] = Field(default_factory=list)
+    vessel_assignments: list[ProfileAssignment] = Field(default_factory=list)
+    unreferenced_sensors: list[RecordKey] = Field(default_factory=list)
+    curation_gaps: list[CatalogCurationGap] = Field(default_factory=list)
+
+
+def _collect_coverage(catalog: DeploymentCatalog) -> AssignmentCoverage:
+    """Collect the assignment coverage of the deployments the catalog names."""
+    platform_labels: set[str] = {
+        entry.deployment_label for entry in catalog.deployment_platforms
+    }
+    vessel_labels: set[str] = {
+        entry.deployment_label for entry in catalog.deployment_vessels
+    }
+    return AssignmentCoverage(
+        deployment_labels=sorted(platform_labels | vessel_labels),
+        platform_only=sorted(platform_labels - vessel_labels),
+        vessel_only=sorted(vessel_labels - platform_labels),
+    )
+
+
+def _collect_assignments(
+    profile_keys: list[ProfileKey],
+    labels_by_profile: dict[ProfileKey, list[str]],
+) -> list[ProfileAssignment]:
+    """
+    Pair every profile with its assigned deployments, ordered by descending
+    assignment count, then by profile key.
+    """
+    assignments: list[ProfileAssignment] = [
+        ProfileAssignment(
+            profile_key=profile_key,
+            deployment_labels=sorted(labels_by_profile.get(profile_key, [])),
+        )
+        for profile_key in profile_keys
+    ]
+    return sorted(
+        assignments, key=lambda entry: (-entry.count, entry.profile_key)
+    )
+
+
+def _collect_platform_assignments(
+    catalog: DeploymentCatalog,
+) -> list[ProfileAssignment]:
+    """Pair every platform profile with its assigned deployments."""
+    labels_by_profile: dict[ProfileKey, list[str]] = {}
+    for entry in catalog.deployment_platforms:
+        labels_by_profile.setdefault(entry.platform_profile, []).append(
+            entry.deployment_label
+        )
+    return _collect_assignments(
+        [profile.key for profile in catalog.platform_profiles],
+        labels_by_profile,
+    )
+
+
+def _collect_vessel_assignments(
+    catalog: DeploymentCatalog,
+) -> list[ProfileAssignment]:
+    """Pair every vessel profile with its assigned deployments."""
+    labels_by_profile: dict[ProfileKey, list[str]] = {}
+    for entry in catalog.deployment_vessels:
+        labels_by_profile.setdefault(entry.vessel_profile, []).append(
+            entry.deployment_label
+        )
+    return _collect_assignments(
+        [profile.key for profile in catalog.vessel_profiles], labels_by_profile
+    )
+
+
+def collect_unreferenced_sensors(
+    catalog: DeploymentCatalog,
+) -> list[RecordKey]:
+    """
+    Collect the sensor identities no profile sensor references.
+
+    Arguments
+    ---------
+    catalog: Deployment catalog to inspect.
+
+    Returns
+    -------
+    Keys of the unreferenced sensor identities, in file order.
+    """
+    profiles: list[CatalogPlatformProfile | CatalogVesselProfile] = [
+        *catalog.platform_profiles,
+        *catalog.vessel_profiles,
+    ]
+    referenced: set[str] = {
+        sensor.identity for profile in profiles for sensor in profile.sensors
+    }
+    return [
+        sensor.key
+        for sensor in catalog.sensor_identities
+        if sensor.key not in referenced
+    ]
+
+
+def _sensor_pose_gaps(
+    profile_key: ProfileKey,
+    sensors: list[CatalogProfileSensor],
+) -> list[RecordKey]:
+    """Collect the profile sensors left without a mounting pose."""
+    return [
+        f"{profile_key}[{sensor.key}]"
+        for sensor in sensors
+        if sensor.extrinsics is None
+    ]
+
+
+def _empty_fields(
+    record: CatalogRecord,
+    fields: tuple[str, ...],
+    section: str,
+) -> list[tuple[FieldName, RecordKey]]:
+    """Pair every empty string field of a record with the record's key."""
+    return [
+        (f"{section}.{field}", record.key)
+        for field in fields
+        if not getattr(record, field)
+    ]
+
+
+def collect_catalog_curation_gaps(
+    catalog: DeploymentCatalog,
+) -> list[CatalogCurationGap]:
+    """
+    Collect the catalog's unfilled curated slots, grouped per field.
+
+    A slot is unfilled when a curated string field is empty, or when a profile
+    sensor carries no mounting pose.
+
+    Arguments
+    ---------
+    catalog: Deployment catalog to inspect.
+
+    Returns
+    -------
+    Gaps ordered by descending record count, then by field name.
+    """
+    keys_by_field: dict[FieldName, list[RecordKey]] = {}
+
+    def add(field_name: FieldName, record_key: RecordKey) -> None:
+        keys_by_field.setdefault(field_name, []).append(record_key)
+
+    for sensor_identity in catalog.sensor_identities:
+        for field_name, record_key in _empty_fields(
+            sensor_identity,
+            ("label", "vendor", "product", "type"),
+            "sensor_identities",
+        ):
+            add(field_name, record_key)
+
+    for platform_profile in catalog.platform_profiles:
+        for field_name, record_key in _empty_fields(
+            platform_profile,
+            ("platform_label", "platform_class", "platform_operator"),
+            "platform_profiles",
+        ):
+            add(field_name, record_key)
+        for sensor_key in _sensor_pose_gaps(
+            platform_profile.key, platform_profile.sensors
+        ):
+            add("platform_profiles.sensors.extrinsics", sensor_key)
+
+    for vessel_profile in catalog.vessel_profiles:
+        for field_name, record_key in _empty_fields(
+            vessel_profile, ("vessel_name",), "vessel_profiles"
+        ):
+            add(field_name, record_key)
+        for sensor_key in _sensor_pose_gaps(
+            vessel_profile.key, vessel_profile.sensors
+        ):
+            add("vessel_profiles.sensors.extrinsics", sensor_key)
+
+    return [
+        CatalogCurationGap(field_name=field_name, record_keys=record_keys)
+        for field_name, record_keys in sorted(
+            keys_by_field.items(), key=lambda item: (-len(item[1]), item[0])
+        )
+    ]
+
+
+def summarize_catalog(catalog: DeploymentCatalog) -> CatalogSummary:
+    """
+    Aggregate a curated deployment catalog into a summary.
+
+    Referential integrity is left to ``DeploymentCatalog.validate_catalog``;
+    what is reported here is curation progress — empty curated fields, and
+    records nothing references or assigns.
+
+    Arguments
+    ---------
+    catalog: Deployment catalog to summarize.
+
+    Returns
+    -------
+    The computed summary. An empty catalog summarizes to zero counts.
+    """
+    return CatalogSummary(
+        sensor_identity_count=len(catalog.sensor_identities),
+        platform_profile_count=len(catalog.platform_profiles),
+        vessel_profile_count=len(catalog.vessel_profiles),
+        coverage=_collect_coverage(catalog),
+        platform_assignments=_collect_platform_assignments(catalog),
+        vessel_assignments=_collect_vessel_assignments(catalog),
+        unreferenced_sensors=collect_unreferenced_sensors(catalog),
+        curation_gaps=collect_catalog_curation_gaps(catalog),
+    )

--- a/src/afft/tasks/deployment_catalog/__init__.py
+++ b/src/afft/tasks/deployment_catalog/__init__.py
@@ -14,6 +14,14 @@ from .runner import (
     run_scaffold_catalog as run_scaffold_catalog,
     scaffold_catalog as scaffold_catalog,
 )
+from .summary_runner import (
+    log_summary as log_summary,
+    run_summarize_catalog as run_summarize_catalog,
+)
+from .summary_types import (
+    SummarizeCatalogCommand as SummarizeCatalogCommand,
+    SummarizeCatalogResult as SummarizeCatalogResult,
+)
 from .types import (
     CatalogWarning as CatalogWarning,
     ScaffoldCatalogCommand as ScaffoldCatalogCommand,

--- a/src/afft/tasks/deployment_catalog/summary_runner.py
+++ b/src/afft/tasks/deployment_catalog/summary_runner.py
@@ -1,0 +1,141 @@
+"""Runner for the summarize catalog task."""
+
+from rich.console import Console
+from rich.table import Table
+
+from afft.deployment import (
+    CatalogSummary,
+    DeploymentCatalog,
+    ProfileAssignment,
+    read_deployment_catalog,
+    summarize_catalog,
+)
+from afft.utils.log import logger
+
+from .summary_types import SummarizeCatalogCommand, SummarizeCatalogResult
+
+
+def _assignment_table(
+    title: str,
+    assignments: list[ProfileAssignment],
+) -> Table:
+    """Build a table of profiles and their assignment counts."""
+    table = Table(title=title, title_justify="left")
+    table.add_column("Profile")
+    table.add_column("Deployments", justify="right")
+    for assignment in assignments:
+        table.add_row(assignment.profile_key, str(assignment.count))
+    return table
+
+
+def log_summary(summary: CatalogSummary, verbose: bool) -> None:
+    """
+    Print the brief catalog summary to the terminal.
+
+    Arguments
+    ---------
+    summary: The computed summary.
+    verbose: List the offending profile and deployment keys for each gap.
+    """
+    console = Console()
+    coverage = summary.coverage
+
+    records = Table(title="Records", title_justify="left", show_header=False)
+    records.add_column("Table")
+    records.add_column("Count", justify="right")
+    records.add_row("Sensor identities", str(summary.sensor_identity_count))
+    records.add_row("Platform profiles", str(summary.platform_profile_count))
+    records.add_row("Vessel profiles", str(summary.vessel_profile_count))
+    console.print(records)
+
+    assignment = Table(
+        title="Assignment coverage", title_justify="left", show_header=False
+    )
+    assignment.add_column("Field")
+    assignment.add_column("Count", justify="right")
+    assignment.add_row("Deployments", str(coverage.deployment_count))
+    assignment.add_row("With platform", str(coverage.with_platform))
+    assignment.add_row("With vessel", str(coverage.with_vessel))
+    assignment.add_row("Platform only", str(len(coverage.platform_only)))
+    assignment.add_row("Vessel only", str(len(coverage.vessel_only)))
+    console.print(assignment)
+
+    if verbose:
+        for label, labels in (
+            ("Platform only", coverage.platform_only),
+            ("Vessel only", coverage.vessel_only),
+        ):
+            if labels:
+                console.print(f"{label}:")
+                for deployment_label in labels:
+                    console.print(f"  {deployment_label}")
+
+    console.print(
+        _assignment_table("Platform profiles", summary.platform_assignments)
+    )
+    console.print(
+        _assignment_table("Vessel profiles", summary.vessel_assignments)
+    )
+
+    if summary.unreferenced_sensors:
+        console.print(
+            f"{len(summary.unreferenced_sensors)} sensor identity(s) "
+            "referenced by no profile:"
+        )
+        for sensor_key in summary.unreferenced_sensors:
+            console.print(f"  {sensor_key}")
+
+    if not summary.curation_gaps:
+        console.print("No unfilled curated slots.")
+        return
+
+    gaps = Table(title="Curation gaps", title_justify="left")
+    gaps.add_column("Field")
+    gaps.add_column("Records", justify="right")
+    for gap in summary.curation_gaps:
+        gaps.add_row(gap.field_name, str(gap.count))
+    console.print(gaps)
+
+    if verbose:
+        for gap in summary.curation_gaps:
+            console.print(f"{gap.field_name}:")
+            for record_key in gap.record_keys:
+                console.print(f"  {record_key}")
+
+
+def run_summarize_catalog(
+    command: SummarizeCatalogCommand,
+) -> SummarizeCatalogResult:
+    """
+    Summarize a curated deployment catalog, printing the aggregates to the
+    terminal.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The computed summary.
+
+    Raises
+    ------
+    FileNotFoundError: If the input file is missing.
+    """
+    if not command.input_file.exists():
+        raise FileNotFoundError(
+            f"input file does not exist: {command.input_file}"
+        )
+
+    logger.info("-------------------------------------")
+    logger.info("Summarize Deployment Catalog")
+    logger.info(f"  input file: {command.input_file}")
+    logger.info(f"  verbose:    {command.verbose}")
+    logger.info("-------------------------------------")
+
+    catalog: DeploymentCatalog = read_deployment_catalog(command.input_file)
+    summary: CatalogSummary = summarize_catalog(catalog)
+
+    log_summary(summary, command.verbose)
+
+    return SummarizeCatalogResult(summary=summary)

--- a/src/afft/tasks/deployment_catalog/summary_types.py
+++ b/src/afft/tasks/deployment_catalog/summary_types.py
@@ -1,0 +1,38 @@
+"""Data types for the summarize catalog task."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+from afft.deployment import CatalogSummary
+
+
+class SummarizeCatalogCommand(BaseModel):
+    """
+    Command for summarizing a curated deployment catalog.
+
+    Attributes
+    ----------
+    input_file: Path to the deployment catalog TOML file.
+    verbose: List the offending profile and deployment keys in the terminal
+        summary.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    verbose: bool = False
+
+
+class SummarizeCatalogResult(BaseModel):
+    """
+    Result of the summarize catalog task.
+
+    Attributes
+    ----------
+    summary: The computed summary.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    summary: CatalogSummary

--- a/tests/test_summarize_catalog.py
+++ b/tests/test_summarize_catalog.py
@@ -1,0 +1,287 @@
+"""Tests for the summarize catalog task and its CLI."""
+
+from pathlib import Path
+
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.deployment import (
+    CatalogDeploymentPlatform,
+    CatalogDeploymentVessel,
+    CatalogPlatformProfile,
+    CatalogProfileSensor,
+    CatalogSensorExtrinsics,
+    CatalogSensorIdentity,
+    CatalogSummary,
+    CatalogVesselProfile,
+    DeploymentCatalog,
+    collect_unreferenced_sensors,
+    summarize_catalog,
+    write_deployment_catalog,
+)
+from afft.tasks.deployment_catalog import (
+    SummarizeCatalogCommand,
+    SummarizeCatalogResult,
+    run_summarize_catalog,
+)
+
+
+def _extrinsics() -> CatalogSensorExtrinsics:
+    """Builds a filled mounting pose."""
+    return CatalogSensorExtrinsics(
+        locx=0.1, locy=0.2, locz=0.3, rotx=0.0, roty=0.0, rotz=0.0
+    )
+
+
+def _sensor_identity(
+    key: str = "dvl_teledyne",
+    vendor: str = "Teledyne RDI",
+) -> CatalogSensorIdentity:
+    """Builds a sensor identity, optionally with an empty vendor."""
+    return CatalogSensorIdentity(
+        key=key,
+        label="Doppler velocity log",
+        vendor=vendor,
+        product="Work Horse Navigator",
+        type="dvl",
+    )
+
+
+def _build_catalog() -> DeploymentCatalog:
+    """Builds a fully curated catalog covering two deployments."""
+    return DeploymentCatalog(
+        sensor_identities=[_sensor_identity()],
+        platform_profiles=[
+            CatalogPlatformProfile(
+                key="sirius_2010",
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="ACFR",
+                sensors=[
+                    CatalogProfileSensor(
+                        key="RDI",
+                        identity="dvl_teledyne",
+                        extrinsics=_extrinsics(),
+                    )
+                ],
+            )
+        ],
+        vessel_profiles=[
+            CatalogVesselProfile(key="linnaeus", vessel_name="RV Linnaeus")
+        ],
+        deployment_platforms=[
+            CatalogDeploymentPlatform(
+                deployment_label="aaa_20100428_020202",
+                platform_profile="sirius_2010",
+            ),
+            CatalogDeploymentPlatform(
+                deployment_label="bbb_20110415_020103",
+                platform_profile="sirius_2010",
+            ),
+        ],
+        deployment_vessels=[
+            CatalogDeploymentVessel(
+                deployment_label="aaa_20100428_020202",
+                vessel_profile="linnaeus",
+            ),
+            CatalogDeploymentVessel(
+                deployment_label="bbb_20110415_020103",
+                vessel_profile="linnaeus",
+            ),
+        ],
+    )
+
+
+def test_summarize_counts_records_and_coverage() -> None:
+    """Record counts and coverage aggregate over the whole catalog."""
+    summary: CatalogSummary = summarize_catalog(_build_catalog())
+
+    assert summary.sensor_identity_count == 1
+    assert summary.platform_profile_count == 1
+    assert summary.vessel_profile_count == 1
+    assert summary.coverage.deployment_count == 2
+    assert summary.coverage.with_platform == 2
+    assert summary.coverage.with_vessel == 2
+    assert not summary.coverage.platform_only
+    assert not summary.coverage.vessel_only
+    assert not summary.unreferenced_sensors
+    assert not summary.curation_gaps
+
+
+def test_summarize_reports_deployments_missing_an_assignment() -> None:
+    """A deployment assigned only one profile is named as such."""
+    catalog: DeploymentCatalog = _build_catalog()
+    catalog = catalog.model_copy(
+        update={"deployment_vessels": catalog.deployment_vessels[:1]}
+    )
+
+    summary: CatalogSummary = summarize_catalog(catalog)
+
+    assert summary.coverage.deployment_count == 2
+    assert summary.coverage.with_platform == 2
+    assert summary.coverage.with_vessel == 1
+    assert summary.coverage.platform_only == ["bbb_20110415_020103"]
+    assert not summary.coverage.vessel_only
+
+
+def test_summarize_lists_profiles_assigned_no_deployment() -> None:
+    """Profiles carry their assignment count, zero included."""
+    catalog: DeploymentCatalog = _build_catalog()
+    catalog = catalog.model_copy(
+        update={
+            "platform_profiles": [
+                *catalog.platform_profiles,
+                CatalogPlatformProfile(
+                    key="sirius_2011",
+                    platform_label="AUV Sirius",
+                    platform_class="SEABED",
+                    platform_operator="ACFR",
+                ),
+            ]
+        }
+    )
+
+    summary: CatalogSummary = summarize_catalog(catalog)
+    counts: dict[str, int] = {
+        assignment.profile_key: assignment.count
+        for assignment in summary.platform_assignments
+    }
+
+    assert counts == {"sirius_2010": 2, "sirius_2011": 0}
+    assert summary.platform_assignments[0].profile_key == "sirius_2010"
+    assert summary.platform_assignments[0].deployment_labels == [
+        "aaa_20100428_020202",
+        "bbb_20110415_020103",
+    ]
+
+
+def test_summarize_reports_unreferenced_sensor_identities() -> None:
+    """A sensor identity no profile mounts is reported as unused."""
+    catalog: DeploymentCatalog = _build_catalog()
+    catalog = catalog.model_copy(
+        update={
+            "sensor_identities": [
+                *catalog.sensor_identities,
+                _sensor_identity(key="usbl_linkquest"),
+            ]
+        }
+    )
+
+    summary: CatalogSummary = summarize_catalog(catalog)
+
+    assert summary.unreferenced_sensors == ["usbl_linkquest"]
+    assert collect_unreferenced_sensors(catalog) == ["usbl_linkquest"]
+
+
+def test_summarize_groups_curation_gaps_by_field() -> None:
+    """Gaps group by field and carry the records they affect."""
+    catalog = DeploymentCatalog(
+        sensor_identities=[_sensor_identity(vendor="")],
+        platform_profiles=[
+            CatalogPlatformProfile(
+                key="sirius_2010",
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="",
+                sensors=[
+                    CatalogProfileSensor(key="RDI", identity="dvl_teledyne"),
+                    CatalogProfileSensor(
+                        key="OAS",
+                        identity="dvl_teledyne",
+                        extrinsics=_extrinsics(),
+                    ),
+                ],
+            )
+        ],
+        vessel_profiles=[CatalogVesselProfile(key="linnaeus", vessel_name="")],
+    )
+
+    summary: CatalogSummary = summarize_catalog(catalog)
+    gaps: dict[str, list[str]] = {
+        gap.field_name: gap.record_keys for gap in summary.curation_gaps
+    }
+
+    assert gaps["sensor_identities.vendor"] == ["dvl_teledyne"]
+    assert gaps["platform_profiles.platform_operator"] == ["sirius_2010"]
+    assert gaps["platform_profiles.sensors.extrinsics"] == ["sirius_2010[RDI]"]
+    assert gaps["vessel_profiles.vessel_name"] == ["linnaeus"]
+    assert "platform_profiles.platform_label" not in gaps
+
+
+def test_summarize_orders_gaps_by_descending_count_then_field() -> None:
+    """Ordering is deterministic so repeated runs read the same."""
+    catalog = DeploymentCatalog(
+        sensor_identities=[
+            _sensor_identity(key="dvl_teledyne", vendor=""),
+            _sensor_identity(key="usbl_linkquest", vendor=""),
+        ],
+        vessel_profiles=[CatalogVesselProfile(key="linnaeus", vessel_name="")],
+    )
+
+    summary: CatalogSummary = summarize_catalog(catalog)
+
+    assert [gap.field_name for gap in summary.curation_gaps] == [
+        "sensor_identities.vendor",
+        "vessel_profiles.vessel_name",
+    ]
+
+
+def test_summarize_accepts_an_empty_catalog() -> None:
+    """An empty catalog summarizes to zeros rather than failing."""
+    summary: CatalogSummary = summarize_catalog(DeploymentCatalog())
+
+    assert summary.sensor_identity_count == 0
+    assert summary.coverage.deployment_count == 0
+    assert not summary.platform_assignments
+    assert not summary.curation_gaps
+
+
+def test_run_summarize_catalog_reads_the_input(tmp_path: Path) -> None:
+    """The task reads the catalog and returns the computed summary."""
+    input_file: Path = tmp_path / "catalog.toml"
+    write_deployment_catalog(input_file, _build_catalog())
+
+    result: SummarizeCatalogResult = run_summarize_catalog(
+        SummarizeCatalogCommand(input_file=input_file)
+    )
+
+    assert result.summary.platform_profile_count == 1
+    assert result.summary.coverage.deployment_count == 2
+
+
+def test_run_summarize_catalog_rejects_a_missing_input(tmp_path: Path) -> None:
+    """A missing input file fails before anything is read."""
+    with pytest.raises(FileNotFoundError):
+        run_summarize_catalog(
+            SummarizeCatalogCommand(input_file=tmp_path / "missing.toml")
+        )
+
+
+def test_cli_summarize_catalog_exits_zero_with_gaps(tmp_path: Path) -> None:
+    """Curation gaps are output, not failure, so the command exits zero."""
+    input_file: Path = tmp_path / "catalog.toml"
+    write_deployment_catalog(
+        input_file,
+        DeploymentCatalog(
+            sensor_identities=[_sensor_identity(vendor="")],
+            vessel_profiles=[
+                CatalogVesselProfile(key="linnaeus", vessel_name="")
+            ],
+        ),
+    )
+
+    runner = CliRunner()
+    result: Result = runner.invoke(
+        cli,
+        [
+            "deployment",
+            "summarize-catalog",
+            "--input",
+            str(input_file),
+            "--verbose",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
Closes #192.

Adds a read-only task and CLI command that summarizes a curated deployment catalog in the terminal, the sibling of the descriptor summary in #191.

## Changes

- `deployment/catalog_summary.py` — `CatalogSummary`, `AssignmentCoverage`, `ProfileAssignment`, and `CatalogCurationGap`, plus `summarize_catalog` and the two collectors it composes. Aggregation lives beside the catalog types so it is testable without the CLI.
- `tasks/deployment_catalog/summary_types.py` — `SummarizeCatalogCommand` and `SummarizeCatalogResult`.
- `tasks/deployment_catalog/summary_runner.py` — `run_summarize_catalog` and `log_summary`, rendering the summary as `rich` tables.
- `cli/deployment` — `afft deployment summarize-catalog --input <catalog.toml> [--verbose]`.
- `tests/test_summarize_catalog.py` — 10 tests over the aggregation, the task, and the command.

Referential integrity is left to `DeploymentCatalog.validate_catalog`; what the summary reports is curation progress — record counts, assignment coverage, profiles assigned no deployment, sensor identities nothing references, and curated fields still empty.

## Deviations from the issue

- **Assignment coverage is measured over the union of the two assignment tables.** The issue asks for deployments "with neither" profile, but a catalog names a deployment only through `deployment_platforms` and `deployment_vessels`, so a deployment assigned neither has no row anywhere and that count is structurally always zero. Coverage instead reports the deployments the catalog names, how many carry each profile, and the platform-only and vessel-only labels. If the count is wanted later, it comes back as an optional `--descriptors` path without changing the rest.
- **An empty catalog summarizes to zeros** rather than raising, unlike `summarize_descriptors`. A scaffolded but unpopulated catalog is a legitimate thing to point the command at.
- **The collectors are named `collect_catalog_curation_gaps` and `collect_unreferenced_sensors`.** `afft.deployment` is a flat namespace and `collect_curation_gaps` is already taken by `descriptor_summary`.

## Verification

`ruff format --check`, `ruff check`, `mypy --strict`, and the full test suite (222 passed) are clean.

Against `data/deployment_catalog_v1.toml` the command reports 21 sensor identities, 9 platform profiles, and 18 vessel profiles over 52 deployments — one of them, `qdchdmy1_20120501_071203`, assigned a platform profile but no vessel profile — with the largest curation gap being the 135 platform profile sensors that carry no extrinsics. `--verbose` lists the offending keys under each.
