### PR TITLE
Split the USBL transponder and transceiver sensor identities

### DIFF
--- a/data/deployment_catalog_v1_all.toml
+++ b/data/deployment_catalog_v1_all.toml
@@ -75,24 +75,31 @@ product = ""
 type = "gnss"
 
 [[sensor_identities]]
-key = "usbl_linkquest"
-label = "LinkQuest TrackLink 1500HA USBL"
+key = "usbl_linkquest_transponder"
+label = "LinkQuest TrackLink 1500HA USBL transponder"
 vendor = "LinkQuest"
 product = "TrackLink 1500HA"
 type = "usbl"
 
 [[sensor_identities]]
-key = "usbl_evologics"
-label = "EvoLogics S2C R 18/34 USBL"
+key = "usbl_linkquest_transceiver"
+label = "LinkQuest TrackLink 1500HA USBL transceiver"
+vendor = "LinkQuest"
+product = "TrackLink 1500HA"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_evologics_transponder"
+label = "EvoLogics S2C R 18/34 USBL transponder"
 vendor = "EvoLogics"
 product = "S2C R 18/34"
 type = "usbl"
 
 [[sensor_identities]]
-key = "usbl_unrecorded"
-label = "USBL transceiver of unrecorded make"
-vendor = ""
-product = ""
+key = "usbl_evologics_transceiver"
+label = "EvoLogics S2C R 18/34 USBL transceiver"
+vendor = "EvoLogics"
+product = "S2C R 18/34"
 type = "usbl"
 
 [[sensor_identities]]
@@ -137,7 +144,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -157,7 +164,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -177,7 +184,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -200,7 +207,7 @@ sensors = [
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
     { key = "IMU", identity = "imu" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -222,7 +229,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -244,7 +251,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -265,7 +272,7 @@ sensors = [
     { key = "BATT2", identity = "battery_pack" },
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "GPS", identity = "gnss_ublox" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
@@ -287,7 +294,7 @@ sensors = [
     { key = "BATT2", identity = "battery_pack" },
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "GPS", identity = "gnss_ublox" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
@@ -311,7 +318,7 @@ platform_operator = "ACFR"
 sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "GPSD", identity = "gnss_ublox" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
@@ -329,133 +336,133 @@ sensors = [
 key = "200906_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201004_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201006_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
 ]
 
 [[vessel_profiles]]
 key = "201010_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
 ]
 
 [[vessel_profiles]]
 key = "201102_rv_cape_ferguson"
 vessel_name = "RV Cape Ferguson"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
 ]
 
 [[vessel_profiles]]
 key = "201104_rv_naturaliste"
 vessel_name = "RV Naturaliste"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
 ]
 
 [[vessel_profiles]]
 key = "201106_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
 ]
 
 [[vessel_profiles]]
 key = "201108_solander"
 vessel_name = "Solander"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
 ]
 
 [[vessel_profiles]]
 key = "201204_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
 ]
 
 [[vessel_profiles]]
 key = "201205_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
 ]
 
 [[vessel_profiles]]
 key = "201210_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
 ]
 
 [[vessel_profiles]]
 key = "201304_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201306_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
 ]
 
 [[vessel_profiles]]
 key = "201310_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
 ]
 
 [[vessel_profiles]]
 key = "201403_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
 ]
 
 [[vessel_profiles]]
 key = "201406_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
 ]
 
 [[vessel_profiles]]
 key = "201502_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
 ]
 
 [[vessel_profiles]]
 key = "201705_silver_streak"
 vessel_name = "Silver Streak"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
 ]
 
 [[vessel_profiles]]
 key = "202102_poppag"
 vessel_name = "PoppaG"
 sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_catalog_v1_subset.toml
+++ b/data/deployment_catalog_v1_subset.toml
@@ -68,24 +68,31 @@ product = ""
 type = "gnss"
 
 [[sensor_identities]]
