### PR TITLE
Curated sensor key vocabulary and topic mapping in the catalog

### DIFF
--- a/data/deployment_catalog_v1_all.toml
+++ b/data/deployment_catalog_v1_all.toml
@@ -6,9 +6,11 @@
 #
 # Platform profiles are curated at one per calendar year, from the AUV pose
 # families in the deployment localizer configs; no year spans two pose
-# configurations. The family-to-key mapping is dvl -> RDI,
-# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
-# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
+# configurations. The family-to-key mapping is dvl ->
+# dvl_teledyne_navigator, stereo -> the camera of the era, deltat ->
+# multibeam_deltat, depth_sensor -> pressure_parosci, and position2d ->
+# usbl_linkquest_transponder through 2014 and usbl_evologics_transponder from
+# 2017. The localizer's sonar family is
 # excluded as an unmeasured placeholder for a device nothing consumes, and
 # nav_frame is not a sensor. PAROSCI carries its pose as written, including the
 # locx the localizer config flags for measurement.
@@ -17,9 +19,17 @@
 # config/deployment_configs_all.toml and cover all 52 deployments. The platform
 # side also covers all 52, every profile carrying its mounting poses.
 #
-# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
-# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
-# Roster keys with no entry here are simply left unenriched.
+# A profile sensor is keyed on the sensor_identities record of the unit fitted
+# to that slot, so the two tables share one vocabulary, and message_topics
+# carries the mapping from RAW telemetry topics to the sensor that emits them.
+# Enrichment writes a profile's roster into the descriptor whole, so a profile
+# states the vehicle as curated rather than as the system config labelled it.
+#
+# The thrusters, the battery packs, the MICRON / OAS obstacle avoidance sonar
+# and the IMU are deliberately unmounted: nothing downstream consumes them.
+# Their hardware keeps a sensor_identities record so it stays described, except
+# the IMU, which no deployment logs a topic for. MP_INPUT is not a sensor and
+# has no record at all.
 
 # --------------------------------------------------------------------------------------
 # Sensor identities
@@ -40,7 +50,7 @@ product = "Manta G-1236"
 type = "stereo_camera"
 
 [[sensor_identities]]
-key = "dvl_teledyne"
+key = "dvl_teledyne_navigator"
 label = "Teledyne RDI Work Horse Navigator DVL"
 vendor = "Teledyne RDI"
 product = "Work Horse Navigator"
@@ -110,11 +120,25 @@ product = ""
 type = "multibeam_sonar"
 
 [[sensor_identities]]
-key = "imu"
-label = "Inertial measurement unit"
+key = "oxygen_aanderaa"
+label = "Aanderaa 4319 oxygen optode"
+vendor = "Aanderaa"
+product = "4319"
+type = "oxygen"
+
+[[sensor_identities]]
+key = "sonar_micron"
+label = "Tritech Micron scanning sonar"
+vendor = "Tritech"
+product = "Micron"
+type = "sonar"
+
+[[sensor_identities]]
+key = "sonar_obstacle_avoidance"
+label = "Obstacle avoidance sonar"
 vendor = ""
 product = ""
-type = "imu"
+type = "sonar"
 
 [[sensor_identities]]
 key = "thruster"
@@ -140,18 +164,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -160,18 +180,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -180,18 +196,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -200,21 +212,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "IMU", identity = "imu" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -223,20 +228,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -245,20 +244,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -267,20 +260,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_evologics_transponder", message_topics = ["EVOLOGICS_FIX"], extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -289,26 +276,21 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_evologics_transponder", message_topics = ["EVOLOGICS_FIX"], extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
-# The 2021 syscfg has VIS, SEABIRD and the battery channels commented out, so
-# SEABIRD and the batteries are absent here. The VIS slot is kept, carrying the
-# Manta the vehicle flew by then and the stereo pose from the localizer config;
-# it stays unenriched until a roster names the camera.
+# The 2021 syscfg has the camera, the CTD and the battery channels commented
+# out, so the CTD is absent here. The camera is kept — the deployments log VIS
+# throughout — carrying the Manta the vehicle flew by then and the stereo pose
+# from the localizer config. The oxygen optode is the reverse case: the syscfg
+# names no channel for it, but all three deployments log AANDERAA_4319.
 
 [[platform_profiles]]
 key = "2021_auv_sirius"
@@ -316,16 +298,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "GPSD", identity = "gnss_ublox" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_manta", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_manta", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "oxygen_aanderaa", message_topics = ["AANDERAA_4319"] },
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_evologics_transponder", message_topics = ["EVOLOGICS_FIX"], extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 # --------------------------------------------------------------------------------------
@@ -336,133 +316,133 @@ sensors = [
 key = "200906_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201004_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201006_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
 ]
 
 [[vessel_profiles]]
 key = "201010_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
 ]
 
 [[vessel_profiles]]
 key = "201102_rv_cape_ferguson"
 vessel_name = "RV Cape Ferguson"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
 ]
 
 [[vessel_profiles]]
 key = "201104_rv_naturaliste"
 vessel_name = "RV Naturaliste"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
 ]
 
 [[vessel_profiles]]
 key = "201106_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
 ]
 
 [[vessel_profiles]]
 key = "201108_solander"
 vessel_name = "Solander"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
 ]
 
 [[vessel_profiles]]
 key = "201204_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
 ]
 
 [[vessel_profiles]]
 key = "201205_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
 ]
 
 [[vessel_profiles]]
 key = "201210_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
 ]
 
 [[vessel_profiles]]
 key = "201304_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201306_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
 ]
 
 [[vessel_profiles]]
 key = "201310_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
 ]
 
 [[vessel_profiles]]
 key = "201403_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
 ]
 
 [[vessel_profiles]]
 key = "201406_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
 ]
 
 [[vessel_profiles]]
 key = "201502_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
 ]
 
 [[vessel_profiles]]
 key = "201705_silver_streak"
 vessel_name = "Silver Streak"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
 ]
 
 [[vessel_profiles]]
 key = "202102_poppag"
 vessel_name = "PoppaG"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_catalog_v1_subset.toml
+++ b/data/deployment_catalog_v1_subset.toml
@@ -6,9 +6,11 @@
 #
 # Platform profiles are curated at one per calendar year, from the AUV pose
 # families of the 17 deployments whose localizer configs are on disk; no year
-# spans two pose configurations. The family-to-key mapping is dvl -> RDI,
-# stereo -> VIS, deltat -> DELTA_T, depth_sensor -> PAROSCI, and position2d ->
-# LQMODEM through 2014 and EVOLOGICS from 2017. The localizer's sonar family is
+# spans two pose configurations. The family-to-key mapping is dvl ->
+# dvl_teledyne_navigator, stereo -> the camera of the era, deltat ->
+# multibeam_deltat, depth_sensor -> pressure_parosci, and position2d ->
+# usbl_linkquest_transponder through 2014 and usbl_evologics_transponder from
+# 2017. The localizer's sonar family is
 # excluded as an unmeasured placeholder for a device nothing consumes, and
 # nav_frame is not a sensor. PAROSCI carries its pose as written, including the
 # locx the localizer config flags for measurement.
@@ -17,9 +19,17 @@
 # config/deployment_configs_all.toml and cover all 52 deployments; the platform
 # side covers the 17 on disk, and the rest follow when the archive does.
 #
-# The OAS / MICRON obstacle avoidance sonar and MP_INPUT are deliberately
-# uncurated: nothing downstream consumes them, and MP_INPUT is not a sensor.
-# Roster keys with no entry here are simply left unenriched.
+# A profile sensor is keyed on the sensor_identities record of the unit fitted
+# to that slot, so the two tables share one vocabulary, and message_topics
+# carries the mapping from RAW telemetry topics to the sensor that emits them.
+# Enrichment writes a profile's roster into the descriptor whole, so a profile
+# states the vehicle as curated rather than as the system config labelled it.
+#
+# The thrusters, the battery packs, the MICRON / OAS obstacle avoidance sonar
+# and the IMU are deliberately unmounted: nothing downstream consumes them.
+# Their hardware keeps a sensor_identities record so it stays described, except
+# the IMU, which no deployment logs a topic for. MP_INPUT is not a sensor and
+# has no record at all.
 
 # --------------------------------------------------------------------------------------
 # Sensor identities
@@ -33,7 +43,7 @@ product = "Prosilica GC1380"
 type = "stereo_camera"
 
 [[sensor_identities]]
-key = "dvl_teledyne"
+key = "dvl_teledyne_navigator"
 label = "Teledyne RDI Work Horse Navigator DVL"
 vendor = "Teledyne RDI"
 product = "Work Horse Navigator"
@@ -103,11 +113,18 @@ product = ""
 type = "multibeam_sonar"
 
 [[sensor_identities]]
-key = "imu"
-label = "Inertial measurement unit"
+key = "sonar_micron"
+label = "Tritech Micron scanning sonar"
+vendor = "Tritech"
+product = "Micron"
+type = "sonar"
+
+[[sensor_identities]]
+key = "sonar_obstacle_avoidance"
+label = "Obstacle avoidance sonar"
 vendor = ""
 product = ""
-type = "imu"
+type = "sonar"
 
 [[sensor_identities]]
 key = "thruster"
@@ -133,18 +150,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.55, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -153,18 +166,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -173,18 +182,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = 0.0076, roty = 0.084, rotz = -3.125 } },  # rotation in degrees: 0.435, 4.813, -179.049
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"] },
 ]
 
 [[platform_profiles]]
@@ -193,21 +198,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "IMU", identity = "imu" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -215,102 +213,16 @@ key = "2013_auv_sirius"
 platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
-
-[[platform_profiles.sensors]]
-key = "BATT0"
-identity = "battery_pack"
-
-[[platform_profiles.sensors]]
-key = "BATT1"
-identity = "battery_pack"
-
-[[platform_profiles.sensors]]
-key = "BATT2"
-identity = "battery_pack"
-
-[[platform_profiles.sensors]]
-key = "DELTA_T"
-identity = "multibeam_deltat"
-
-[platform_profiles.sensors.extrinsics]
-locx = 0.588
-locy = 0.25
-locz = 0.048
-rotx = -0.0076  # -0.435 deg
-roty = 0.084  # 4.813 deg
-rotz = 0.0
-
-[[platform_profiles.sensors]]
-key = "ECOPUCK"
-identity = "ecopuck_wetlabs"
-
-[[platform_profiles.sensors]]
-key = "GPS"
-identity = "gnss_ublox"
-
-[[platform_profiles.sensors]]
-key = "LQMODEM"
-identity = "usbl_linkquest_transponder"
-
-[platform_profiles.sensors.extrinsics]
-locx = -1.27
-locy = 0.0
-locz = -0.9
-rotx = 0.0
-roty = 0.0
-rotz = 0.0
-
-[[platform_profiles.sensors]]
-key = "PAROSCI"
-identity = "pressure_parosci"
-
-[platform_profiles.sensors.extrinsics]
-locx = 0.4
-locy = 0.0
-locz = -0.23
-rotx = 0.0
-roty = 0.0
-rotz = 0.0
-
-[[platform_profiles.sensors]]
-key = "RDI"
-identity = "dvl_teledyne"
-
-[platform_profiles.sensors.extrinsics]
-locx = 0.0
-locy = 0.0
-locz = 0.0
-rotx = 0.0
-roty = 3.1416  # 180.000 deg
-rotz = -1.5708  # -90.000 deg
-
-[[platform_profiles.sensors]]
-key = "SEABIRD"
-identity = "ctd_seabird"
-
-[[platform_profiles.sensors]]
-key = "THR_PORT"
-identity = "thruster"
-
-[[platform_profiles.sensors]]
-key = "THR_STBD"
-identity = "thruster"
-
-[[platform_profiles.sensors]]
-key = "THR_VERT"
-identity = "thruster"
-
-[[platform_profiles.sensors]]
-key = "VIS"
-identity = "camera_avt_prosilica"
-
-[platform_profiles.sensors.extrinsics]
-locx = 0.82
-locy = -0.035  # half of the ~0.07 m stereo baseline
-locz = 0.0
-rotx = -0.0373  # -2.137 deg
-roty = -0.0065  # -0.372 deg
-rotz = 1.5488  # 88.740 deg
+sensors = [
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+]
 
 [[platform_profiles]]
 key = "2014_auv_sirius"
