### PR TITLE
Add deployment bundle types and read/write Protocol interfaces

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -14,6 +14,33 @@ from .catalog_io import (
     read_deployment_catalog as read_deployment_catalog,
     write_deployment_catalog as write_deployment_catalog,
 )
+from .bundle_types import (
+    DeploymentBundleHeader as DeploymentBundleHeader,
+    DeploymentIdentity as DeploymentIdentity,
+    DeploymentProvenance as DeploymentProvenance,
+    ProcessedProvenance as ProcessedProvenance,
+)
+from .bundle_protocols import (
+    DeploymentBundleReader as DeploymentBundleReader,
+    DeploymentBundleSectionReader as DeploymentBundleSectionReader,
+    DeploymentBundleSectionWriter as DeploymentBundleSectionWriter,
+    DeploymentBundleWriter as DeploymentBundleWriter,
+    MetoceanBundleSectionReader as MetoceanBundleSectionReader,
+    MetoceanBundleSectionWriter as MetoceanBundleSectionWriter,
+    PlatformBundleSectionReader as PlatformBundleSectionReader,
+    PlatformBundleSectionWriter as PlatformBundleSectionWriter,
+    ProcessedTelemetryBundleSectionReader as ProcessedTelemetryBundleSectionReader,
+    ProcessedTelemetryBundleSectionWriter as ProcessedTelemetryBundleSectionWriter,
+    RawTelemetryBundleSectionReader as RawTelemetryBundleSectionReader,
+    RawTelemetryBundleSectionWriter as RawTelemetryBundleSectionWriter,
+    TelemetryBundleSectionReader as TelemetryBundleSectionReader,
+    TelemetryBundleSectionWriter as TelemetryBundleSectionWriter,
+    TimeWindow as TimeWindow,
+    VesselBundleSectionReader as VesselBundleSectionReader,
+    VesselBundleSectionWriter as VesselBundleSectionWriter,
+    open_deployment_bundle_reader as open_deployment_bundle_reader,
+    open_deployment_bundle_writer as open_deployment_bundle_writer,
+)
 from .catalog_summary import (
     AssignmentCoverage as AssignmentCoverage,
     CatalogCurationGap as CatalogCurationGap,

--- a/src/afft/deployment/bundle_protocols.py
+++ b/src/afft/deployment/bundle_protocols.py
@@ -1,0 +1,350 @@
+"""Storage-agnostic read and write interfaces for a deployment bundle."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Protocol
+
+import pandas as pd
+
+from .bundle_types import (
+    DeploymentBundleHeader,
+    DeploymentIdentity,
+    DeploymentProvenance,
+    ProcessedProvenance,
+)
+from .common_types import (
+    DeploymentMetadata,
+    PlatformIdentity,
+    PlatformSensor,
+    VesselIdentity,
+    VesselSensor,
+)
+
+
+class TimeWindow(Protocol):
+    """
+    A time range for narrowing a telemetry or metocean read, replacing a
+    PyTables ``where=`` string so the interface never speaks PyTables query
+    syntax.
+
+    Attributes
+    ----------
+    start: Start of the window; unbounded below when ``None``.
+    end: End of the window; unbounded above when ``None``.
+    """
+
+    start: datetime | None
+    end: datetime | None
+
+
+class DeploymentBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``deployment`` section."""
+
+    def identity(self) -> DeploymentIdentity:
+        """Read ``deployment/identity``."""
+        ...
+
+    def metadata(self) -> DeploymentMetadata:
+        """Read ``deployment/metadata``."""
+        ...
+
+    def provenance(self) -> DeploymentProvenance:
+        """Read ``deployment/provenance``."""
+        ...
+
+    def files(self) -> pd.DataFrame:
+        """Read ``deployment/files``."""
+        ...
+
+
+class PlatformBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``platform`` section."""
+
+    def identity(self) -> PlatformIdentity:
+        """Read ``platform/identity``."""
+        ...
+
+    def sensor_keys(self) -> list[str]:
+        """List the platform's sensor keys."""
+        ...
+
+    def sensors(self) -> list[PlatformSensor]:
+        """
+        Read the platform's sensor roster.
+
+        Each returned sensor already carries its identity, message topics,
+        extrinsics, and calibration.
+        """
+        ...
+
+
+class VesselBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``vessel`` section."""
+
+    def identity(self) -> VesselIdentity:
+        """Read ``vessel/identity``."""
+        ...
+
+    def sensor_keys(self) -> list[str]:
+        """List the vessel's sensor keys."""
+        ...
+
+    def sensors(self) -> list[VesselSensor]:
+        """
+        Read the vessel's sensor roster.
+
+        Each returned sensor already carries its identity, message topics,
+        extrinsics, and calibration.
+        """
+        ...
+
+
+class RawTelemetryBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``telemetry/raw`` section."""
+
+    def topics(self) -> list[tuple[str, str]]:
+        """List the ``(sensor_key, message_topic)`` pairs present."""
+        ...
+
+    def sensor_keys(self) -> list[str]:
+        """List the sensor keys with raw telemetry present."""
+        ...
+
+    def read(
+        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        """Read one raw telemetry table, optionally narrowed to a window."""
+        ...
+
+
+class ProcessedTelemetryBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``telemetry/processed`` section."""
+
+    def topics(self) -> list[tuple[str, str]]:
+        """List the ``(sensor_key, message_topic)`` pairs present."""
+        ...
+
+    def sensor_keys(self) -> list[str]:
+        """List the sensor keys with processed telemetry present, including ``"_derived"``."""
+        ...
+
+    def read(
+        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        """Read one processed telemetry table, optionally narrowed to a window."""
+        ...
+
+    def provenance(self, sensor_key: str, topic: str) -> ProcessedProvenance:
+        """Read the provenance of one processed telemetry table."""
+        ...
+
+
+class TelemetryBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``telemetry`` section."""
+
+    raw: RawTelemetryBundleSectionReader
+    processed: ProcessedTelemetryBundleSectionReader
+
+    def topics(self) -> list[tuple[str, str]]:
+        """List the ``(sensor_key, message_topic)`` pairs present across raw and processed."""
+        ...
+
+
+class MetoceanBundleSectionReader(Protocol):
+    """Read accessor for a bundle's ``metocean`` section."""
+
+    def providers(self) -> list[str]:
+        """List the metocean providers present."""
+        ...
+
+    def variables(self, provider: str) -> list[str]:
+        """List the variables present for one provider."""
+        ...
+
+    def read(
+        self, provider: str, variable: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        """Read one metocean table, optionally narrowed to a window."""
+        ...
+
+
+class DeploymentBundleReader(Protocol):
+    """Read interface for a deployment bundle."""
+
+    header: DeploymentBundleHeader
+    deployment: DeploymentBundleSectionReader
+    platform: PlatformBundleSectionReader
+    vessel: VesselBundleSectionReader
+    telemetry: TelemetryBundleSectionReader
+    metocean: MetoceanBundleSectionReader
+
+
+class DeploymentBundleSectionWriter(Protocol):
+    """
+    Write primitives for a bundle's ``deployment`` section.
+
+    Each method is write-once — it raises if the target node already exists.
+    """
+
+    def write_identity(self, value: DeploymentIdentity) -> None:
+        """Write ``deployment/identity``."""
+        ...
+
+    def write_metadata(self, value: DeploymentMetadata) -> None:
+        """Write ``deployment/metadata``."""
+        ...
+
+    def write_files(self, frame: pd.DataFrame) -> None:
+        """Write ``deployment/files``."""
+        ...
+
+    def write_provenance(self, value: DeploymentProvenance) -> None:
+        """Write ``deployment/provenance``."""
+        ...
+
+
+class PlatformBundleSectionWriter(Protocol):
+    """
+    Write primitives for a bundle's ``platform`` section.
+
+    Each method is write-once — it raises if the target node already exists.
+    """
+
+    def write_identity(self, value: PlatformIdentity) -> None:
+        """Write ``platform/identity``."""
+        ...
+
+    def write_sensors(self, values: list[PlatformSensor]) -> None:
+        """Write the platform's sensor roster."""
+        ...
+
+
+class VesselBundleSectionWriter(Protocol):
+    """
+    Write primitives for a bundle's ``vessel`` section.
+
+    Each method is write-once — it raises if the target node already exists.
+    """
+
+    def write_identity(self, value: VesselIdentity) -> None:
+        """Write ``vessel/identity``."""
+        ...
+
+    def write_sensors(self, values: list[VesselSensor]) -> None:
+        """Write the vessel's sensor roster."""
+        ...
+
+
+class RawTelemetryBundleSectionWriter(Protocol):
+    """
+    Write primitive for a bundle's ``telemetry/raw`` section.
+
+    Write-once — it raises if the target node already exists.
+    """
+
+    def write(self, sensor_key: str, topic: str, frame: pd.DataFrame) -> None:
+        """Write one raw telemetry table."""
+        ...
+
+
+class ProcessedTelemetryBundleSectionWriter(Protocol):
+    """Write primitives for a bundle's ``telemetry/processed`` section."""
+
+    def append(
+        self,
+        sensor_key: str,
+        topic: str,
+        frame: pd.DataFrame,
+        provenance: ProcessedProvenance,
+    ) -> None:
+        """Append rows to one processed telemetry table."""
+        ...
+
+    def replace(
+        self,
+        sensor_key: str,
+        topic: str,
+        frame: pd.DataFrame,
+        provenance: ProcessedProvenance,
+    ) -> None:
+        """Replace one processed telemetry table."""
+        ...
+
+
+class TelemetryBundleSectionWriter(Protocol):
+    """Write primitives for a bundle's ``telemetry`` section."""
+
+    raw: RawTelemetryBundleSectionWriter
+    processed: ProcessedTelemetryBundleSectionWriter
+
+
+class MetoceanBundleSectionWriter(Protocol):
+    """
+    Write primitive for a bundle's ``metocean`` section.
+
+    Write-once — it raises if the target node already exists.
+    """
+
+    def write(self, provider: str, variable: str, frame: pd.DataFrame) -> None:
+        """Write one metocean table."""
+        ...
+
+
+class DeploymentBundleWriter(Protocol):
+    """Write interface for a deployment bundle."""
+
+    def write_header(self, value: DeploymentBundleHeader) -> None:
+        """Write the root ``bundle`` table."""
+        ...
+
+    deployment: DeploymentBundleSectionWriter
+    platform: PlatformBundleSectionWriter
+    vessel: VesselBundleSectionWriter
+    telemetry: TelemetryBundleSectionWriter
+    metocean: MetoceanBundleSectionWriter
+
+
+@contextmanager
+def open_deployment_bundle_reader(
+    path: Path,
+) -> Iterator[DeploymentBundleReader]:
+    """
+    Open a deployment bundle for reading.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Returns
+    -------
+    A context manager yielding a ``DeploymentBundleReader``.
+    """
+    raise NotImplementedError(
+        "open_deployment_bundle_reader has no concrete implementation yet; "
+        "see afft #208"
+    )
+    yield  # pragma: no cover
+
+
+@contextmanager
+def open_deployment_bundle_writer(
+    path: Path,
+) -> Iterator[DeploymentBundleWriter]:
+    """
+    Open a deployment bundle for writing.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Returns
+    -------
+    A context manager yielding a ``DeploymentBundleWriter``.
+    """
+    raise NotImplementedError(
+        "open_deployment_bundle_writer has no concrete implementation yet; "
+        "see afft #208"
+    )
+    yield  # pragma: no cover

--- a/src/afft/deployment/bundle_types.py
+++ b/src/afft/deployment/bundle_types.py
@@ -1,0 +1,80 @@
+"""Data types describing a deployment bundle, as distinct from the deployment itself."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DeploymentIdentity(BaseModel):
+    """
+    Core identity of a deployment, stored as the single row of
+    ``deployment/identity``.
+
+    Attributes
+    ----------
+    deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
+    deployment_datetime: Deployment datetime.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_label: str
+    deployment_datetime: datetime
+
+
+class DeploymentBundleHeader(BaseModel):
+    """
+    File-level facts about a deployment bundle, stored as the single row of
+    the root ``bundle`` table.
+
+    Attributes
+    ----------
+    schema_version: Layout version the bundle was written against.
+    created_datetime: When the bundle file was created.
+    builder_version: Version of the builder that produced the bundle.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: str
+    created_datetime: datetime
+    builder_version: str
+
+
+class DeploymentProvenance(BaseModel):
+    """
+    Facts about how a bundle's deployment description was derived, stored as
+    the single row of ``deployment/provenance``.
+
+    Fields beyond ``deployment_key`` are unsettled — descriptor hash, catalog
+    version, and enrichment version are all candidates but not yet decided
+    and are expected to be added later.
+
+    Attributes
+    ----------
+    deployment_key: Identifier of the deployment the bundle was built from.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    deployment_key: str
+
+
+class ProcessedProvenance(BaseModel):
+    """
+    Facts about how one processed telemetry table was produced, stored
+    alongside it at
+    ``telemetry/processed/<sensor_key>/<message_topic>/provenance``.
+
+    Fields beyond ``run_datetime`` are unsettled — input paths, processor
+    versions, and pipeline config are all candidates but not yet decided and
+    are expected to be added later.
+
+    Attributes
+    ----------
+    run_datetime: When the processing step ran.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    run_datetime: datetime

--- a/tests/test_deployment_bundle_types.py
+++ b/tests/test_deployment_bundle_types.py
@@ -1,0 +1,49 @@
+"""Tests for the deployment bundle datatypes."""
+
+from datetime import datetime
+
+from afft.deployment import (
+    DeploymentBundleHeader,
+    DeploymentIdentity,
+    DeploymentProvenance,
+    ProcessedProvenance,
+)
+
+
+def test_deployment_identity() -> None:
+    """Constructs a deployment identity."""
+    identity: DeploymentIdentity = DeploymentIdentity(
+        deployment_label="r20101003_054452_alligator_creek_south_02",
+        deployment_datetime=datetime(2010, 10, 3, 5, 44, 52),
+    )
+    assert identity.deployment_label == (
+        "r20101003_054452_alligator_creek_south_02"
+    )
+
+
+def test_deployment_bundle_header() -> None:
+    """Constructs a deployment bundle header."""
+    header: DeploymentBundleHeader = DeploymentBundleHeader(
+        schema_version="1.0",
+        created_datetime=datetime(2026, 8, 5, 12, 0, 0),
+        builder_version="0.1.0",
+    )
+    assert header.schema_version == "1.0"
+
+
+def test_deployment_provenance() -> None:
+    """Constructs a deployment provenance record."""
+    provenance: DeploymentProvenance = DeploymentProvenance(
+        deployment_key="r20101003_054452_alligator_creek_south_02"
+    )
+    assert provenance.deployment_key == (
+        "r20101003_054452_alligator_creek_south_02"
+    )
+
+
+def test_processed_provenance() -> None:
+    """Constructs a processed telemetry provenance record."""
+    provenance: ProcessedProvenance = ProcessedProvenance(
+        run_datetime=datetime(2026, 8, 5, 12, 0, 0)
+    )
+    assert provenance.run_datetime == datetime(2026, 8, 5, 12, 0, 0)


### PR DESCRIPTION
## Summary
- Adds the storage-agnostic deployment bundle contract from #199: `bundle_types.py` (`DeploymentIdentity`, `DeploymentBundleHeader`, `DeploymentProvenance`, `ProcessedProvenance`) and `bundle_protocols.py` (section-scoped read/write `Protocol`s plus `open_deployment_bundle_reader`/`writer`)
- `open_deployment_bundle_reader`/`writer` are stubbed with `NotImplementedError` pending the HDF5 implementation in #208
- Exports new types from `afft.deployment`

## Test plan
- [x] `ruff check` / `ruff format --check`
- [x] `mypy src`
- [x] `pytest` (221 passed)

Closes #199