-key = "usbl_linkquest"
-label = "LinkQuest TrackLink 1500HA USBL"
+key = "usbl_linkquest_transponder"
+label = "LinkQuest TrackLink 1500HA USBL transponder"
 vendor = "LinkQuest"
 product = "TrackLink 1500HA"
 type = "usbl"
 
 [[sensor_identities]]
-key = "usbl_evologics"
-label = "EvoLogics S2C R 18/34 USBL"
+key = "usbl_linkquest_transceiver"
+label = "LinkQuest TrackLink 1500HA USBL transceiver"
+vendor = "LinkQuest"
+product = "TrackLink 1500HA"
+type = "usbl"
+
+[[sensor_identities]]
+key = "usbl_evologics_transponder"
+label = "EvoLogics S2C R 18/34 USBL transponder"
 vendor = "EvoLogics"
 product = "S2C R 18/34"
 type = "usbl"
 
 [[sensor_identities]]
-key = "usbl_unrecorded"
-label = "USBL transceiver of unrecorded make"
-vendor = ""
-product = ""
+key = "usbl_evologics_transceiver"
+label = "EvoLogics S2C R 18/34 USBL transceiver"
+vendor = "EvoLogics"
+product = "S2C R 18/34"
 type = "usbl"
 
 [[sensor_identities]]