@@ -318,20 +230,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "LQMODEM", identity = "usbl_linkquest_transponder", extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transponder", message_topics = ["LQMODEM"], extrinsics = { locx = -1.27, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[platform_profiles]]
@@ -340,20 +246,14 @@ platform_label = "AUV Sirius"
 platform_class = "SEABED"
 platform_operator = "ACFR"
 sensors = [
-    { key = "BATT0", identity = "battery_pack" },
-    { key = "BATT1", identity = "battery_pack" },
-    { key = "BATT2", identity = "battery_pack" },
-    { key = "DELTA_T", identity = "multibeam_deltat", extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
-    { key = "ECOPUCK", identity = "ecopuck_wetlabs" },
-    { key = "EVOLOGICS", identity = "usbl_evologics_transponder", extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "GPS", identity = "gnss_ublox" },
-    { key = "PAROSCI", identity = "pressure_parosci", extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
-    { key = "RDI", identity = "dvl_teledyne", extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
-    { key = "SEABIRD", identity = "ctd_seabird" },
-    { key = "THR_PORT", identity = "thruster" },
-    { key = "THR_STBD", identity = "thruster" },
-    { key = "THR_VERT", identity = "thruster" },
-    { key = "VIS", identity = "camera_avt_prosilica", extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "camera_avt_prosilica", message_topics = ["VIS"], extrinsics = { locx = 0.82, locy = -0.035, locz = 0.0, rotx = -0.0373, roty = -0.0065, rotz = 1.5488 } },  # rotation in degrees: -2.137, -0.372, 88.740; locy: half of the ~0.07 m stereo baseline
+    { key = "ctd_seabird", message_topics = ["SEABIRD"] },
+    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { locx = 0.0, locy = 0.0, locz = 0.0, rotx = 0.0, roty = 3.1416, rotz = -1.5708 } },  # rotation in degrees: 0.000, 180.000, -90.000
+    { key = "ecopuck_wetlabs", message_topics = ["ECOPUCK"] },
+    { key = "gnss_ublox", message_topics = ["GPS_RMC", "GPS_GSV"] },
+    { key = "multibeam_deltat", message_topics = [], extrinsics = { locx = 0.588, locy = 0.25, locz = 0.048, rotx = -0.0076, roty = 0.084, rotz = 0.0 } },  # rotation in degrees: -0.435, 4.813, 0.000
+    { key = "pressure_parosci", message_topics = ["PAROSCI"], extrinsics = { locx = 0.4, locy = 0.0, locz = -0.23, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_evologics_transponder", message_topics = ["EVOLOGICS_FIX"], extrinsics = { locx = 0.0, locy = 0.0, locz = -0.9, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 # --------------------------------------------------------------------------------------
@@ -364,133 +264,133 @@ sensors = [
 key = "200906_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 0.53, locy = 4.33, locz = 3.29, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201004_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.715, locy = -1.258, locz = 1.352, rotx = 0.3316, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 18.999, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201006_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 1.21, locy = 2.97, locz = 2.27, rotx = -0.5058, roty = -0.0042, rotz = 0.3138 } },  # rotation in degrees: -28.980, -0.241, 17.979
 ]
 
 [[vessel_profiles]]
 key = "201010_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -4.46, locy = -4.826, locz = 2.48, rotx = 0.5084, roty = -0.0622, rotz = -0.0509 } },  # rotation in degrees: 29.129, -3.564, -2.916
 ]
 
 [[vessel_profiles]]
 key = "201102_rv_cape_ferguson"
 vessel_name = "RV Cape Ferguson"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -2.69, locy = -0.221, locz = 5.555, rotx = 0.5389, roty = -0.0016, rotz = -0.0106 } },  # rotation in degrees: 30.877, -0.092, -0.607
 ]
 
 [[vessel_profiles]]
 key = "201104_rv_naturaliste"
 vessel_name = "RV Naturaliste"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.21, locy = -3.34, locz = 3.14, rotx = 0.525, roty = -0.0007, rotz = 0.0375 } },  # rotation in degrees: 30.080, -0.040, 2.149
 ]
 
 [[vessel_profiles]]
 key = "201106_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 1.404, locy = 4.412, locz = 4.534, rotx = -0.5409, roty = -0.0605, rotz = -0.24 } },  # rotation in degrees: -30.991, -3.466, -13.751
 ]
 
 [[vessel_profiles]]
 key = "201108_solander"
 vessel_name = "Solander"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -19.057, locy = 3.18, locz = 4.88, rotx = -0.5117, roty = 0.041, rotz = -0.0609 } },  # rotation in degrees: -29.318, 2.349, -3.489
 ]
 
 [[vessel_profiles]]
 key = "201204_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -6.156, locy = -1.477, locz = 1.567, rotx = 0.3529, roty = 0.001, rotz = 0.2548 } },  # rotation in degrees: 20.220, 0.057, 14.599
 ]
 
 [[vessel_profiles]]
 key = "201205_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 3.497, locy = 3.23, locz = 3.679, rotx = -0.4283, roty = -0.0429, rotz = 0.1861 } },  # rotation in degrees: -24.540, -2.458, 10.663
 ]
 
 [[vessel_profiles]]
 key = "201210_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.723, locy = -5.235, locz = 1.769, rotx = 0.5553, roty = -0.0036, rotz = -0.0511 } },  # rotation in degrees: 31.816, -0.206, -2.928
 ]
 
 [[vessel_profiles]]
 key = "201304_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -1.18, locy = 0.7, locz = 2.0, rotx = 0.0, roty = 0.0, rotz = 0.0 } },  # rotation in degrees: 0.000, 0.000, 0.000
 ]
 
 [[vessel_profiles]]
 key = "201306_rv_challenger"
 vessel_name = "RV Challenger"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = 7.615, locy = 6.329, locz = 4.529, rotx = -0.4283, roty = 0.0176, rotz = -0.2815 } },  # rotation in degrees: -24.540, 1.008, -16.129
 ]
 
 [[vessel_profiles]]
 key = "201310_rv_tom_marshall"
 vessel_name = "RV Tom Marshall"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -5.541, locy = -5.364, locz = 3.224, rotx = 0.5678, roty = 0.0022, rotz = 0.2499 } },  # rotation in degrees: 32.533, 0.126, 14.318
 ]
 
 [[vessel_profiles]]
 key = "201403_rv_linnaeus"
 vessel_name = "RV Linnaeus"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -1.26, locy = 0.704, locz = 2.195, rotx = 0.0254, roty = -0.0126, rotz = -0.0685 } },  # rotation in degrees: 1.455, -0.722, -3.925
 ]
 
 [[vessel_profiles]]
 key = "201406_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_linkquest_transceiver", extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
+    { key = "usbl_linkquest_transceiver", message_topics = [], extrinsics = { locx = -11.916, locy = 4.761, locz = 10.752, rotx = -0.5026, roty = -0.0103, rotz = -0.0327 } },  # rotation in degrees: -28.797, -0.590, -1.874
 ]
 
 [[vessel_profiles]]
 key = "201502_tasmania_bluefin"
 vessel_name = "Tasmania Bluefin"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -11.062, locy = -6.656, locz = 9.998, rotx = 0.0159, roty = 0.0195, rotz = -0.0464 } },  # rotation in degrees: 0.911, 1.117, -2.659
 ]
 
 [[vessel_profiles]]
 key = "201705_silver_streak"
 vessel_name = "Silver Streak"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -4.793, locy = 4.302, locz = 4.043, rotx = -0.0067, roty = 0.0032, rotz = 0.4713 } },  # rotation in degrees: -0.384, 0.183, 27.004
 ]
 
 [[vessel_profiles]]
 key = "202102_poppag"
 vessel_name = "PoppaG"
 sensors = [
-    { key = "USBL", identity = "usbl_evologics_transceiver", extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
+    { key = "usbl_evologics_transceiver", message_topics = [], extrinsics = { locx = -9.4, locy = -3.72, locz = 7.49, rotx = 0.0, roty = 0.23, rotz = -0.21 } },  # rotation in degrees: 0.000, 13.178, -12.032
 ]
 
 # --------------------------------------------------------------------------------------

--- a/data/deployment_descriptors_v1.toml
+++ b/data/deployment_descriptors_v1.toml
@@ -68,48 +68,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -122,6 +81,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -187,48 +162,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -241,6 +175,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -310,57 +260,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -373,6 +273,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -439,51 +358,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -497,6 +372,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -566,54 +458,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -628,6 +473,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -692,48 +555,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -746,6 +568,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -813,57 +651,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -876,6 +664,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -942,51 +749,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1000,6 +763,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1071,39 +851,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1118,6 +866,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -1186,48 +947,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1240,6 +960,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1309,48 +1045,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1363,6 +1058,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1432,57 +1143,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1495,6 +1156,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -1563,51 +1243,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1621,6 +1257,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1697,54 +1350,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1758,6 +1364,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1828,54 +1452,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1890,6 +1467,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -1963,39 +1558,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2010,6 +1573,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2074,48 +1650,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2128,6 +1663,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -2192,57 +1743,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2255,6 +1756,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -2321,51 +1841,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2379,6 +1855,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -2452,54 +1945,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2513,6 +1959,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -2581,54 +2045,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2643,6 +2060,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2727,39 +2162,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2774,6 +2177,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2844,48 +2260,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2898,6 +2273,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -2980,54 +2371,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3041,6 +2385,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3115,54 +2477,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3176,6 +2491,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3248,54 +2581,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3309,6 +2595,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3376,48 +2680,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3430,6 +2693,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -3500,57 +2779,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3563,6 +2792,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -3630,54 +2878,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3691,6 +2892,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -3757,48 +2976,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3811,6 +2989,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -3878,57 +3072,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3941,6 +3085,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -4009,54 +3172,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4070,6 +3186,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4134,48 +3268,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4188,6 +3281,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4255,54 +3364,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4316,6 +3378,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4385,54 +3465,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4446,6 +3479,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4508,48 +3559,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4561,6 +3571,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -4623,48 +3649,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4676,6 +3661,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -4739,48 +3740,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4793,6 +3753,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4860,54 +3836,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4921,6 +3850,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4985,48 +3932,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5038,6 +3944,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -5100,48 +4022,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5153,6 +4034,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -5215,48 +4112,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5269,6 +4125,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5339,54 +4211,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5400,6 +4225,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -5464,48 +4307,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5518,6 +4320,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5584,51 +4402,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5642,6 +4416,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5704,51 +4495,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5762,6 +4509,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -5826,48 +4590,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5880,6 +4603,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5946,51 +4685,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6004,6 +4699,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6066,51 +4778,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6124,6 +4792,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -6188,48 +4873,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6242,6 +4886,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6308,51 +4968,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6366,6 +4982,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6428,51 +5061,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6486,6 +5075,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]

--- a/data/deployment_descriptors_v1_all.toml
+++ b/data/deployment_descriptors_v1_all.toml
@@ -68,48 +68,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -122,6 +81,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -187,48 +162,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -241,6 +175,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -310,57 +260,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -373,6 +273,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -439,51 +358,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -497,6 +372,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -566,54 +458,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -628,6 +473,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -692,48 +555,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -746,6 +568,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -813,57 +651,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -876,6 +664,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -942,51 +749,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1000,6 +763,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1071,39 +851,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1118,6 +866,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -1186,48 +947,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1240,6 +960,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1309,48 +1045,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1363,6 +1058,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1432,57 +1143,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1495,6 +1156,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -1563,51 +1243,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1621,6 +1257,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1697,54 +1350,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1758,6 +1364,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1828,54 +1452,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1890,6 +1467,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -1963,39 +1558,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2010,6 +1573,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2074,48 +1650,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2128,6 +1663,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -2192,57 +1743,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2255,6 +1756,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -2321,51 +1841,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2379,6 +1855,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -2452,54 +1945,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2513,6 +1959,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -2581,54 +2045,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2643,6 +2060,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2727,39 +2162,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2774,6 +2177,19 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -2844,48 +2260,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2898,6 +2273,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -2980,54 +2371,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3041,6 +2385,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3115,54 +2477,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3176,6 +2491,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3248,54 +2581,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3309,6 +2595,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -3376,48 +2680,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3430,6 +2693,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -3500,57 +2779,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3563,6 +2792,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -3630,54 +2878,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3691,6 +2892,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -3757,48 +2976,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3811,6 +2989,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -3878,57 +3072,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3941,6 +3085,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -4009,54 +3172,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4070,6 +3186,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4134,48 +3268,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4188,6 +3281,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4255,54 +3364,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4316,6 +3378,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4385,54 +3465,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4446,6 +3479,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4508,48 +3559,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4561,6 +3571,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -4623,48 +3649,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4676,6 +3661,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -4739,48 +3740,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4793,6 +3753,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -4860,54 +3836,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4921,6 +3850,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -4985,48 +3932,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5038,6 +3944,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -5100,48 +4022,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5153,6 +4034,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -5215,48 +4112,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5269,6 +4125,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5339,54 +4211,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5400,6 +4225,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -5464,48 +4307,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5518,6 +4320,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5584,51 +4402,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5642,6 +4416,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5704,51 +4495,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5762,6 +4509,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -5826,48 +4590,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5880,6 +4603,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -5946,51 +4685,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6004,6 +4699,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6066,51 +4778,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6124,6 +4792,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -6188,48 +4873,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6242,6 +4886,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6308,51 +4968,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6366,6 +4982,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -6428,51 +5061,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6486,6 +5075,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]

