### PR TITLE
Add sensor calibration to PlatformSensor and VesselSensor

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -27,6 +27,7 @@ from .common_types import (
     DeploymentMetadata as DeploymentMetadata,
     PlatformIdentity as PlatformIdentity,
     PlatformSensor as PlatformSensor,
+    SensorCalibration as SensorCalibration,
     SensorExtrinsics as SensorExtrinsics,
     SensorIdentity as SensorIdentity,
     VesselIdentity as VesselIdentity,

--- a/src/afft/deployment/common_types.py
+++ b/src/afft/deployment/common_types.py
@@ -75,6 +75,25 @@ class SensorExtrinsics(BaseModel):
     rotz: float
 
 
+class SensorCalibration(BaseModel):
+    """
+    A sensor's calibration. Filled during bundle building from parsed
+    calibration files, not by enrichment — unlike identity and extrinsics,
+    it has no catalog source.
+
+    Attributes
+    ----------
+    sensor_type: Discriminates which calibration model ``parameters``
+        follows, e.g. ``"pinhole"``, ``"fisheye"``.
+    parameters: Named calibration values for that model.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    sensor_type: str
+    parameters: dict[str, float]
+
+
 class PlatformSensor(BaseModel):
     """
     A sensor mounted on the deployment's platform. The whole roster is curated
@@ -92,6 +111,8 @@ class PlatformSensor(BaseModel):
         wrote.
     extrinsics: Mounting pose in the vehicle (SNAME) body frame; ``None``
         where the sensor has no surveyed pose.
+    calibration: Camera calibration parameters; ``None`` until bundle
+        building resolves it from parsed calibration files.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -100,6 +121,7 @@ class PlatformSensor(BaseModel):
     message_topics: list[str] = Field(default_factory=list)
     identity: SensorIdentity | None = None
     extrinsics: SensorExtrinsics | None = None
+    calibration: SensorCalibration | None = None
 
 
 class VesselSensor(BaseModel):
@@ -117,6 +139,8 @@ class VesselSensor(BaseModel):
         wrote.
     extrinsics: Mounting pose in the ship reference frame; ``None`` where the
         sensor has no surveyed pose.
+    calibration: Camera calibration parameters; ``None`` until bundle
+        building resolves it from parsed calibration files.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -125,6 +149,7 @@ class VesselSensor(BaseModel):
     message_topics: list[str] = Field(default_factory=list)
     identity: SensorIdentity | None = None
     extrinsics: SensorExtrinsics | None = None
+    calibration: SensorCalibration | None = None
 
 
 class PlatformIdentity(BaseModel):

--- a/src/afft/deployment/common_types.py
+++ b/src/afft/deployment/common_types.py
@@ -83,14 +83,14 @@ class SensorCalibration(BaseModel):
 
     Attributes
     ----------
-    sensor_type: Discriminates which calibration model ``parameters``
+    calibration_type: Discriminates which calibration model ``parameters``
         follows, e.g. ``"pinhole"``, ``"fisheye"``.
     parameters: Named calibration values for that model.
     """
 
     model_config = ConfigDict(frozen=True)
 
-    sensor_type: str
+    calibration_type: str
     parameters: dict[str, float]
 
 

--- a/src/afft/deployment/descriptor_io.py
+++ b/src/afft/deployment/descriptor_io.py
@@ -97,10 +97,7 @@ def _format_table(
     for key, value in table.items():
         if isinstance(value, dict):
             if dotted_children:
-                lines.extend(
-                    f"{key}.{_format_pair(nested_key, nested_value)}"
-                    for nested_key, nested_value in value.items()
-                )
+                lines.extend(_format_dotted_pairs(key, value))
             else:
                 tables.append((key, value))
         elif _is_table_array(value):
@@ -132,6 +129,29 @@ def _is_table_array(value: Any) -> bool:
         and bool(value)
         and all(isinstance(entry, dict) for entry in value)
     )
+
+
+def _format_dotted_pairs(prefix: str, table: dict[str, Any]) -> list[str]:
+    """
+    Format a nested table as dotted-key lines, recursing through nested
+    dicts so every leaf value becomes its own ``prefix.path = value`` line.
+
+    Arguments
+    ---------
+    prefix: Dotted key path built so far.
+    table: The table's contents.
+
+    Returns
+    -------
+    One dotted-key line per leaf value.
+    """
+    lines: list[str] = []
+    for key, value in table.items():
+        if isinstance(value, dict):
+            lines.extend(_format_dotted_pairs(f"{prefix}.{key}", value))
+        else:
+            lines.append(f"{prefix}.{_format_pair(key, value)}")
+    return lines
 
 
 def _format_pair(key: str, value: Any) -> str:

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -12,6 +12,7 @@ from afft.deployment import (
     PlatformDescriptorSection,
     PlatformIdentity,
     PlatformSensor,
+    SensorCalibration,
     SensorExtrinsics,
     SystemDescriptorSection,
     TelemetryDescriptorSection,
@@ -115,12 +116,14 @@ def test_unfilled_curated_slots_are_omitted(tmp_path: Path) -> None:
     assert "identity" not in entry["platform"]
     assert "identity" not in entry["platform"]["sensors"][0]
     assert "extrinsics" not in entry["platform"]["sensors"][0]
+    assert "calibration" not in entry["platform"]["sensors"][0]
 
     descriptors = read_deployment_descriptors(path)
     assert descriptors[0].vessel == VesselDescriptorSection()
     assert descriptors[0].platform.identity is None
     assert descriptors[0].platform.sensors[0].identity is None
     assert descriptors[0].platform.sensors[0].extrinsics is None
+    assert descriptors[0].platform.sensors[0].calibration is None
 
 
 def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
@@ -142,6 +145,10 @@ def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
                             rotx=0.0,
                             roty=0.0,
                             rotz=3.14,
+                        ),
+                        calibration=SensorCalibration(
+                            sensor_type="pinhole",
+                            parameters={"fx": 500.0, "fy": 500.0},
                         ),
                     )
                 ],
@@ -170,6 +177,10 @@ def test_filled_vessel_section_round_trip(tmp_path: Path) -> None:
                             rotx=0.0,
                             roty=0.0,
                             rotz=1.57,
+                        ),
+                        calibration=SensorCalibration(
+                            sensor_type="pinhole",
+                            parameters={"fx": 500.0, "fy": 500.0},
                         ),
                     )
                 ],

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -147,7 +147,7 @@ def test_filled_curated_slots_round_trip(tmp_path: Path) -> None:
                             rotz=3.14,
                         ),
                         calibration=SensorCalibration(
-                            sensor_type="pinhole",
+                            calibration_type="pinhole",
                             parameters={"fx": 500.0, "fy": 500.0},
                         ),
                     )
@@ -179,7 +179,7 @@ def test_filled_vessel_section_round_trip(tmp_path: Path) -> None:
                             rotz=1.57,
                         ),
                         calibration=SensorCalibration(
-                            sensor_type="pinhole",
+                            calibration_type="pinhole",
                             parameters={"fx": 500.0, "fy": 500.0},
                         ),
                     )


### PR DESCRIPTION
## Summary
- Adds `SensorCalibration` (`sensor_type` + `parameters: dict[str, float]`) to `common_types.py`, and an optional `calibration` field to `PlatformSensor`/`VesselSensor`. Unlike `identity`/`extrinsics`, it's populated during bundle building from parsed calibration files rather than by enrichment, so it stays `None` until then.
- Fixes a gap in the deployment descriptor TOML writer surfaced by this change: the dotted-key serialization only supported one level of nesting (`extrinsics.locx`), which broke on `calibration.parameters` (a dict of a dict). Added a recursive `_format_dotted_pairs` helper so arbitrarily nested dicts under a sensor roster entry serialize correctly.

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy` (strict)
- [x] `pytest` — full suite passes (217 passed), including new/extended coverage in `test_deployment_descriptor.py` for calibration omission and round-trip (platform + vessel)