@@ -130,7 +137,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -150,7 +157,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -170,7 +177,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest" },
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -193,7 +200,7 @@ sensors = [
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
     { key = "IMU", identity = "imu" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -243,7 +250,7 @@ identity = "gnss_ublox"
 
 [[platform_profiles.sensors]]
 key = "LQMODEM"
-identity = "usbl_linkquest"
+identity = "usbl_linkquest_transponder"
 
 [platform_profiles.sensors.extrinsics]
 locx = -1.27
@@ -317,7 +324,7 @@ sensors = [
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
     { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
     { key = "SEABIRD", identity = "ctd_seabird" },
@@ -338,7 +345,7 @@ sensors = [
     { key = "BATT2", identity = "battery_pack" },
     { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
     { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "GPS", identity = "gnss_ublox" },
     { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
     { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
@@ -357,133 +364,133 @@ sensors = [
 key = "200906_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201004_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201006_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
 ]
 
 [[vessel_profiles]]
 key = "201010_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
 ]
 
 [[vessel_profiles]]
 key = "201102_rv_cape_ferguson"
 vessel_name = "RV Cape Ferguson"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
 ]
 
 [[vessel_profiles]]
 key = "201104_rv_naturaliste"
 vessel_name = "RV Naturaliste"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
 ]
 
 [[vessel_profiles]]
 key = "201106_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
 ]
 
 [[vessel_profiles]]
 key = "201108_solander"
 vessel_name = "Solander"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
 ]
 
 [[vessel_profiles]]
 key = "201204_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
 ]
 
 [[vessel_profiles]]
 key = "201205_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
 ]
 
 [[vessel_profiles]]
 key = "201210_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
 ]
 
 [[vessel_profiles]]
 key = "201304_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201306_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
 ]
 
 [[vessel_profiles]]
 key = "201310_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
 ]
 
 [[vessel_profiles]]
 key = "201403_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
 ]
 
 [[vessel_profiles]]
 key = "201406_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
 ]
 
 [[vessel_profiles]]
 key = "201502_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
 ]
 
 [[vessel_profiles]]
 key = "201705_silver_streak"
 vessel_name = "Silver Streak"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
 ]
 
 [[vessel_profiles]]
 key = "202102_poppag"
 vessel_name = "PoppaG"
 sensors = [
-    { key = "USBL", identity = "usbl_unrecorded", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_descriptors_v1_all_enriched.toml
+++ b/data/deployment_descriptors_v1_all_enriched.toml
@@ -152,7 +152,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -208,7 +208,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -363,7 +363,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -419,7 +419,7 @@ vessel_name = "RV Cape Ferguson"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -592,7 +592,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -662,7 +662,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -818,7 +818,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -881,7 +881,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1085,7 +1085,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -1118,7 +1118,7 @@ vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -1272,7 +1272,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1328,7 +1328,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1499,7 +1499,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1569,7 +1569,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1725,7 +1725,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1788,7 +1788,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1953,7 +1953,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -1986,9 +1986,9 @@ vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -9.4
 extrinsics.locy = -3.72
@@ -2144,7 +2144,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2200,7 +2200,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2359,7 +2359,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2415,7 +2415,7 @@ vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2588,7 +2588,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2658,7 +2658,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2816,7 +2816,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2879,7 +2879,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3059,7 +3059,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3122,7 +3122,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3327,7 +3327,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -3360,7 +3360,7 @@ vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -3527,7 +3527,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -3560,9 +3560,9 @@ vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -9.4
 extrinsics.locy = -3.72
@@ -3714,7 +3714,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3770,7 +3770,7 @@ vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3938,7 +3938,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4008,7 +4008,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4164,7 +4164,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4227,7 +4227,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4404,7 +4404,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4467,7 +4467,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -4670,7 +4670,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -4703,7 +4703,7 @@ vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -4881,7 +4881,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -4914,9 +4914,9 @@ vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -9.4
 extrinsics.locy = -3.72
@@ -5074,7 +5074,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -5130,7 +5130,7 @@ vessel_name = "Solander"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -5347,7 +5347,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -5379,9 +5379,9 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -11.062
 extrinsics.locy = -6.656
@@ -5588,7 +5588,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -5620,9 +5620,9 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -11.062
 extrinsics.locy = -6.656
@@ -5827,7 +5827,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -5859,9 +5859,9 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "USBL transceiver of unrecorded make"
-identity.vendor = ""
-identity.product = ""
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
+identity.vendor = "EvoLogics"
+identity.product = "S2C R 18/34"
 identity.type = "usbl"
 extrinsics.locx = -11.062
 extrinsics.locy = -6.656
@@ -6016,7 +6016,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6072,7 +6072,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6246,7 +6246,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6316,7 +6316,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6493,7 +6493,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6549,7 +6549,7 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6705,7 +6705,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6761,7 +6761,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -6932,7 +6932,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7002,7 +7002,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7180,7 +7180,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7236,7 +7236,7 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7390,7 +7390,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7446,7 +7446,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7617,7 +7617,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7680,7 +7680,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7860,7 +7860,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -7916,7 +7916,7 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8049,7 +8049,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8123,7 +8123,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8256,7 +8256,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8330,7 +8330,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8483,7 +8483,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8539,7 +8539,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8710,7 +8710,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8773,7 +8773,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8908,7 +8908,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -8982,7 +8982,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9115,7 +9115,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9189,7 +9189,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9341,7 +9341,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9397,7 +9397,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9571,7 +9571,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9634,7 +9634,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9788,7 +9788,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -9844,7 +9844,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10001,7 +10001,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10064,7 +10064,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10230,7 +10230,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10286,7 +10286,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10440,7 +10440,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10496,7 +10496,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10653,7 +10653,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10716,7 +10716,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10882,7 +10882,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -10938,7 +10938,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11092,7 +11092,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11148,7 +11148,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11305,7 +11305,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11368,7 +11368,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11534,7 +11534,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -11590,7 +11590,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"

--- a/data/deployment_descriptors_v1_subset_enriched.toml
+++ b/data/deployment_descriptors_v1_subset_enriched.toml
@@ -145,7 +145,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -201,7 +201,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -360,7 +360,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -416,7 +416,7 @@ vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -589,7 +589,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -659,7 +659,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -817,7 +817,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -880,7 +880,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1034,7 +1034,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1090,7 +1090,7 @@ vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1258,7 +1258,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1328,7 +1328,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1484,7 +1484,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1547,7 +1547,7 @@ vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1750,7 +1750,7 @@ key = "MICRON"
 
 [[deployments.platform.sensors]]
 key = "EVOLOGICS"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -1783,7 +1783,7 @@ vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "EvoLogics S2C R 18/34 USBL"
+identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
 identity.type = "usbl"
@@ -1939,7 +1939,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -1995,7 +1995,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2166,7 +2166,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2236,7 +2236,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2414,7 +2414,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2470,7 +2470,7 @@ vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2605,7 +2605,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2679,7 +2679,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2831,7 +2831,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -2887,7 +2887,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3061,7 +3061,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3124,7 +3124,7 @@ vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3278,7 +3278,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3334,7 +3334,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3491,7 +3491,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3554,7 +3554,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3720,7 +3720,7 @@ identity.type = "battery"
 
 [[deployments.platform.sensors]]
 key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
@@ -3776,7 +3776,7 @@ vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
 key = "USBL"
-identity.label = "LinkQuest TrackLink 1500HA USBL"
+identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"

--- a/tests/test_deployment_catalog.py
+++ b/tests/test_deployment_catalog.py
@@ -27,9 +27,16 @@ DVL_SENSOR: CatalogSensorIdentity = CatalogSensorIdentity(
     product="Work Horse Navigator",
     type="dvl",
 )
-USBL_SENSOR: CatalogSensorIdentity = CatalogSensorIdentity(
-    key="usbl_linkquest",
-    label="LinkQuest TrackLink 1500HA USBL",
+USBL_TRANSPONDER: CatalogSensorIdentity = CatalogSensorIdentity(
+    key="usbl_linkquest_transponder",
+    label="LinkQuest TrackLink 1500HA USBL transponder",
+    vendor="LinkQuest",
+    product="TrackLink 1500HA",
+    type="usbl",
+)
+USBL_TRANSCEIVER: CatalogSensorIdentity = CatalogSensorIdentity(
+    key="usbl_linkquest_transceiver",
+    label="LinkQuest TrackLink 1500HA USBL transceiver",
     vendor="LinkQuest",
     product="TrackLink 1500HA",
     type="usbl",
@@ -39,7 +46,7 @@ USBL_SENSOR: CatalogSensorIdentity = CatalogSensorIdentity(
 def _build_catalog() -> DeploymentCatalog:
     """Builds a catalog covering one platform and one vessel profile."""
     return DeploymentCatalog(
-        sensor_identities=[DVL_SENSOR, USBL_SENSOR],
+        sensor_identities=[DVL_SENSOR, USBL_TRANSPONDER, USBL_TRANSCEIVER],
         platform_profiles=[
             CatalogPlatformProfile(
                 key="2010_auv_sirius",
@@ -60,7 +67,7 @@ def _build_catalog() -> DeploymentCatalog:
                         ),
                     ),
                     CatalogProfileSensor(
-                        key="LQMODEM", identity="usbl_linkquest"
+                        key="LQMODEM", identity="usbl_linkquest_transponder"
                     ),
                 ],
             )
@@ -72,7 +79,7 @@ def _build_catalog() -> DeploymentCatalog:
                 sensors=[
                     CatalogProfileSensor(
                         key="USBL",
-                        identity="usbl_linkquest",
+                        identity="usbl_linkquest_transceiver",
                         extrinsics=CatalogSensorExtrinsics(
                             locx=-5.715,
                             locy=-1.258,

--- a/tests/test_deployment_enrichment.py
+++ b/tests/test_deployment_enrichment.py
@@ -102,8 +102,8 @@ def _build_catalog() -> DeploymentCatalog:
                 type="multibeam_sonar",
             ),
             CatalogSensorIdentity(
-                key="usbl_evologics",
-                label="EvoLogics S2CR USBL modem",
+                key="usbl_evologics_transceiver",
+                label="EvoLogics S2CR USBL transceiver",
                 vendor="EvoLogics",
                 product="S2CR 18/34",
                 type="usbl",
@@ -146,7 +146,7 @@ def _build_catalog() -> DeploymentCatalog:
                 sensors=[
                     CatalogProfileSensor(
                         key="USBL",
-                        identity="usbl_evologics",
+                        identity="usbl_evologics_transceiver",
                         extrinsics=CatalogSensorExtrinsics(
                             locx=1.2,
                             locy=-0.4,

--- a/tests/test_summarize_catalog.py
+++ b/tests/test_summarize_catalog.py
@@ -164,15 +164,17 @@ def test_summarize_reports_unreferenced_sensor_identities() -> None:
         update={
             "sensor_identities": [
                 *catalog.sensor_identities,
-                _sensor_identity(key="usbl_linkquest"),
+                _sensor_identity(key="usbl_linkquest_transceiver"),
             ]
         }
     )
 
     summary: CatalogSummary = summarize_catalog(catalog)
 
-    assert summary.unreferenced_sensors == ["usbl_linkquest"]
-    assert collect_unreferenced_sensors(catalog) == ["usbl_linkquest"]
+    assert summary.unreferenced_sensors == ["usbl_linkquest_transceiver"]
+    assert collect_unreferenced_sensors(catalog) == [
+        "usbl_linkquest_transceiver"
+    ]
 
 
 def test_summarize_groups_curation_gaps_by_field() -> None:
@@ -215,7 +217,7 @@ def test_summarize_orders_gaps_by_descending_count_then_field() -> None:
     catalog = DeploymentCatalog(
         sensor_identities=[
             _sensor_identity(key="dvl_teledyne", vendor=""),
-            _sensor_identity(key="usbl_linkquest", vendor=""),
+            _sensor_identity(key="usbl_linkquest_transceiver", vendor=""),
         ],
         vessel_profiles=[CatalogVesselProfile(key="linnaeus", vessel_name="")],
     )


### PR DESCRIPTION
Closes #202.

A USBL system is two physically separate units — a transponder on the platform and a transceiver on the vessel — but the catalog described each system with a single identity record referenced from both. One record therefore carried the label, vendor, product, and type of two different units, whose mounting poses are stated in different reference frames.

## Changes

- Split `usbl_linkquest` and `usbl_evologics` into transponder and transceiver identity records.
- Repoint the platform `LQMODEM` / `EVOLOGICS` slots to the transponder identities and the vessel `USBL` slots to the transceiver identities, in `deployment_catalog_v1_all.toml` and `deployment_catalog_v1_subset.toml`.
- Reattribute the two vessel profiles carrying `usbl_unrecorded` to `usbl_evologics_transceiver`, and drop the now-unreferenced record.
- Update the catalog, summary, and enrichment test fixtures that carried the old identity keys — the catalog fixture mirrored the conflation, using one identity for both `LQMODEM` and vessel `USBL`.
- Re-enrich both enriched descriptor files.

Roster keys are unchanged. The vessel has one `USBL` slot whichever unit is installed, and which unit it was is exactly what the identity records.

## On the reattribution

The two vessel profiles carrying `usbl_unrecorded` — `201502_tasmania_bluefin` and `202102_poppag`, six deployments between them — both pair with platform profiles carrying an EvoLogics modem. Across all 52 deployments the platform modem and the vessel transceiver correlate without exception, and USBL ranging requires a matched pair: a LinkQuest transceiver cannot interrogate an EvoLogics transponder.

**This is inference from modem pairing, not a recovered record**, and it is the one part of the diff that would be wrong if the reasoning is. It could not be confirmed against raw data, since no 2015 or 2021 deployment is present in the local data set.

## Verification

- Both catalogs validate through `read_deployment_catalog`, with no unreferenced identities.
- Across all 52 deployments, every vessel transceiver pairs with a platform modem of the same system — 43 LinkQuest, 9 EvoLogics, zero mismatches.
- In the enriched descriptors, every platform-side USBL identity ends in `transponder` and every vessel-side one in `transceiver`.
- The descriptor diff is 150 insertions against 150 deletions, touching only `identity.label` (138) plus `identity.vendor` and `identity.product` (6 each, the reattributed deployments). Extrinsics, types, and every non-USBL sensor are untouched.
- 214 tests pass; ruff check, ruff format, and mypy are clean.

## Follow-on

`vendor` and `product` are carried across unchanged from the system record, so both halves still name the system rather than the unit. Correcting them to the actual transponder and transceiver model numbers needs a source this change does not have; the split is what unblocks it.