--- a/data/deployment_descriptors_v1_all_enriched.toml
+++ b/data/deployment_descriptors_v1_all_enriched.toml
@@ -75,23 +75,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -104,7 +91,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -117,7 +117,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -130,63 +168,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -200,6 +189,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -207,7 +212,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -286,23 +292,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -315,7 +308,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -328,7 +334,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -341,63 +385,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -411,6 +406,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -418,7 +429,8 @@ logged_streams = [
 vessel_name = "RV Cape Ferguson"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -501,23 +513,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -530,7 +529,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -543,7 +555,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -556,42 +606,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -602,44 +620,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -654,6 +634,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -661,7 +660,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -740,10 +740,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -756,7 +756,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -769,7 +782,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -782,42 +833,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -828,37 +847,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -873,6 +861,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -880,7 +885,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -963,23 +969,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -992,7 +985,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1005,7 +1011,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1018,73 +1062,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -1110,6 +1091,24 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -1117,7 +1116,8 @@ logged_streams = [
 vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -1195,23 +1195,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1224,7 +1211,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1237,7 +1237,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1250,63 +1288,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1320,6 +1309,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -1327,7 +1332,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1408,23 +1414,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1437,7 +1430,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1450,7 +1456,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1463,42 +1507,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1509,44 +1521,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1561,6 +1535,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -1568,7 +1561,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1647,10 +1641,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1663,7 +1657,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1676,7 +1683,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1689,42 +1734,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1735,37 +1748,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1780,6 +1762,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -1787,7 +1786,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1872,23 +1872,26 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
+key = "camera_avt_manta"
+message_topics = [
+    "VIS",
+]
+identity.label = "Allied Vision Manta G-1236 stereo camera"
+identity.vendor = "Allied Vision"
+identity.product = "Manta G-1236"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1901,7 +1904,55 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "oxygen_aanderaa"
+message_topics = [
+    "AANDERAA_4319",
+]
+identity.label = "Aanderaa 4319 oxygen optode"
+identity.vendor = "Aanderaa"
+identity.product = "4319"
+identity.type = "oxygen"
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1914,45 +1965,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -1978,6 +1994,19 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -1985,7 +2014,8 @@ logged_streams = [
 vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -2067,23 +2097,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2096,7 +2113,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2109,7 +2139,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2122,63 +2190,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2192,6 +2211,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -2199,7 +2234,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2282,23 +2318,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2311,7 +2334,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2324,7 +2360,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2337,63 +2411,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2407,6 +2432,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -2414,7 +2455,8 @@ logged_streams = [
 vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2497,23 +2539,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2526,7 +2555,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2539,7 +2581,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2552,42 +2632,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2598,44 +2646,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2650,6 +2660,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -2657,7 +2686,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2738,10 +2768,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2754,7 +2784,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2767,7 +2810,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2780,42 +2861,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2826,37 +2875,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2871,6 +2889,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -2878,7 +2913,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2968,23 +3004,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2997,7 +3020,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3010,7 +3046,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3023,42 +3097,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3069,37 +3111,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3114,6 +3125,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -3121,7 +3150,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3205,23 +3235,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3234,7 +3251,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3247,7 +3277,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3260,73 +3328,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -3352,6 +3357,24 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -3359,7 +3382,8 @@ logged_streams = [
 vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -3446,23 +3470,26 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
+key = "camera_avt_manta"
+message_topics = [
+    "VIS",
+]
+identity.label = "Allied Vision Manta G-1236 stereo camera"
+identity.vendor = "Allied Vision"
+identity.product = "Manta G-1236"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3475,7 +3502,55 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "oxygen_aanderaa"
+message_topics = [
+    "AANDERAA_4319",
+]
+identity.label = "Aanderaa 4319 oxygen optode"
+identity.vendor = "Aanderaa"
+identity.product = "4319"
+identity.type = "oxygen"
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3488,45 +3563,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -3552,6 +3592,19 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -3559,7 +3612,8 @@ logged_streams = [
 vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -3637,23 +3691,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3666,7 +3707,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3679,7 +3733,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3692,63 +3784,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3762,6 +3805,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -3769,7 +3828,8 @@ logged_streams = [
 vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3847,23 +3907,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3876,7 +3923,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3889,7 +3949,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3902,42 +4000,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3948,44 +4014,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4000,6 +4028,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -4007,7 +4054,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -4086,10 +4134,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -4102,7 +4150,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -4115,7 +4176,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -4128,42 +4227,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -4174,37 +4241,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4219,6 +4255,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -4226,7 +4279,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -4313,23 +4367,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -4342,7 +4383,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -4355,7 +4409,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -4368,42 +4460,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -4414,37 +4474,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -4459,6 +4488,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -4466,7 +4513,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -4548,23 +4596,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -4577,7 +4612,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -4590,7 +4638,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -4603,73 +4689,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -4695,6 +4718,24 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -4702,7 +4743,8 @@ logged_streams = [
 vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -4800,23 +4842,26 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
+key = "camera_avt_manta"
+message_topics = [
+    "VIS",
+]
+identity.label = "Allied Vision Manta G-1236 stereo camera"
+identity.vendor = "Allied Vision"
+identity.product = "Manta G-1236"
+identity.type = "stereo_camera"
+extrinsics.locx = 0.82
+extrinsics.locy = -0.035
+extrinsics.locz = 0.0
+extrinsics.rotx = -0.0373
+extrinsics.roty = -0.0065
+extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -4829,7 +4874,55 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "oxygen_aanderaa"
+message_topics = [
+    "AANDERAA_4319",
+]
+identity.label = "Aanderaa 4319 oxygen optode"
+identity.vendor = "Aanderaa"
+identity.product = "4319"
+identity.type = "oxygen"
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -4842,45 +4935,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPSD"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -4906,6 +4964,19 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "ECOPUCK",
+    "GPSD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -4913,7 +4984,8 @@ logged_streams = [
 vessel_name = "PoppaG"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -4997,23 +5069,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -5026,7 +5085,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -5039,7 +5111,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -5052,63 +5162,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -5122,6 +5183,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -5129,7 +5206,8 @@ logged_streams = [
 vessel_name = "Solander"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -5225,23 +5303,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -5254,7 +5319,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -5267,7 +5345,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -5280,73 +5396,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5371,6 +5424,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -5378,7 +5449,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5466,23 +5538,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -5495,7 +5554,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -5508,7 +5580,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -5521,73 +5631,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5612,6 +5659,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -5619,7 +5684,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5705,23 +5771,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -5734,7 +5787,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -5747,7 +5813,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -5760,73 +5864,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5851,6 +5892,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -5858,7 +5917,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -5939,23 +5999,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -5968,7 +6015,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -5981,7 +6041,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -5994,63 +6092,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6064,6 +6113,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -6071,7 +6136,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6155,23 +6221,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -6184,7 +6237,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -6197,7 +6263,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -6210,42 +6314,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6256,44 +6328,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6308,6 +6342,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -6315,7 +6368,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6395,23 +6449,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -6424,7 +6465,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -6437,7 +6491,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -6450,49 +6542,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6503,30 +6556,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6541,6 +6570,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -6548,7 +6595,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6628,23 +6676,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -6657,7 +6692,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -6670,7 +6718,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -6683,63 +6769,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6753,6 +6790,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -6760,7 +6813,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6841,23 +6895,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -6870,7 +6911,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -6883,7 +6937,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -6896,42 +6988,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -6942,44 +7002,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -6994,6 +7016,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -7001,7 +7042,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7082,23 +7124,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -7111,7 +7140,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -7124,7 +7166,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -7137,49 +7217,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7190,30 +7231,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -7228,6 +7245,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -7235,7 +7270,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7313,23 +7349,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -7342,7 +7365,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -7355,7 +7391,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -7368,63 +7442,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -7438,6 +7463,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -7445,7 +7486,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7526,23 +7568,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -7555,7 +7584,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -7568,7 +7610,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -7581,42 +7661,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7627,37 +7675,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -7672,6 +7689,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -7679,7 +7714,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7762,23 +7798,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -7791,7 +7814,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -7804,7 +7840,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -7817,49 +7891,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7870,30 +7905,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -7908,6 +7919,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -7915,7 +7944,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -7991,10 +8021,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -8007,55 +8037,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
-identity.label = "Paroscientific Digiquartz pressure sensor"
-identity.vendor = "Paroscientific"
-identity.product = "Digiquartz"
-identity.type = "pressure"
-extrinsics.locx = 0.4
-extrinsics.locy = 0.0
-extrinsics.locz = -0.23
-extrinsics.rotx = 0.0
-extrinsics.roty = 0.0
-extrinsics.rotz = 0.0
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
-identity.vendor = "LinkQuest"
-identity.product = "TrackLink 1500HA"
-identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -8068,31 +8063,29 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
 identity.label = "WET Labs ECO Puck Triplet sensor"
 identity.vendor = "WET Labs"
 identity.product = "ECO Puck Triplet"
 identity.type = "optical"
 
 [[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
 
 [[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+key = "multibeam_deltat"
+message_topics = []
 identity.label = "Delta T multibeam profiling sonar"
 identity.vendor = ""
 identity.product = ""
@@ -8103,6 +8096,32 @@ extrinsics.locz = 0.0
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -8115,6 +8134,22 @@ logged_streams = [
     "AUV",
     "MSG",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
+]
 
 [deployments.vessel]
 
@@ -8122,7 +8157,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -8198,10 +8234,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -8214,55 +8250,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
-identity.label = "Paroscientific Digiquartz pressure sensor"
-identity.vendor = "Paroscientific"
-identity.product = "Digiquartz"
-identity.type = "pressure"
-extrinsics.locx = 0.4
-extrinsics.locy = 0.0
-extrinsics.locz = -0.23
-extrinsics.rotx = 0.0
-extrinsics.roty = 0.0
-extrinsics.rotz = 0.0
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
-identity.vendor = "LinkQuest"
-identity.product = "TrackLink 1500HA"
-identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -8275,31 +8276,29 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
 identity.label = "WET Labs ECO Puck Triplet sensor"
 identity.vendor = "WET Labs"
 identity.product = "ECO Puck Triplet"
 identity.type = "optical"
 
 [[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
 
 [[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+key = "multibeam_deltat"
+message_topics = []
 identity.label = "Delta T multibeam profiling sonar"
 identity.vendor = ""
 identity.product = ""
@@ -8310,6 +8309,32 @@ extrinsics.locz = 0.0
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -8322,6 +8347,22 @@ logged_streams = [
     "AUV",
     "MSG",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
+]
 
 [deployments.vessel]
 
@@ -8329,7 +8370,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -8406,23 +8448,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -8435,7 +8464,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -8448,7 +8490,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -8461,63 +8541,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -8531,6 +8562,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -8538,7 +8585,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -8619,23 +8667,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -8648,7 +8683,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -8661,7 +8709,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -8674,42 +8760,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -8720,37 +8774,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -8765,6 +8788,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -8772,7 +8813,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -8850,10 +8892,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -8866,55 +8908,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
-identity.label = "Paroscientific Digiquartz pressure sensor"
-identity.vendor = "Paroscientific"
-identity.product = "Digiquartz"
-identity.type = "pressure"
-extrinsics.locx = 0.4
-extrinsics.locy = 0.0
-extrinsics.locz = -0.23
-extrinsics.rotx = 0.0
-extrinsics.roty = 0.0
-extrinsics.rotz = 0.0
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
-identity.vendor = "LinkQuest"
-identity.product = "TrackLink 1500HA"
-identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -8927,31 +8934,29 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
 identity.label = "WET Labs ECO Puck Triplet sensor"
 identity.vendor = "WET Labs"
 identity.product = "ECO Puck Triplet"
 identity.type = "optical"
 
 [[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
 
 [[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+key = "multibeam_deltat"
+message_topics = []
 identity.label = "Delta T multibeam profiling sonar"
 identity.vendor = ""
 identity.product = ""
@@ -8962,6 +8967,32 @@ extrinsics.locz = 0.0
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -8974,6 +9005,22 @@ logged_streams = [
     "AUV",
     "MSG",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
+]
 
 [deployments.vessel]
 
@@ -8981,7 +9028,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9057,10 +9105,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -9073,55 +9121,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
-identity.label = "Paroscientific Digiquartz pressure sensor"
-identity.vendor = "Paroscientific"
-identity.product = "Digiquartz"
-identity.type = "pressure"
-extrinsics.locx = 0.4
-extrinsics.locy = 0.0
-extrinsics.locz = -0.23
-extrinsics.rotx = 0.0
-extrinsics.roty = 0.0
-extrinsics.rotz = 0.0
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
-identity.vendor = "LinkQuest"
-identity.product = "TrackLink 1500HA"
-identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -9134,31 +9147,29 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
 identity.label = "WET Labs ECO Puck Triplet sensor"
 identity.vendor = "WET Labs"
 identity.product = "ECO Puck Triplet"
 identity.type = "optical"
 
 [[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
 
 [[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+key = "multibeam_deltat"
+message_topics = []
 identity.label = "Delta T multibeam profiling sonar"
 identity.vendor = ""
 identity.product = ""
@@ -9169,6 +9180,32 @@ extrinsics.locz = 0.0
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -9181,6 +9218,22 @@ logged_streams = [
     "AUV",
     "MSG",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
+]
 
 [deployments.vessel]
 
@@ -9188,7 +9241,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9264,23 +9318,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -9293,7 +9334,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -9306,7 +9360,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -9319,63 +9411,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -9389,6 +9432,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -9396,7 +9455,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9480,23 +9540,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -9509,7 +9556,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -9522,7 +9582,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -9535,42 +9633,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9581,37 +9647,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -9626,6 +9661,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -9633,7 +9686,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9711,23 +9765,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -9740,7 +9781,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -9753,7 +9807,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -9766,63 +9858,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -9836,6 +9879,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -9843,7 +9902,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -9923,10 +9983,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -9939,7 +9999,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -9952,7 +10025,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -9965,42 +10076,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10011,37 +10090,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -10056,6 +10104,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -10063,7 +10128,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10139,23 +10205,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -10168,7 +10221,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -10181,7 +10247,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -10194,42 +10298,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10240,30 +10312,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -10278,6 +10326,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -10285,7 +10350,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10363,23 +10429,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -10392,7 +10445,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -10405,7 +10471,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -10418,63 +10522,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -10488,6 +10543,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -10495,7 +10566,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10575,10 +10647,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -10591,7 +10663,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -10604,7 +10689,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -10617,42 +10740,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10663,37 +10754,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -10708,6 +10768,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -10715,7 +10792,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10791,23 +10869,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -10820,7 +10885,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -10833,7 +10911,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -10846,42 +10962,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -10892,30 +10976,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -10930,6 +10990,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -10937,7 +11014,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -11015,23 +11093,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -11044,7 +11109,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -11057,7 +11135,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -11070,63 +11186,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -11140,6 +11207,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -11147,7 +11230,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -11227,10 +11311,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -11243,7 +11327,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -11256,7 +11353,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -11269,42 +11404,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -11315,37 +11418,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -11360,6 +11432,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -11367,7 +11456,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -11443,23 +11533,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -11472,7 +11549,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -11485,7 +11575,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -11498,42 +11626,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -11544,30 +11640,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -11582,6 +11654,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -11589,7 +11678,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"

--- a/data/deployment_descriptors_v1_subset.toml
+++ b/data/deployment_descriptors_v1_subset.toml
@@ -61,48 +61,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -115,6 +74,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -184,48 +159,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -238,6 +172,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -307,57 +257,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -370,6 +270,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -438,51 +357,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -496,6 +371,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -560,48 +452,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -614,6 +465,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -678,57 +545,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -741,6 +558,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -807,51 +643,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -865,6 +657,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -933,54 +742,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -995,6 +757,24 @@ logged_streams = [
     "RDI",
     "IMU",
     "MICRON",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
 ]
 
 [deployments.vessel]
@@ -1061,48 +841,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1115,6 +854,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1182,57 +937,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1245,6 +950,25 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+    "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
     "IMU",
 ]
 
@@ -1313,54 +1037,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1374,6 +1051,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1438,48 +1133,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1491,6 +1145,22 @@ logged_streams = [
     "CTL",
     "AUV",
     "MSG",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
 ]
 
 [deployments.vessel]
@@ -1553,48 +1223,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1607,6 +1236,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1677,54 +1322,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1738,6 +1336,24 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]
@@ -1802,48 +1418,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1856,6 +1431,22 @@ logged_streams = [
     "AUV",
     "MSG",
     "RDI",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -1922,51 +1513,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "OAS"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1980,6 +1527,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
 ]
 
 [deployments.vessel]
@@ -2042,51 +1606,7 @@ topics = [
 ]
 
 [deployments.platform]
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
-
-[[deployments.platform.sensors]]
-key = "RDI"
-
-[[deployments.platform.sensors]]
-key = "PAROSCI"
-
-[[deployments.platform.sensors]]
-key = "THR_PORT"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
+sensors = []
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2100,6 +1620,23 @@ logged_streams = [
     "MSG",
     "RDI",
     "IMU",
+]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
 ]
 
 [deployments.vessel]

--- a/data/deployment_descriptors_v1_subset_enriched.toml
+++ b/data/deployment_descriptors_v1_subset_enriched.toml
@@ -68,23 +68,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -97,7 +84,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -110,7 +110,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -123,63 +161,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -193,6 +182,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -200,7 +205,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -283,23 +289,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -312,7 +305,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -325,7 +331,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -338,63 +382,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -408,6 +403,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -415,7 +426,8 @@ logged_streams = [
 vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -498,23 +510,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -527,7 +526,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -540,7 +552,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -553,42 +603,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -599,44 +617,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -651,6 +631,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -658,7 +657,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -739,10 +739,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -755,7 +755,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -768,7 +781,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -781,42 +832,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -827,37 +846,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -872,6 +860,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -879,7 +884,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -957,23 +963,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -986,7 +979,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -999,7 +1005,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1012,63 +1056,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1082,6 +1077,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -1089,7 +1100,8 @@ logged_streams = [
 vessel_name = "RV Naturaliste"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1167,23 +1179,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1196,7 +1195,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1209,7 +1221,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1222,42 +1272,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1268,44 +1286,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1320,6 +1300,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -1327,7 +1326,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1406,10 +1406,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1422,7 +1422,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1435,7 +1448,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1448,42 +1499,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1494,37 +1513,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1539,6 +1527,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -1546,7 +1551,8 @@ logged_streams = [
 vessel_name = "RV Linnaeus"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -1628,23 +1634,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1657,7 +1650,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1670,7 +1676,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1683,73 +1727,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
-
-[[deployments.platform.sensors]]
-key = "EVOLOGICS"
+key = "usbl_evologics_transponder"
+message_topics = [
+    "EVOLOGICS_FIX",
+]
 identity.label = "EvoLogics S2C R 18/34 USBL transponder"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -1775,6 +1756,24 @@ logged_streams = [
     "IMU",
     "MICRON",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+    "EVOLOGICS",
+]
 
 [deployments.vessel]
 
@@ -1782,7 +1781,8 @@ logged_streams = [
 vessel_name = "Silver Streak"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_evologics_transceiver"
+message_topics = []
 identity.label = "EvoLogics S2C R 18/34 USBL transceiver"
 identity.vendor = "EvoLogics"
 identity.product = "S2C R 18/34"
@@ -1862,23 +1862,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -1891,7 +1878,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -1904,7 +1904,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -1917,63 +1955,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -1987,6 +1976,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -1994,7 +1999,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2075,23 +2081,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2104,7 +2097,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2117,7 +2123,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2130,42 +2174,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2176,44 +2188,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "IMU"
-identity.label = "Inertial measurement unit"
-identity.vendor = ""
-identity.product = ""
-identity.type = "imu"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2228,6 +2202,25 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+    "IMU",
+]
 
 [deployments.vessel]
 
@@ -2235,7 +2228,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2316,23 +2310,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2345,7 +2326,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2358,7 +2352,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2371,49 +2403,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2424,30 +2417,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2462,6 +2431,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -2469,7 +2456,8 @@ logged_streams = [
 vessel_name = "Tasmania Bluefin"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2547,10 +2535,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2563,55 +2551,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
-identity.label = "Paroscientific Digiquartz pressure sensor"
-identity.vendor = "Paroscientific"
-identity.product = "Digiquartz"
-identity.type = "pressure"
-extrinsics.locx = 0.4
-extrinsics.locy = 0.0
-extrinsics.locz = -0.23
-extrinsics.rotx = 0.0
-extrinsics.roty = 0.0
-extrinsics.rotz = 0.0
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
-identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
-identity.vendor = "LinkQuest"
-identity.product = "TrackLink 1500HA"
-identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "RDI"
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2624,31 +2577,29 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
 identity.label = "WET Labs ECO Puck Triplet sensor"
 identity.vendor = "WET Labs"
 identity.product = "ECO Puck Triplet"
 identity.type = "optical"
 
 [[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
 
 [[deployments.platform.sensors]]
-key = "OAS"
-
-[[deployments.platform.sensors]]
-key = "DELTA_T"
+key = "multibeam_deltat"
+message_topics = []
 identity.label = "Delta T multibeam profiling sonar"
 identity.vendor = ""
 identity.product = ""
@@ -2659,6 +2610,32 @@ extrinsics.locz = 0.0
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
+identity.label = "Paroscientific Digiquartz pressure sensor"
+identity.vendor = "Paroscientific"
+identity.product = "Digiquartz"
+identity.type = "pressure"
+extrinsics.locx = 0.4
+extrinsics.locy = 0.0
+extrinsics.locz = -0.23
+extrinsics.rotx = 0.0
+extrinsics.roty = 0.0
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
+identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
+identity.vendor = "LinkQuest"
+identity.product = "TrackLink 1500HA"
+identity.type = "usbl"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2671,6 +2648,22 @@ logged_streams = [
     "AUV",
     "MSG",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_STBD",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "RDI",
+    "GPS",
+    "ECOPUCK",
+    "SEABIRD",
+    "OAS",
+    "DELTA_T",
+]
 
 [deployments.vessel]
 
@@ -2678,7 +2671,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2754,23 +2748,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2783,7 +2764,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -2796,7 +2790,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -2809,63 +2841,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -2879,6 +2862,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -2886,7 +2885,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -2970,23 +2970,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -2999,7 +2986,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3012,7 +3012,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3025,42 +3063,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3071,37 +3077,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3116,6 +3091,24 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -3123,7 +3116,8 @@ logged_streams = [
 vessel_name = "RV Challenger"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3201,23 +3195,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = 0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = -3.125
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3230,7 +3211,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3243,7 +3237,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = 0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = -3.125
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3256,63 +3288,14 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
 identity.type = "usbl"
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3326,6 +3309,22 @@ logged_streams = [
     "MSG",
     "RDI",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -3333,7 +3332,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3413,10 +3413,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3429,7 +3429,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3442,7 +3455,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3455,42 +3506,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3501,37 +3520,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "ECOPUCK"
-identity.label = "WET Labs ECO Puck Triplet sensor"
-identity.vendor = "WET Labs"
-identity.product = "ECO Puck Triplet"
-identity.type = "optical"
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "OAS"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3546,6 +3534,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "ECOPUCK",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "OAS",
+]
 
 [deployments.vessel]
 
@@ -3553,7 +3558,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3629,23 +3635,10 @@ platform_class = "SEABED"
 platform_operator = "ACFR"
 
 [[deployments.platform.sensors]]
-key = "DELTA_T"
-identity.label = "Delta T multibeam profiling sonar"
-identity.vendor = ""
-identity.product = ""
-identity.type = "multibeam_sonar"
-extrinsics.locx = 0.588
-extrinsics.locy = 0.25
-extrinsics.locz = 0.048
-extrinsics.rotx = -0.0076
-extrinsics.roty = 0.084
-extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "MP_INPUT"
-
-[[deployments.platform.sensors]]
-key = "VIS"
+key = "camera_avt_prosilica"
+message_topics = [
+    "VIS",
+]
 identity.label = "AVT Prosilica GC1380 stereo camera"
 identity.vendor = "AVT"
 identity.product = "Prosilica GC1380"
@@ -3658,7 +3651,20 @@ extrinsics.roty = -0.0065
 extrinsics.rotz = 1.5488
 
 [[deployments.platform.sensors]]
-key = "RDI"
+key = "ctd_seabird"
+message_topics = [
+    "SEABIRD",
+]
+identity.label = "Seabird SBE 37-SIP CTD"
+identity.vendor = "Seabird"
+identity.product = "SBE 37-SIP"
+identity.type = "ctd"
+
+[[deployments.platform.sensors]]
+key = "dvl_teledyne_navigator"
+message_topics = [
+    "RDI",
+]
 identity.label = "Teledyne RDI Work Horse Navigator DVL"
 identity.vendor = "Teledyne RDI"
 identity.product = "Work Horse Navigator"
@@ -3671,7 +3677,45 @@ extrinsics.roty = 3.1416
 extrinsics.rotz = -1.5708
 
 [[deployments.platform.sensors]]
-key = "PAROSCI"
+key = "ecopuck_wetlabs"
+message_topics = [
+    "ECOPUCK",
+]
+identity.label = "WET Labs ECO Puck Triplet sensor"
+identity.vendor = "WET Labs"
+identity.product = "ECO Puck Triplet"
+identity.type = "optical"
+
+[[deployments.platform.sensors]]
+key = "gnss_ublox"
+message_topics = [
+    "GPS_RMC",
+    "GPS_GSV",
+]
+identity.label = "u-blox GNSS receiver"
+identity.vendor = "u-blox"
+identity.product = ""
+identity.type = "gnss"
+
+[[deployments.platform.sensors]]
+key = "multibeam_deltat"
+message_topics = []
+identity.label = "Delta T multibeam profiling sonar"
+identity.vendor = ""
+identity.product = ""
+identity.type = "multibeam_sonar"
+extrinsics.locx = 0.588
+extrinsics.locy = 0.25
+extrinsics.locz = 0.048
+extrinsics.rotx = -0.0076
+extrinsics.roty = 0.084
+extrinsics.rotz = 0.0
+
+[[deployments.platform.sensors]]
+key = "pressure_parosci"
+message_topics = [
+    "PAROSCI",
+]
 identity.label = "Paroscientific Digiquartz pressure sensor"
 identity.vendor = "Paroscientific"
 identity.product = "Digiquartz"
@@ -3684,42 +3728,10 @@ extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
 
 [[deployments.platform.sensors]]
-key = "THR_PORT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "THR_VERT"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "BATT0"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT1"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "BATT2"
-identity.label = "Vehicle battery pack"
-identity.vendor = ""
-identity.product = ""
-identity.type = "battery"
-
-[[deployments.platform.sensors]]
-key = "LQMODEM"
+key = "usbl_linkquest_transponder"
+message_topics = [
+    "LQMODEM",
+]
 identity.label = "LinkQuest TrackLink 1500HA USBL transponder"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"
@@ -3730,30 +3742,6 @@ extrinsics.locz = -0.9
 extrinsics.rotx = 0.0
 extrinsics.roty = 0.0
 extrinsics.rotz = 0.0
-
-[[deployments.platform.sensors]]
-key = "GPS"
-identity.label = "u-blox GNSS receiver"
-identity.vendor = "u-blox"
-identity.product = ""
-identity.type = "gnss"
-
-[[deployments.platform.sensors]]
-key = "THR_STBD"
-identity.label = "Vehicle thruster"
-identity.vendor = ""
-identity.product = ""
-identity.type = "thruster"
-
-[[deployments.platform.sensors]]
-key = "SEABIRD"
-identity.label = "Seabird SBE 37-SIP CTD"
-identity.vendor = "Seabird"
-identity.product = "SBE 37-SIP"
-identity.type = "ctd"
-
-[[deployments.platform.sensors]]
-key = "MICRON"
 
 [deployments.system]
 vehicle_name = "SEABED"
@@ -3768,6 +3756,23 @@ logged_streams = [
     "RDI",
     "IMU",
 ]
+sensors = [
+    "DELTA_T",
+    "MP_INPUT",
+    "VIS",
+    "RDI",
+    "PAROSCI",
+    "THR_PORT",
+    "THR_VERT",
+    "BATT0",
+    "BATT1",
+    "BATT2",
+    "LQMODEM",
+    "GPS",
+    "THR_STBD",
+    "SEABIRD",
+    "MICRON",
+]
 
 [deployments.vessel]
 
@@ -3775,7 +3780,8 @@ logged_streams = [
 vessel_name = "RV Tom Marshall"
 
 [[deployments.vessel.sensors]]
-key = "USBL"
+key = "usbl_linkquest_transceiver"
+message_topics = []
 identity.label = "LinkQuest TrackLink 1500HA USBL transceiver"
 identity.vendor = "LinkQuest"
 identity.product = "TrackLink 1500HA"

--- a/src/afft/cli/renav/actions.py
+++ b/src/afft/cli/renav/actions.py
@@ -32,7 +32,7 @@ from afft.tasks.transform_camera_poses import (
     run_transform_camera_poses_batch,
 )
 
-CAMERA_SENSOR_KEY: str = "VIS"
+CAMERA_SENSOR_TYPE: str = "stereo_camera"
 
 
 def dispatch_process_renav(
@@ -208,12 +208,12 @@ def _camera_extrinsics(
     if sensor is None:
         raise KeyError(
             f"deployment {descriptor.deployment_label} has no"
-            f" {CAMERA_SENSOR_KEY} sensor in its platform roster"
+            f" {CAMERA_SENSOR_TYPE} sensor in its platform roster"
         )
     if sensor.extrinsics is None:
         raise ValueError(
             f"deployment {descriptor.deployment_label} has no extrinsics for"
-            f" its {CAMERA_SENSOR_KEY} sensor"
+            f" its {CAMERA_SENSOR_TYPE} sensor"
         )
     return _camera_vehicle_extrinsics(sensor.extrinsics)
 
@@ -221,9 +221,13 @@ def _camera_extrinsics(
 def _find_camera_sensor(
     descriptor: DeploymentDescriptor,
 ) -> PlatformSensor | None:
+    # The roster is keyed on the mounted unit, and the vehicle flew two
+    # different cameras over the years, so the camera is found by sensor type
+    # rather than by key.
     for sensor in descriptor.platform.sensors:
-        if sensor.key == CAMERA_SENSOR_KEY:
-            return sensor
+        if sensor.identity is not None:
+            if sensor.identity.type == CAMERA_SENSOR_TYPE:
+                return sensor
     return None
 
 

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -58,6 +58,7 @@ from .enrichment import (
     DeploymentCatalogIndex as DeploymentCatalogIndex,
     DeploymentEnrichment as DeploymentEnrichment,
     EnrichmentSection as EnrichmentSection,
+    compare_topics as compare_topics,
     enrich_descriptor as enrich_descriptor,
     enrich_platform_section as enrich_platform_section,
     enrich_vessel_section as enrich_vessel_section,

--- a/src/afft/deployment/catalog_io.py
+++ b/src/afft/deployment/catalog_io.py
@@ -117,9 +117,12 @@ def _format_profile_sensors(sensors: list[CatalogProfileSensor]) -> str:
 
     lines: list[str] = ["sensors = ["]
     for sensor in sensors:
+        topics: str = ", ".join(
+            _toml_string(topic) for topic in sensor.message_topics
+        )
         entry: str = (
             f"    {{ key = {_toml_string(sensor.key)}, "
-            f"identity = {_toml_string(sensor.identity)}"
+            f"message_topics = [{topics}]"
         )
         comment: str = ""
         if sensor.extrinsics is not None:

--- a/src/afft/deployment/catalog_summary.py
+++ b/src/afft/deployment/catalog_summary.py
@@ -196,7 +196,12 @@ def collect_unreferenced_sensors(
     catalog: DeploymentCatalog,
 ) -> list[RecordKey]:
     """
-    Collect the sensor identities no profile sensor references.
+    Collect the sensor identities no profile mounts.
+
+    Not every unmounted identity is an oversight: the catalog keeps reference
+    records for hardware the vehicle carried but nothing downstream consumes,
+    such as the thrusters and the obstacle avoidance sonar. They are reported
+    all the same, since the record itself does not say which it is.
 
     Arguments
     ---------
@@ -204,14 +209,14 @@ def collect_unreferenced_sensors(
 
     Returns
     -------
-    Keys of the unreferenced sensor identities, in file order.
+    Keys of the unmounted sensor identities, in file order.
     """
     profiles: list[CatalogPlatformProfile | CatalogVesselProfile] = [
         *catalog.platform_profiles,
         *catalog.vessel_profiles,
     ]
     referenced: set[str] = {
-        sensor.identity for profile in profiles for sensor in profile.sensors
+        sensor.key for profile in profiles for sensor in profile.sensors
     }
     return [
         sensor.key

--- a/src/afft/deployment/catalog_types.py
+++ b/src/afft/deployment/catalog_types.py
@@ -8,11 +8,14 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 class CatalogSensorIdentity(BaseModel):
     """
-    A curated sensor identity record.
+    A curated sensor identity record, describing one physical unit rather than
+    a hardware type: a slot fitted with its own device carries its own record.
 
     Attributes
     ----------
-    key: Catalog lookup key, referenced by ``CatalogProfileSensor.identity``.
+    key: Catalog lookup key, named by ``CatalogProfileSensor.key``. Lowercase,
+        descriptive, and underscore-separated, carrying as much of the vendor
+        and product as the record knows (e.g. ``"dvl_teledyne_navigator"``).
     label: Human-readable sensor name.
     vendor: Manufacturer.
     product: Product name.
@@ -58,9 +61,14 @@ class CatalogProfileSensor(BaseModel):
 
     Attributes
     ----------
-    key: Sensor identifier, matched against ``PlatformSensor.key`` /
-        ``VesselSensor.key`` during enrichment.
-    identity: Key of the ``CatalogSensorIdentity`` describing this hardware.
+    key: Key of the ``CatalogSensorIdentity`` describing the mounted unit;
+        enrichment writes it to the descriptor roster as the sensor's key.
+    message_topics: RAW telemetry topics the sensor emits. A topic cannot be
+        derived from the key by string equality — ``GPS_RMC`` and ``GPS_GSV``
+        come from one receiver — so the mapping is curated. Empty where the
+        sensor emits no topic, either because it logs nothing (``DELTA_T``) or
+        because its data arrives by another route (the vessel's ``USBL``,
+        through the ``usbl_logs`` file role).
     extrinsics: Curated mounting pose; ``None`` where the sensor has no
         surveyed pose.
     """
@@ -68,7 +76,7 @@ class CatalogProfileSensor(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     key: str
-    identity: str
+    message_topics: list[str] = Field(default_factory=list)
     extrinsics: CatalogSensorExtrinsics | None = None
 
 
@@ -253,10 +261,10 @@ def _check_sensor_identities(
     sensors: list[CatalogProfileSensor],
     sensor_keys: set[str],
 ) -> None:
-    """Check that every profile sensor identity names a catalog sensor."""
+    """Check that every profile sensor key names a catalog sensor identity."""
     for sensor in sensors:
-        if sensor.identity not in sensor_keys:
+        if sensor.key not in sensor_keys:
             raise ValueError(
-                f"profile {profile_key!r} sensor {sensor.key!r} references "
-                f"unknown sensor identity: {sensor.identity!r}"
+                f"profile {profile_key!r} references unknown sensor identity: "
+                f"{sensor.key!r}"
             )

--- a/src/afft/deployment/descriptor_summary.py
+++ b/src/afft/deployment/descriptor_summary.py
@@ -149,13 +149,17 @@ def _sensor_gaps(
     sensors: list[PlatformSensor] | list[VesselSensor],
     section: str,
 ) -> list[FieldName]:
-    """Collect the unfilled slots of a platform or vessel sensor roster."""
+    """
+    Collect the unfilled slots of a platform or vessel sensor roster.
+
+    A roster is written whole by enrichment, so a sensor that exists at all
+    has an identity: the gaps are the identity's empty fields and a missing
+    pose. An unenriched descriptor shows up as an empty roster instead.
+    """
     unfilled: list[FieldName] = []
     for sensor in sensors:
         prefix: str = f"{section}.sensors[{sensor.key}]"
-        if sensor.identity is None:
-            unfilled.append(f"{prefix}.identity")
-        else:
+        if sensor.identity is not None:
             unfilled.extend(
                 _empty_identity_fields(sensor.identity, f"{prefix}.identity")
             )

--- a/src/afft/deployment/descriptor_types.py
+++ b/src/afft/deployment/descriptor_types.py
@@ -57,19 +57,27 @@ class SensorExtrinsics(BaseModel):
 
 class PlatformSensor(BaseModel):
     """
-    A sensor mounted on the deployment's platform.
+    A sensor mounted on the deployment's platform. The whole roster is curated
+    — enrichment writes it from the assigned catalog profile — so a platform
+    section either has no sensors at all or has them fully identified.
 
     Attributes
     ----------
-    key: Terse sensor identifier (e.g. ``"RDI"``); the catalog lookup key.
-    identity: Curated sensor metadata; ``None`` until enrichment fills it.
+    key: Curated sensor identifier (e.g. ``"dvl_teledyne_navigator"``); the
+        catalog lookup key.
+    message_topics: RAW telemetry topics the sensor emits, carried from the
+        catalog so the descriptor states the mapping a build used. Empty where
+        the sensor emits no topic.
+    identity: Curated sensor metadata; ``None`` only on a roster no enrichment
+        wrote.
     extrinsics: Mounting pose in the vehicle (SNAME) body frame; ``None``
-        until enrichment fills it.
+        where the sensor has no surveyed pose.
     """
 
     model_config = ConfigDict(frozen=True)
 
     key: str
+    message_topics: list[str] = Field(default_factory=list)
     identity: SensorIdentity | None = None
     extrinsics: SensorExtrinsics | None = None
 
@@ -81,15 +89,20 @@ class VesselSensor(BaseModel):
 
     Attributes
     ----------
-    key: Terse sensor identifier (e.g. ``"USBL"``); the catalog lookup key.
-    identity: Curated sensor metadata; ``None`` until enrichment fills it.
-    extrinsics: Mounting pose in the ship reference frame; ``None`` until
-        enrichment fills it.
+    key: Curated sensor identifier (e.g. ``"usbl_linkquest_transceiver"``);
+        the catalog lookup key.
+    message_topics: RAW telemetry topics the sensor emits; empty for the
+        topside sensors, whose data arrives through a file role instead.
+    identity: Curated sensor metadata; ``None`` only on a roster no enrichment
+        wrote.
+    extrinsics: Mounting pose in the ship reference frame; ``None`` where the
+        sensor has no surveyed pose.
     """
 
     model_config = ConfigDict(frozen=True)
 
     key: str
+    message_topics: list[str] = Field(default_factory=list)
     identity: SensorIdentity | None = None
     extrinsics: SensorExtrinsics | None = None
 
@@ -133,14 +146,16 @@ class DeploymentPlatformSection(BaseModel):
     """
     The deployment platform's curated identity and its sensor roster.
 
-    The roster comes from the SEABED system config at describe time; the
-    curated slots are filled by enrichment. Poses are in the vehicle (SNAME)
-    body frame.
+    Filled entirely by enrichment from the assigned catalog profile: the
+    system config's roster is a vehicle-scoped set of labels rather than a
+    curated vocabulary, and it is kept as observed data on the system section
+    instead. Poses are in the vehicle (SNAME) body frame.
 
     Attributes
     ----------
     identity: Curated platform identity; ``None`` until enrichment fills it.
-    sensors: One entry per configured platform sensor.
+    sensors: One entry per curated platform sensor; empty until enrichment
+        fills it.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -181,6 +196,11 @@ class DeploymentSystemSection(BaseModel):
     log_directory: On-vehicle log directory (e.g. ``"/files1/Log"``).
     logged_streams: Stream types written to disk (e.g. ``["SYSLOG", "RAW",
         "CTL", "AUV", "MSG", "RDI"]``).
+    sensors: Sensor labels the config declares (e.g. ``["RDI", "VIS",
+        "MP_INPUT"]``), kept as observed data. The labels are scoped to one
+        vehicle configuration and the roster is not always complete, so it
+        stands beside the curated ``platform.sensors`` rather than feeding it
+        — its value is that the two can disagree.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -189,6 +209,7 @@ class DeploymentSystemSection(BaseModel):
     vehicle_config: str
     log_directory: str
     logged_streams: list[str]
+    sensors: list[str] = Field(default_factory=list)
 
 
 class DeploymentFileSection(BaseModel):
@@ -249,8 +270,10 @@ class DeploymentDescriptor(BaseModel):
     metadata: Collected deployment metadata.
     files: Inventory of the deployment's files, keyed by role.
     telemetry: Message topics observed in the RAW AUV logs.
-    platform: The platform's curated identity and its sensor roster.
-    system: The vehicle's identity and logging setup.
+    platform: The platform's curated identity and its sensor roster; empty
+        until enrichment fills it.
+    system: The vehicle's identity, logging setup, and configured sensor
+        labels.
     vessel: The support vessel's curated identity and its sensor roster; empty
         until enrichment fills it.
     """

--- a/src/afft/deployment/enrichment.py
+++ b/src/afft/deployment/enrichment.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from .catalog_types import (
     CatalogPlatformProfile,
@@ -140,6 +140,10 @@ class DeploymentEnrichment(BaseModel):
         ``None`` if the platform section was not requested.
     vessel_matched: Whether the vessel section resolved to a profile; ``None``
         if the vessel section was not requested.
+    undeclared_topics: Topics the deployment logged that no curated sensor
+        claims, sorted.
+    unobserved_topics: Topics the curated roster declares that the deployment
+        never logged, sorted.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -147,6 +151,8 @@ class DeploymentEnrichment(BaseModel):
     descriptor: DeploymentDescriptor
     platform_matched: bool | None = None
     vessel_matched: bool | None = None
+    undeclared_topics: list[str] = Field(default_factory=list)
+    unobserved_topics: list[str] = Field(default_factory=list)
 
 
 def enrich_descriptor(
@@ -170,7 +176,8 @@ def enrich_descriptor(
 
     Returns
     -------
-    The enriched descriptor and which requested sections resolved.
+    The enriched descriptor, which requested sections resolved, and how the
+    resolved roster's declared topics compare to the observed ones.
     """
     updates: dict[str, DeploymentPlatformSection | DeploymentVesselSection] = {}
     platform_matched: bool | None = None
@@ -196,11 +203,52 @@ def enrich_descriptor(
                 descriptor.vessel, vessel_profile, index.sensor_identities
             )
 
+    enriched: DeploymentDescriptor = descriptor.model_copy(update=updates)
+    undeclared_topics: list[str] = []
+    unobserved_topics: list[str] = []
+    # The platform sensors own the RAW topics, so the comparison only means
+    # something once their roster is the curated one.
+    if platform_matched:
+        undeclared_topics, unobserved_topics = compare_topics(enriched)
+
     return DeploymentEnrichment(
-        descriptor=descriptor.model_copy(update=updates),
+        descriptor=enriched,
         platform_matched=platform_matched,
         vessel_matched=vessel_matched,
+        undeclared_topics=undeclared_topics,
+        unobserved_topics=unobserved_topics,
     )
+
+
+def compare_topics(
+    descriptor: DeploymentDescriptor,
+) -> tuple[list[str], list[str]]:
+    """
+    Compare the topics a descriptor's curated roster declares against the
+    topics its deployment logged.
+
+    A mismatch is a curation signal rather than an error in either direction:
+    a sensor can be fitted and log nothing, and a logged topic can belong to
+    hardware the catalog deliberately leaves unmounted.
+
+    Arguments
+    ---------
+    descriptor: Enriched descriptor to check.
+
+    Returns
+    -------
+    The observed topics no sensor claims and the declared topics the
+    deployment never logged, each sorted.
+    """
+    sensors: list[PlatformSensor | VesselSensor] = [
+        *descriptor.platform.sensors,
+        *descriptor.vessel.sensors,
+    ]
+    declared: set[str] = {
+        topic for sensor in sensors for topic in sensor.message_topics
+    }
+    observed: set[str] = set(descriptor.telemetry.topics)
+    return sorted(observed - declared), sorted(declared - observed)
 
 
 def enrich_platform_section(
@@ -209,11 +257,11 @@ def enrich_platform_section(
     identities: dict[CatalogKey, CatalogSensorIdentity],
 ) -> DeploymentPlatformSection:
     """
-    Fill a platform section's curated slots from a platform profile.
+    Fill a platform section from a platform profile.
 
-    The roster comes from the deployment's system config, so it is preserved
-    key by key: a roster key the profile does not carry keeps its empty slots,
-    and a profile entry no roster key names is unused.
+    Every field of the section is curated — the deployment data names the
+    vehicle's sensors only by system config label, a vocabulary of its own —
+    so the profile's roster replaces the section's contents outright.
 
     Arguments
     ---------
@@ -225,9 +273,6 @@ def enrich_platform_section(
     -------
     The enriched platform section.
     """
-    entries: dict[str, CatalogProfileSensor] = {
-        sensor.key: sensor for sensor in profile.sensors
-    }
     return section.model_copy(
         update={
             "identity": PlatformIdentity(
@@ -235,16 +280,9 @@ def enrich_platform_section(
                 platform_class=profile.platform_class,
                 platform_operator=profile.platform_operator,
             ),
-            "sensors": [
-                PlatformSensor(
-                    key=sensor.key,
-                    identity=_sensor_identity(
-                        entries.get(sensor.key), identities
-                    ),
-                    extrinsics=_sensor_extrinsics(entries.get(sensor.key)),
-                )
-                for sensor in section.sensors
-            ],
+            "sensors": _resolve_sensors(
+                profile.sensors, identities, PlatformSensor
+            ),
         }
     )
 
@@ -274,26 +312,42 @@ def enrich_vessel_section(
     return section.model_copy(
         update={
             "identity": VesselIdentity(vessel_name=profile.vessel_name),
-            "sensors": [
-                VesselSensor(
-                    key=sensor.key,
-                    identity=_sensor_identity(sensor, identities),
-                    extrinsics=_sensor_extrinsics(sensor),
-                )
-                for sensor in profile.sensors
-            ],
+            "sensors": _resolve_sensors(
+                profile.sensors, identities, VesselSensor
+            ),
         }
     )
 
 
+def _resolve_sensors[SensorT: (PlatformSensor, VesselSensor)](
+    sensors: list[CatalogProfileSensor],
+    identities: dict[CatalogKey, CatalogSensorIdentity],
+    sensor_type: type[SensorT],
+) -> list[SensorT]:
+    """
+    Resolve a profile's roster into descriptor sensors.
+
+    The two bodies differ only in which sensor model their roster holds: both
+    key a sensor on its catalog identity, and both carry the curated topic
+    mapping and pose through unchanged.
+    """
+    return [
+        sensor_type(
+            key=sensor.key,
+            message_topics=list(sensor.message_topics),
+            identity=_sensor_identity(sensor, identities),
+            extrinsics=_sensor_extrinsics(sensor),
+        )
+        for sensor in sensors
+    ]
+
+
 def _sensor_identity(
-    entry: CatalogProfileSensor | None,
+    entry: CatalogProfileSensor,
     identities: dict[CatalogKey, CatalogSensorIdentity],
 ) -> SensorIdentity | None:
-    """Resolve a profile sensor's identity reference against the catalog."""
-    if entry is None:
-        return None
-    identity: CatalogSensorIdentity | None = identities.get(entry.identity)
+    """Resolve a profile sensor's key against the catalog identity records."""
+    identity: CatalogSensorIdentity | None = identities.get(entry.key)
     if identity is None:
         return None
     return SensorIdentity(
@@ -305,10 +359,10 @@ def _sensor_identity(
 
 
 def _sensor_extrinsics(
-    entry: CatalogProfileSensor | None,
+    entry: CatalogProfileSensor,
 ) -> SensorExtrinsics | None:
     """Convert a profile sensor's curated pose to descriptor extrinsics."""
-    if entry is None or entry.extrinsics is None:
+    if entry.extrinsics is None:
         return None
     return SensorExtrinsics(
         locx=entry.extrinsics.locx,

--- a/src/afft/tasks/deployment_catalog/__init__.py
+++ b/src/afft/tasks/deployment_catalog/__init__.py
@@ -8,7 +8,6 @@ from .builders import (
     build_vessel_profile_stubs as build_vessel_profile_stubs,
     map_platform_profile_keys as map_platform_profile_keys,
     map_vessel_profile_keys as map_vessel_profile_keys,
-    sensor_identity_key as sensor_identity_key,
 )
 from .runner import (
     run_scaffold_catalog as run_scaffold_catalog,

--- a/src/afft/tasks/deployment_catalog/builders.py
+++ b/src/afft/tasks/deployment_catalog/builders.py
@@ -17,25 +17,6 @@ from .types import ScaffoldCatalogDiagnostics
 _NON_ALPHANUMERIC_PATTERN = re.compile(r"[^a-z0-9]+")
 
 
-def sensor_identity_key(sensor_key: str) -> str:
-    """
-    Derive a stub sensor identity key from a roster sensor key.
-
-    The identity of the hardware behind a key is not derivable from a
-    deployment, so the stub is keyed on the lowercased roster key (``"RDI"``
-    -> ``"rdi"``) for the curator to rename once vendor and product are known.
-
-    Arguments
-    ---------
-    sensor_key: Roster sensor key, as it appears in the system config.
-
-    Returns
-    -------
-    The stub identity key.
-    """
-    return _snake_case(sensor_key)
-
-
 def map_platform_profile_keys(
     descriptors: list[DeploymentDescriptor],
 ) -> dict[str, str]:
@@ -118,20 +99,24 @@ def build_sensor_stubs(
     descriptors: list[DeploymentDescriptor],
 ) -> list[CatalogSensorIdentity]:
     """
-    Build one sensor identity stub per observed roster sensor key.
+    Build one sensor identity stub per observed system config sensor label.
+
+    The hardware behind a label is not derivable from a deployment, so the
+    stub is keyed on the lowercased label (``"RDI"`` -> ``"rdi"``) for the
+    curator to rename once vendor and product are known.
 
     Arguments
     ---------
-    descriptors: Deployment descriptors to collect sensor keys from.
+    descriptors: Deployment descriptors to collect sensor labels from.
 
     Returns
     -------
     Sensor stubs with empty curated fields, sorted by key.
     """
     identity_keys: set[str] = {
-        sensor_identity_key(sensor.key)
+        _snake_case(label)
         for descriptor in descriptors
-        for sensor in descriptor.platform.sensors
+        for label in descriptor.system.sensors
     }
     return [
         CatalogSensorIdentity(key=key, label="", vendor="", product="", type="")
@@ -147,10 +132,14 @@ def build_platform_profile_stubs(
     """
     Build one platform profile stub per assigned profile key.
 
-    A profile's sensor list is the union of the roster keys observed across its
-    deployments: enrichment fills only the slots whose key matches, so a union
-    serves every roster in the group. Extrinsics are omitted rather than
-    zero-filled — an all-zero pose is a real mounting here, not a placeholder.
+    A profile's sensor list is the union of the system config sensor labels
+    observed across its deployments, each stubbed under its lowercased key.
+    Extrinsics are omitted rather than zero-filled — an all-zero pose is a real
+    mounting here, not a placeholder.
+
+    A stub claims a topic only where the label was also observed in the group's
+    telemetry, so the mapping starts from evidence: the labels that name no
+    topic, and the topics no label matches, are the curator's work.
 
     Arguments
     ---------
@@ -163,15 +152,17 @@ def build_platform_profile_stubs(
     Platform profile stubs with empty curated fields, sorted by key.
     """
     rosters: dict[str, set[str]] = {}
+    topics: dict[str, set[str]] = {}
     platform_classes: dict[str, str] = {}
     for descriptor in descriptors:
         profile_key: str = profile_keys[descriptor.deployment_label]
-        if not descriptor.platform.sensors:
+        if not descriptor.system.sensors:
             diagnostics.warning(
-                descriptor.deployment_label, "empty platform sensor roster"
+                descriptor.deployment_label, "empty system config sensor roster"
             )
-        rosters.setdefault(profile_key, set()).update(
-            sensor.key for sensor in descriptor.platform.sensors
+        rosters.setdefault(profile_key, set()).update(descriptor.system.sensors)
+        topics.setdefault(profile_key, set()).update(
+            descriptor.telemetry.topics
         )
         platform_classes[profile_key] = descriptor.system.vehicle_name
 
@@ -183,9 +174,12 @@ def build_platform_profile_stubs(
             platform_operator="",
             sensors=[
                 CatalogProfileSensor(
-                    key=sensor_key, identity=sensor_identity_key(sensor_key)
+                    key=_snake_case(label),
+                    message_topics=(
+                        [label] if label in topics[profile_key] else []
+                    ),
                 )
-                for sensor_key in sorted(rosters[profile_key])
+                for label in sorted(rosters[profile_key])
             ],
         )
         for profile_key in sorted(rosters)

--- a/src/afft/tasks/deployment_descriptor/__init__.py
+++ b/src/afft/tasks/deployment_descriptor/__init__.py
@@ -3,7 +3,6 @@
 from .builders import (
     build_deployment_file_section as build_deployment_file_section,
     build_deployment_metadata as build_deployment_metadata,
-    build_platform_section as build_platform_section,
     build_system_section as build_system_section,
     build_telemetry_section as build_telemetry_section,
 )

--- a/src/afft/tasks/deployment_descriptor/builders.py
+++ b/src/afft/tasks/deployment_descriptor/builders.py
@@ -8,10 +8,8 @@ from afft.deployment import (
     DeploymentFiles,
     DeploymentFileSection,
     DeploymentMetadata,
-    DeploymentPlatformSection,
     DeploymentSystemSection,
     DeploymentTelemetrySection,
-    PlatformSensor,
 )
 from afft.seabed import SeabedSystemConfig
 
@@ -70,39 +68,14 @@ def build_system_section(
 
     Returns
     -------
-    The deployment vehicle's identity and logging setup.
+    The deployment vehicle's identity, logging setup, and sensor labels.
     """
     return DeploymentSystemSection(
         vehicle_name=system_config.vehicle.vehicle_name,
         vehicle_config=system_config.vehicle.vehicle_config,
         log_directory=system_config.logger.log_dir,
         logged_streams=system_config.logger.logged_streams,
-    )
-
-
-def build_platform_section(
-    system_config: SeabedSystemConfig,
-) -> DeploymentPlatformSection:
-    """
-    Map a parsed SEABED system config onto the descriptor's platform section.
-
-    The section's curated ``identity`` slot and the sensors' ``identity`` and
-    ``extrinsics`` slots are left unfilled; an enrichment process populates
-    them later.
-
-    Arguments
-    ---------
-    system_config: Parsed SEABED system config.
-
-    Returns
-    -------
-    The platform's configured sensor roster, keys only.
-    """
-    return DeploymentPlatformSection(
-        sensors=[
-            PlatformSensor(key=entry.name)
-            for entry in system_config.sensors.entries
-        ]
+        sensors=[entry.name for entry in system_config.sensors.entries],
     )
 
 

--- a/src/afft/tasks/deployment_descriptor/runner.py
+++ b/src/afft/tasks/deployment_descriptor/runner.py
@@ -9,6 +9,7 @@ from rich.progress import Progress
 from afft.deployment import (
     DeploymentDescriptor,
     DeploymentFiles,
+    DeploymentPlatformSection,
     collect_deployment_files,
     write_deployment_descriptors,
 )
@@ -22,7 +23,6 @@ from afft.utils.log import logger
 from .builders import (
     build_deployment_file_section,
     build_deployment_metadata,
-    build_platform_section,
     build_system_section,
     build_telemetry_section,
 )
@@ -131,6 +131,10 @@ def describe_deployment(
     the results onto the descriptor's sections. The localizer config is parsed
     for validation only — nothing from it reaches the descriptor.
 
+    The description is purely observational: the curated platform and vessel
+    sections are left empty for enrichment, which holds the sensor vocabulary
+    the descriptor's rosters are keyed on.
+
     Arguments
     ---------
     directory: Deployment root directory.
@@ -158,8 +162,7 @@ def describe_deployment(
     system_config: SeabedSystemConfig = parse_system_config(files.system_config)
     parse_localizer_config(files.localizer_config)
 
-    platform = build_platform_section(system_config)
-    if not platform.sensors:
+    if not system_config.sensors.entries:
         diagnostics.warning(
             deployment_label, "empty sensor roster in the system config"
         )
@@ -172,7 +175,7 @@ def describe_deployment(
         ),
         files=build_deployment_file_section(files),
         telemetry=build_telemetry_section(files, deployment_label, diagnostics),
-        platform=platform,
+        platform=DeploymentPlatformSection(),
         system=build_system_section(system_config),
     )
 

--- a/src/afft/tasks/deployment_enrichment/runner.py
+++ b/src/afft/tasks/deployment_enrichment/runner.py
@@ -30,7 +30,10 @@ def enrich_descriptors(
     Enrich a set of deployment descriptors from a curated catalog.
 
     A deployment the catalog assigns no profile is a curation gap rather than
-    a failure: it is reported as a warning and keeps its unfilled slots.
+    a failure: it is reported as a warning and keeps its unfilled slots. So is
+    a roster whose declared topics disagree with the ones the deployment
+    logged — a sensor can be fitted without logging, and the catalog leaves
+    some logged hardware deliberately unmounted.
 
     Arguments
     ---------
@@ -57,6 +60,18 @@ def enrich_descriptors(
         if enrichment.vessel_matched is False:
             diagnostics.warning(
                 descriptor.deployment_label, "no vessel profile assigned"
+            )
+        if enrichment.undeclared_topics:
+            diagnostics.warning(
+                descriptor.deployment_label,
+                "logged topics no curated sensor claims: "
+                f"{', '.join(enrichment.undeclared_topics)}",
+            )
+        if enrichment.unobserved_topics:
+            diagnostics.warning(
+                descriptor.deployment_label,
+                "declared topics the deployment never logged: "
+                f"{', '.join(enrichment.unobserved_topics)}",
             )
         enriched.append(enrichment.descriptor)
 

--- a/tests/test_deployment_catalog.py
+++ b/tests/test_deployment_catalog.py
@@ -55,8 +55,8 @@ def _build_catalog() -> DeploymentCatalog:
                 platform_operator="ACFR",
                 sensors=[
                     CatalogProfileSensor(
-                        key="RDI",
-                        identity="dvl_teledyne",
+                        key="dvl_teledyne",
+                        message_topics=["RDI"],
                         extrinsics=CatalogSensorExtrinsics(
                             locx=0.0,
                             locy=0.0,
@@ -67,7 +67,8 @@ def _build_catalog() -> DeploymentCatalog:
                         ),
                     ),
                     CatalogProfileSensor(
-                        key="LQMODEM", identity="usbl_linkquest_transponder"
+                        key="usbl_linkquest_transponder",
+                        message_topics=["LQMODEM"],
                     ),
                 ],
             )
@@ -78,8 +79,7 @@ def _build_catalog() -> DeploymentCatalog:
                 vessel_name="RV Linnaeus",
                 sensors=[
                     CatalogProfileSensor(
-                        key="USBL",
-                        identity="usbl_linkquest_transceiver",
+                        key="usbl_linkquest_transceiver",
                         extrinsics=CatalogSensorExtrinsics(
                             locx=-5.715,
                             locy=-1.258,
@@ -255,9 +255,7 @@ def test_unknown_sensor_identity_is_rejected() -> None:
                     platform_label="AUV Sirius",
                     platform_class="SEABED",
                     platform_operator="ACFR",
-                    sensors=[
-                        CatalogProfileSensor(key="RDI", identity="dvl_teledyne")
-                    ],
+                    sensors=[CatalogProfileSensor(key="dvl_teledyne")],
                 )
             ]
         )

--- a/tests/test_deployment_enrichment.py
+++ b/tests/test_deployment_enrichment.py
@@ -25,7 +25,6 @@ from afft.deployment import (
     DeploymentSystemSection,
     DeploymentTelemetrySection,
     EnrichmentSection,
-    PlatformSensor,
     enrich_descriptor,
     read_deployment_descriptors,
     write_deployment_catalog,
@@ -44,7 +43,7 @@ UNASSIGNED_LABEL: str = "qd61g27j_20100421_022145"
 
 def _build_descriptor(
     label: str,
-    sensor_keys: tuple[str, ...] = ("RDI", "VIS", "MICRON"),
+    topics: tuple[str, ...] = ("RDI", "VIS", "MICRON"),
 ) -> DeploymentDescriptor:
     """Builds a descriptor carrying only the fields enrichment reads."""
     return DeploymentDescriptor(
@@ -59,15 +58,14 @@ def _build_descriptor(
             magnetic_variation=-1.16,
         ),
         files=DeploymentFileSection(),
-        telemetry=DeploymentTelemetrySection(topics=[]),
-        platform=DeploymentPlatformSection(
-            sensors=[PlatformSensor(key=key) for key in sensor_keys]
-        ),
+        telemetry=DeploymentTelemetrySection(topics=list(topics)),
+        platform=DeploymentPlatformSection(),
         system=DeploymentSystemSection(
             vehicle_name="SEABED",
             vehicle_config="NORM_CFG",
             log_directory="/files1/Log",
             logged_streams=["RAW"],
+            sensors=["RDI", "VIS", "MICRON"],
         ),
     )
 
@@ -75,27 +73,28 @@ def _build_descriptor(
 def _build_catalog() -> DeploymentCatalog:
     """
     Builds a catalog assigning both profiles to one deployment and neither to
-    the other, with a platform profile carrying an entry — ``DELTA_T`` — that
-    no roster names and lacking one — ``MICRON`` — that every roster does.
+    the other, with a platform profile mounting a sensor the system config
+    roster does not name — the multibeam — and leaving one it does name — the
+    MICRON sonar — unmounted.
     """
     return DeploymentCatalog(
         sensor_identities=[
             CatalogSensorIdentity(
-                key="dvl_teledyne",
+                key="dvl_teledyne_navigator",
                 label="Teledyne RDI Work Horse Navigator DVL",
                 vendor="Teledyne RDI",
                 product="Work Horse Navigator",
                 type="dvl",
             ),
             CatalogSensorIdentity(
-                key="camera_prosilica",
+                key="camera_avt_prosilica",
                 label="AVT Prosilica GC1380 stereo camera",
                 vendor="AVT",
                 product="Prosilica GC1380",
                 type="stereo_camera",
             ),
             CatalogSensorIdentity(
-                key="sonar_deltat",
+                key="multibeam_deltat",
                 label="Imagenex DeltaT multibeam sonar",
                 vendor="Imagenex",
                 product="DeltaT 837B",
@@ -117,8 +116,8 @@ def _build_catalog() -> DeploymentCatalog:
                 platform_operator="ACFR",
                 sensors=[
                     CatalogProfileSensor(
-                        key="RDI",
-                        identity="dvl_teledyne",
+                        key="dvl_teledyne_navigator",
+                        message_topics=["RDI"],
                         extrinsics=CatalogSensorExtrinsics(
                             locx=0.55,
                             locy=0.0,
@@ -130,12 +129,11 @@ def _build_catalog() -> DeploymentCatalog:
                     ),
                     # Curated without a surveyed pose, the common outcome.
                     CatalogProfileSensor(
-                        key="VIS", identity="camera_prosilica"
+                        key="camera_avt_prosilica", message_topics=["VIS"]
                     ),
-                    # Carried by the profile but named by no roster.
-                    CatalogProfileSensor(
-                        key="DELTA_T", identity="sonar_deltat"
-                    ),
+                    # Mounted though the system config names no channel for
+                    # it, and emitting no topic of its own.
+                    CatalogProfileSensor(key="multibeam_deltat"),
                 ],
             )
         ],
@@ -145,8 +143,7 @@ def _build_catalog() -> DeploymentCatalog:
                 vessel_name="RV Linnaeus",
                 sensors=[
                     CatalogProfileSensor(
-                        key="USBL",
-                        identity="usbl_evologics_transceiver",
+                        key="usbl_evologics_transceiver",
                         extrinsics=CatalogSensorExtrinsics(
                             locx=1.2,
                             locy=-0.4,
@@ -208,7 +205,8 @@ def test_matched_sensor_gets_its_identity_and_extrinsics(
     assert platform.identity.platform_operator == "ACFR"
 
     dvl = platform.sensors[0]
-    assert dvl.key == "RDI"
+    assert dvl.key == "dvl_teledyne_navigator"
+    assert dvl.message_topics == ["RDI"]
     assert dvl.identity is not None
     assert dvl.identity.vendor == "Teledyne RDI"
     assert dvl.extrinsics is not None
@@ -222,31 +220,61 @@ def test_catalog_entry_without_extrinsics_fills_identity_only(
     enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
 
     camera = enrichment.descriptor.platform.sensors[1]
-    assert camera.key == "VIS"
+    assert camera.key == "camera_avt_prosilica"
     assert camera.identity is not None
     assert camera.identity.product == "Prosilica GC1380"
     assert camera.extrinsics is None
 
 
-def test_roster_key_absent_from_the_profile_stays_unfilled(
+def test_platform_roster_comes_wholly_from_the_profile(
     index: DeploymentCatalogIndex,
 ) -> None:
-    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
+    descriptor = _build_descriptor(PLATFORM_LABEL)
 
-    sonar = enrichment.descriptor.platform.sensors[2]
-    assert sonar.key == "MICRON"
-    assert sonar.identity is None
-    assert sonar.extrinsics is None
+    enrichment = enrich_descriptor(descriptor, index)
 
-
-def test_profile_entry_absent_from_the_roster_is_not_added(
-    index: DeploymentCatalogIndex,
-) -> None:
-    enrichment = enrich_descriptor(_build_descriptor(PLATFORM_LABEL), index)
-
+    # The multibeam is mounted though the system config roster omits it, and
+    # the MICRON sonar the roster names is left off, since no profile mounts
+    # it.
     assert [
         sensor.key for sensor in enrichment.descriptor.platform.sensors
-    ] == ["RDI", "VIS", "MICRON"]
+    ] == [
+        "dvl_teledyne_navigator",
+        "camera_avt_prosilica",
+        "multibeam_deltat",
+    ]
+    assert descriptor.system.sensors == ["RDI", "VIS", "MICRON"]
+
+
+def test_topic_mismatches_are_reported_in_both_directions(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(
+        _build_descriptor(PLATFORM_LABEL, topics=("RDI", "MICRON")), index
+    )
+
+    assert enrichment.undeclared_topics == ["MICRON"]
+    assert enrichment.unobserved_topics == ["VIS"]
+
+
+def test_matching_topics_are_not_reported(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(
+        _build_descriptor(PLATFORM_LABEL, topics=("RDI", "VIS")), index
+    )
+
+    assert enrichment.undeclared_topics == []
+    assert enrichment.unobserved_topics == []
+
+
+def test_topics_are_not_compared_without_a_platform_profile(
+    index: DeploymentCatalogIndex,
+) -> None:
+    enrichment = enrich_descriptor(_build_descriptor(UNASSIGNED_LABEL), index)
+
+    assert enrichment.undeclared_topics == []
+    assert enrichment.unobserved_topics == []
 
 
 def test_vessel_section_is_filled_entirely_from_the_profile(
@@ -258,9 +286,13 @@ def test_vessel_section_is_filled_entirely_from_the_profile(
     assert enrichment.vessel_matched is True
     assert vessel.identity is not None
     assert vessel.identity.vessel_name == "RV Linnaeus"
-    assert [sensor.key for sensor in vessel.sensors] == ["USBL"]
+    assert [sensor.key for sensor in vessel.sensors] == [
+        "usbl_evologics_transceiver"
+    ]
 
     modem = vessel.sensors[0]
+    # The transceiver's data arrives through the usbl_logs file role.
+    assert modem.message_topics == []
     assert modem.identity is not None
     assert modem.identity.type == "usbl"
     assert modem.extrinsics is not None
@@ -290,6 +322,10 @@ def test_missing_assignments_are_warned_about_per_section(
         (warning.deployment_label, warning.message)
         for warning in diagnostics.warnings
     ] == [
+        (
+            PLATFORM_LABEL,
+            "logged topics no curated sensor claims: MICRON",
+        ),
         (UNASSIGNED_LABEL, "no platform profile assigned"),
         (UNASSIGNED_LABEL, "no vessel profile assigned"),
     ]
@@ -335,6 +371,20 @@ def test_unrequested_section_is_not_warned_about(
     assert [warning.message for warning in diagnostics.warnings] == [
         "no vessel profile assigned"
     ]
+
+
+def test_topic_mismatches_are_warned_about(
+    descriptors: list[DeploymentDescriptor], catalog: DeploymentCatalog
+) -> None:
+    diagnostics = EnrichDescriptorDiagnostics()
+
+    enrich_descriptors(descriptors, catalog, diagnostics)
+
+    assert [
+        warning.message
+        for warning in diagnostics.warnings
+        if warning.deployment_label == PLATFORM_LABEL
+    ] == ["logged topics no curated sensor claims: MICRON"]
 
 
 def _write_inputs(

--- a/tests/test_describe_deployment.py
+++ b/tests/test_describe_deployment.py
@@ -17,7 +17,6 @@ from afft.tasks.deployment_descriptor import (
     DescribeDeploymentDiagnostics,
     build_deployment_file_section,
     build_deployment_metadata,
-    build_platform_section,
     build_system_section,
     build_telemetry_section,
     run_describe_deployment,
@@ -147,22 +146,18 @@ def test_build_file_section_empties_absent_optional_roles(
     assert section.magvar_config == []
 
 
-def test_build_system_and_platform_sections(tmp_path: Path) -> None:
+def test_build_system_section(tmp_path: Path) -> None:
     directory = _build_deployment(tmp_path, DEPLOYMENT_CONTENTS)
     files = collect_deployment_files(directory)
     system_config = parse_system_config(files.system_config)
 
     system = build_system_section(system_config)
-    platform = build_platform_section(system_config)
 
     assert system.vehicle_name == "SEABED"
     assert system.vehicle_config == "NORM_CFG"
     assert system.log_directory == "/files1/Log"
     assert system.logged_streams == ["SYSLOG", "RAW", "CTL"]
-    assert platform.identity is None
-    assert [sensor.key for sensor in platform.sensors] == ["RDI", "VIS"]
-    assert all(sensor.identity is None for sensor in platform.sensors)
-    assert all(sensor.extrinsics is None for sensor in platform.sensors)
+    assert system.sensors == ["RDI", "VIS"]
 
 
 def test_build_telemetry_section_collects_topics(
@@ -295,10 +290,8 @@ def test_run_writes_descriptor_toml(tmp_path: Path) -> None:
         "2017-05-25T23:46:00+00:00"
     )
     assert descriptor.telemetry.topics == ["GPS_RMC", "RDI", "VIS"]
-    assert [sensor.key for sensor in descriptor.platform.sensors] == [
-        "RDI",
-        "VIS",
-    ]
+    assert descriptor.platform.sensors == []
+    assert descriptor.system.sensors == ["RDI", "VIS"]
     assert descriptor.system.vehicle_name == "SEABED"
     assert descriptor.metadata.acfr_campaign_label == "WA201705"
     assert descriptor.files.localizer_config == [

--- a/tests/test_scaffold_catalog.py
+++ b/tests/test_scaffold_catalog.py
@@ -15,7 +15,6 @@ from afft.deployment import (
     DeploymentPlatformSection,
     DeploymentSystemSection,
     DeploymentTelemetrySection,
-    PlatformSensor,
     read_deployment_catalog,
     write_deployment_descriptors,
 )
@@ -31,7 +30,8 @@ def _build_descriptor(
     label: str,
     moment: datetime,
     campaign: str,
-    sensor_keys: tuple[str, ...],
+    sensor_labels: tuple[str, ...],
+    topics: tuple[str, ...] = (),
     usbl_logs: tuple[str, ...] = ("usbl/log-1.txt",),
 ) -> DeploymentDescriptor:
     """Builds a descriptor carrying only the fields the scaffolder reads."""
@@ -47,15 +47,14 @@ def _build_descriptor(
             magnetic_variation=-1.16,
         ),
         files=DeploymentFileSection(usbl_logs=list(usbl_logs)),
-        telemetry=DeploymentTelemetrySection(topics=[]),
-        platform=DeploymentPlatformSection(
-            sensors=[PlatformSensor(key=key) for key in sensor_keys]
-        ),
+        telemetry=DeploymentTelemetrySection(topics=list(topics)),
+        platform=DeploymentPlatformSection(),
         system=DeploymentSystemSection(
             vehicle_name="SEABED",
             vehicle_config="NORM_CFG",
             log_directory="/files1/Log",
             logged_streams=["RAW"],
+            sensors=list(sensor_labels),
         ),
     )
 
@@ -69,12 +68,14 @@ def descriptors() -> list[DeploymentDescriptor]:
             datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
             "WA201004",
             ("RDI", "VIS"),
+            topics=("RDI", "VIS"),
         ),
         _build_descriptor(
             "qd61g27j_20100421_022145",
             datetime(2010, 4, 21, 2, 21, 45, tzinfo=timezone.utc),
             "WA201004",
             ("RDI", "PAROSCI"),
+            topics=("RDI",),
         ),
         _build_descriptor(
             "qdch0ftq_20110415_020103",
@@ -105,14 +106,15 @@ def test_platform_profile_sensors_are_the_union_of_the_year(
 
     profile = catalog.platform_profiles[0]
     assert [sensor.key for sensor in profile.sensors] == [
-        "PAROSCI",
-        "RDI",
-        "VIS",
-    ]
-    assert [sensor.identity for sensor in profile.sensors] == [
         "parosci",
         "rdi",
         "vis",
+    ]
+    # A stub claims a label only where the group also logged it as a topic.
+    assert [sensor.message_topics for sensor in profile.sensors] == [
+        [],
+        ["RDI"],
+        ["VIS"],
     ]
     assert all(sensor.extrinsics is None for sensor in profile.sensors)
 

--- a/tests/test_summarize_catalog.py
+++ b/tests/test_summarize_catalog.py
@@ -61,8 +61,8 @@ def _build_catalog() -> DeploymentCatalog:
                 platform_operator="ACFR",
                 sensors=[
                     CatalogProfileSensor(
-                        key="RDI",
-                        identity="dvl_teledyne",
+                        key="dvl_teledyne",
+                        message_topics=["RDI"],
                         extrinsics=_extrinsics(),
                     )
                 ],
@@ -180,7 +180,10 @@ def test_summarize_reports_unreferenced_sensor_identities() -> None:
 def test_summarize_groups_curation_gaps_by_field() -> None:
     """Gaps group by field and carry the records they affect."""
     catalog = DeploymentCatalog(
-        sensor_identities=[_sensor_identity(vendor="")],
+        sensor_identities=[
+            _sensor_identity(vendor=""),
+            _sensor_identity(key="sonar_obstacle_avoidance"),
+        ],
         platform_profiles=[
             CatalogPlatformProfile(
                 key="sirius_2010",
@@ -188,10 +191,12 @@ def test_summarize_groups_curation_gaps_by_field() -> None:
                 platform_class="SEABED",
                 platform_operator="",
                 sensors=[
-                    CatalogProfileSensor(key="RDI", identity="dvl_teledyne"),
                     CatalogProfileSensor(
-                        key="OAS",
-                        identity="dvl_teledyne",
+                        key="dvl_teledyne", message_topics=["RDI"]
+                    ),
+                    CatalogProfileSensor(
+                        key="sonar_obstacle_avoidance",
+                        message_topics=["OAS"],
                         extrinsics=_extrinsics(),
                     ),
                 ],
@@ -207,7 +212,9 @@ def test_summarize_groups_curation_gaps_by_field() -> None:
 
     assert gaps["sensor_identities.vendor"] == ["dvl_teledyne"]
     assert gaps["platform_profiles.platform_operator"] == ["sirius_2010"]
-    assert gaps["platform_profiles.sensors.extrinsics"] == ["sirius_2010[RDI]"]
+    assert gaps["platform_profiles.sensors.extrinsics"] == [
+        "sirius_2010[dvl_teledyne]"
+    ]
     assert gaps["vessel_profiles.vessel_name"] == ["linnaeus"]
     assert "platform_profiles.platform_label" not in gaps
 

--- a/tests/test_summarize_descriptors.py
+++ b/tests/test_summarize_descriptors.py
@@ -211,9 +211,15 @@ def test_summarize_groups_partially_filled_rosters() -> None:
         ),
         sensors=[
             PlatformSensor(
-                key="RDI", identity=_identity(vendor=""), extrinsics=None
+                key="dvl_teledyne_navigator",
+                identity=_identity(vendor=""),
+                extrinsics=None,
             ),
-            PlatformSensor(key="OAS", identity=None, extrinsics=_extrinsics()),
+            PlatformSensor(
+                key="sonar_obstacle_avoidance",
+                identity=_identity(),
+                extrinsics=_extrinsics(),
+            ),
         ],
     )
     descriptors: list[DeploymentDescriptor] = [
@@ -239,12 +245,17 @@ def test_summarize_groups_partially_filled_rosters() -> None:
     assert gaps["platform.identity.platform_operator"] == [
         "aaa_20100428_020202"
     ]
-    assert gaps["platform.sensors[RDI].identity.vendor"] == [
+    assert gaps["platform.sensors[dvl_teledyne_navigator].identity.vendor"] == [
         "aaa_20100428_020202"
     ]
-    assert gaps["platform.sensors[RDI].extrinsics"] == ["aaa_20100428_020202"]
-    assert gaps["platform.sensors[OAS].identity"] == ["aaa_20100428_020202"]
-    assert "platform.sensors[OAS].extrinsics" not in gaps
+    assert gaps["platform.sensors[dvl_teledyne_navigator].extrinsics"] == [
+        "aaa_20100428_020202"
+    ]
+    # A fully curated sensor contributes no gap at all.
+    assert not any(
+        field.startswith("platform.sensors[sonar_obstacle_avoidance]")
+        for field in gaps
+    )
 
 
 def test_collect_unfilled_fields_reports_empty_platform_label() -> None:

--- a/tests/test_transform_camera_poses.py
+++ b/tests/test_transform_camera_poses.py
@@ -25,6 +25,7 @@ from afft.deployment import (
     DeploymentTelemetrySection,
     PlatformSensor,
     SensorExtrinsics,
+    SensorIdentity,
     write_deployment_descriptors,
 )
 from afft.tasks.transform_camera_poses import (
@@ -98,10 +99,34 @@ def _build_descriptor(
     )
 
 
-def _camera_sensor(posx: float = 0.82) -> PlatformSensor:
-    """A VIS sensor carrying the catalog's curated stereo camera pose."""
+def _camera_identity() -> SensorIdentity:
+    """The curated identity the camera is found by."""
+    return SensorIdentity(
+        label="AVT Prosilica GC1380 stereo camera",
+        vendor="AVT",
+        product="Prosilica GC1380",
+        type="stereo_camera",
+    )
+
+
+def _dvl_sensor() -> PlatformSensor:
+    """A roster entry that is not a camera."""
     return PlatformSensor(
-        key="VIS",
+        key="dvl_teledyne_navigator",
+        identity=SensorIdentity(
+            label="Teledyne RDI Work Horse Navigator DVL",
+            vendor="Teledyne RDI",
+            product="Work Horse Navigator",
+            type="dvl",
+        ),
+    )
+
+
+def _camera_sensor(posx: float = 0.82) -> PlatformSensor:
+    """A camera sensor carrying the catalog's curated stereo camera pose."""
+    return PlatformSensor(
+        key="camera_avt_prosilica",
+        identity=_camera_identity(),
         extrinsics=SensorExtrinsics(
             locx=posx,
             locy=-0.035,
@@ -190,18 +215,21 @@ def test_extrinsics_lookup_names_available_deployments(
 
 
 def test_extrinsics_rejects_roster_without_camera() -> None:
-    descriptor = _build_descriptor(
-        "qdch0ftq_20100428_020202", [PlatformSensor(key="RDI")]
-    )
+    descriptor = _build_descriptor("qdch0ftq_20100428_020202", [_dvl_sensor()])
 
-    with pytest.raises(KeyError, match="no VIS sensor"):
+    with pytest.raises(KeyError, match="no stereo_camera sensor"):
         _camera_extrinsics(descriptor)
 
 
-def test_extrinsics_rejects_unenriched_camera() -> None:
-    """The common case: a roster entry whose extrinsics enrichment never filled."""
+def test_extrinsics_rejects_camera_without_a_pose() -> None:
+    """The common case: a curated camera the catalog has no pose for."""
     descriptor = _build_descriptor(
-        "qdch0ftq_20100428_020202", [PlatformSensor(key="VIS")]
+        "qdch0ftq_20100428_020202",
+        [
+            PlatformSensor(
+                key="camera_avt_prosilica", identity=_camera_identity()
+            )
+        ],
     )
 
     with pytest.raises(ValueError, match="no extrinsics"):
@@ -238,11 +266,15 @@ def test_extrinsics_skip_unenriched_deployments(tmp_path: Path) -> None:
         [
             _build_descriptor("qdch0ftq_20100428_020202", [_camera_sensor()]),
             _build_descriptor(
-                "qd61g27j_20100421_022145", [PlatformSensor(key="VIS")]
+                "qd61g27j_20100421_022145",
+                [
+                    PlatformSensor(
+                        key="camera_avt_prosilica",
+                        identity=_camera_identity(),
+                    )
+                ],
             ),
-            _build_descriptor(
-                "qdch0ftq_20110415_020103", [PlatformSensor(key="RDI")]
-            ),
+            _build_descriptor("qdch0ftq_20110415_020103", [_dvl_sensor()]),
         ],
     )
 


### PR DESCRIPTION
Closes #204.

The catalog carried two sensor key vocabularies, and the descriptor carried the wrong one: `CatalogSensorIdentity.key` described hardware, while `CatalogProfileSensor.key` named a system config roster slot.

## Catalog

`CatalogProfileSensor.key` now names the `sensor_identities` record of the unit fitted to that slot, so `identity` disappears and `message_topics` takes its place:

```toml
[[platform_profiles]]
sensors = [
    { key = "dvl_teledyne_navigator", message_topics = ["RDI"], extrinsics = { ... } },
]
```

Identity records become slot-scoped. `dvl_teledyne` is renamed to `dvl_teledyne_navigator`, `oxygen_aanderaa` is new and mounted on `2021_auv_sirius`, `sonar_micron` and `sonar_obstacle_avoidance` are new reference records, and `imu` is removed outright — one profile, no extrinsics, and no topic in any of the 52 deployments. The thrusters, the battery packs and the sonars leave every roster but keep their records, so the hardware stays described.

## Descriptor

`PlatformSensor` and `VesselSensor` gain `message_topics`, so a descriptor holds both the observed topics and the declared ones and needs no catalog to compare them. `DeploymentSystemSection` gains the system config roster, kept as observed data — its value is precisely that it can disagree with the curated roster.

`deployment describe` stops populating the roster and becomes purely observational; `build_platform_section` is removed. Enrichment builds both rosters wholly from the assigned profile, and the platform and vessel paths converge on a shared implementation. That mounts the sensors an incomplete syscfg roster used to drop: the three 2021 deployments log `VIS` and `AANDERAA_4319` but their syscfg names neither, so they previously carried no camera at all.

A sensor´s tri-state collapses to two: with the roster empty before enrichment and complete after, "present but unfilled" disappears for `identity`. Only `extrinsics` stays legitimately `None`.

## Topic cross-check

Enrichment compares the declared `message_topics` against the observed `telemetry.topics` and warns in both directions — a sensor can be fitted without logging, and the catalog leaves some logged hardware deliberately unmounted, so neither direction is an error. This replaces the check lost when the descriptor roster stopped being matched against the profile.

## Consequences

- The renav camera lookup resolves the stereo camera by sensor type rather than the `VIS` key, since a key now identifies a unit rather than a role and the vehicle flew two different cameras.
- `tasks/deployment_catalog/builders.py` loses `sensor_identity_key`; stubs are keyed on the lowercased system config label, and a stub claims a topic only where the label was also observed in the group´s telemetry.
- The four deliberately unmounted reference records surface on every `summarize-catalog` run. That is accepted for now, as the record itself does not say whether it is a reference or an oversight.
- The subset catalog´s `2013_auv_sirius` profile was still written as sub-tables rather than an inline array, which the new schema could not read; it is normalized to match every other profile.

## Verification

All 52 enriched descriptors were regenerated. Every deployment resolves a platform identity and a complete roster, every sensor key names a catalog identity, and each descriptor roster matches its assigned profile exactly. The freshly described output is model-identical to the migrated file. Lint, format, type checks and the 217 tests pass.