### PR TITLE
Implement HDF5 backend for the deployment bundle read/write interfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,3 +139,4 @@ class LinearModel:
 
 - Never reference Claude in commits, pull requests, source code, or documentation. This includes `Co-Authored-By` trailers, body text, or any other attribution to Claude or Anthropic.
 - Use `` ` `` (backtick) for inline code and code blocks in GitHub issues and pull requests, not `` \` `` (escaped backtick).
+- Never run `git commit` without explicit confirmation from the user in that conversation. An instruction to implement, fix, or finish a task is not itself confirmation to commit — ask, or wait to be asked.

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -38,6 +38,8 @@ from .bundle_protocols import (
     TimeWindow as TimeWindow,
     VesselBundleSectionReader as VesselBundleSectionReader,
     VesselBundleSectionWriter as VesselBundleSectionWriter,
+)
+from .bundle_factories import (
     open_deployment_bundle_reader as open_deployment_bundle_reader,
     open_deployment_bundle_writer as open_deployment_bundle_writer,
 )

--- a/src/afft/deployment/bundle_factories.py
+++ b/src/afft/deployment/bundle_factories.py
@@ -1,0 +1,53 @@
+"""Factories selecting and constructing the concrete deployment bundle
+reader/writer behind the storage-agnostic ``Protocol`` interfaces."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import cast
+
+from .bundle_hdf_readers import (
+    open_deployment_bundle_reader as _open_hdf_reader,
+)
+from .bundle_hdf_writers import (
+    open_deployment_bundle_writer as _open_hdf_writer,
+)
+from .bundle_protocols import DeploymentBundleReader, DeploymentBundleWriter
+
+
+@contextmanager
+def open_deployment_bundle_reader(
+    path: Path,
+) -> Iterator[DeploymentBundleReader]:
+    """
+    Open a deployment bundle for reading.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Returns
+    -------
+    A context manager yielding a ``DeploymentBundleReader``.
+    """
+    with _open_hdf_reader(path) as reader:
+        yield cast(DeploymentBundleReader, reader)
+
+
+@contextmanager
+def open_deployment_bundle_writer(
+    path: Path,
+) -> Iterator[DeploymentBundleWriter]:
+    """
+    Open a deployment bundle for writing.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Returns
+    -------
+    A context manager yielding a ``DeploymentBundleWriter``.
+    """
+    with _open_hdf_writer(path) as writer:
+        yield cast(DeploymentBundleWriter, writer)

--- a/src/afft/deployment/bundle_hdf_readers.py
+++ b/src/afft/deployment/bundle_hdf_readers.py
@@ -1,0 +1,501 @@
+"""Concrete `pandas.HDFStore` readers implementing the deployment bundle
+read `Protocol` interfaces defined in `bundle_protocols.py`."""
+
+import re
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import pandas as pd
+
+from pydantic import BaseModel
+
+from .bundle_protocols import TimeWindow
+from .bundle_types import (
+    DeploymentBundleHeader,
+    DeploymentIdentity,
+    DeploymentProvenance,
+    ProcessedProvenance,
+)
+from .common_types import (
+    DeploymentMetadata,
+    PlatformIdentity,
+    PlatformSensor,
+    SensorCalibration,
+    SensorExtrinsics,
+    SensorIdentity,
+    VesselIdentity,
+    VesselSensor,
+)
+
+# --- dataclass / pydantic model <- table conversion ---
+
+
+def frame_to_record[T: BaseModel](frame: pd.DataFrame, cls: type[T]) -> T:
+    """
+    Decode a one-row `DataFrame` back into an instance of `cls`.
+
+    Arguments
+    ---------
+    frame: One-row `DataFrame` to decode.
+    cls: Model class to validate into.
+
+    Returns
+    -------
+    The decoded model instance.
+
+    Raises
+    ------
+    ValueError: If `frame` does not have exactly one row.
+    """
+    if len(frame) != 1:
+        raise ValueError(f"expected exactly one row, got {len(frame)}")
+    return cls.model_validate(frame.iloc[0].to_dict())
+
+
+def frame_to_message_topics(frame: pd.DataFrame) -> list[str]:
+    """Decode a `message_topics` table back into an ordered list."""
+    return [str(topic) for topic in frame["topic"]]
+
+
+def frame_to_sensor_calibration(frame: pd.DataFrame) -> SensorCalibration:
+    """Decode a `calibration` table back into a `SensorCalibration`."""
+    if frame.empty:
+        raise ValueError("calibration table has no rows")
+    calibration_type = str(frame["calibration_type"].iloc[0])
+    parameters = dict(zip(frame["name"], frame["value"], strict=True))
+    return SensorCalibration(
+        calibration_type=calibration_type, parameters=parameters
+    )
+
+
+def time_window_to_where(window: TimeWindow | None) -> str | None:
+    """
+    Translate a `TimeWindow` into a PyTables `where=` predicate string
+    against the `timestamp` column, or `None` for no predicate.
+    """
+    if window is None:
+        return None
+    terms: list[str] = []
+    if window.start is not None:
+        terms.append(f"timestamp >= '{window.start.isoformat()}'")
+    if window.end is not None:
+        terms.append(f"timestamp <= '{window.end.isoformat()}'")
+    if not terms:
+        return None
+    return " & ".join(terms)
+
+
+# --- section readers ---
+
+
+@dataclass
+class HDFDeploymentBundleSectionReader:
+    """Reads `deployment/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "deployment"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    @property
+    def metadata_path(self) -> str:
+        return f"{self.root_path}/metadata"
+
+    @property
+    def files_path(self) -> str:
+        return f"{self.root_path}/files"
+
+    @property
+    def provenance_path(self) -> str:
+        return f"{self.root_path}/provenance"
+
+    def identity(self) -> DeploymentIdentity:
+        return frame_to_record(
+            self.store.select(self.identity_path), DeploymentIdentity
+        )
+
+    def metadata(self) -> DeploymentMetadata:
+        return frame_to_record(
+            self.store.select(self.metadata_path), DeploymentMetadata
+        )
+
+    def provenance(self) -> DeploymentProvenance:
+        return frame_to_record(
+            self.store.select(self.provenance_path), DeploymentProvenance
+        )
+
+    def files(self) -> pd.DataFrame:
+        return self.store.select(self.files_path)
+
+
+@dataclass
+class HDFPlatformBundleSectionReader:
+    """Reads `platform/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "platform"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    def sensor_identity_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/identity"
+
+    def sensor_message_topics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
+
+    def sensor_extrinsics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
+
+    def sensor_calibration_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/calibration"
+
+    def identity(self) -> PlatformIdentity:
+        return frame_to_record(
+            self.store.select(self.identity_path), PlatformIdentity
+        )
+
+    def sensor_keys(self) -> list[str]:
+        return _sensor_keys(self.store, self.root_path)
+
+    def sensors(self) -> list[PlatformSensor]:
+        return [
+            read_platform_sensor(self.store, key) for key in self.sensor_keys()
+        ]
+
+
+@dataclass
+class HDFVesselBundleSectionReader:
+    """Reads `vessel/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "vessel"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    def sensor_identity_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/identity"
+
+    def sensor_message_topics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
+
+    def sensor_extrinsics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
+
+    def sensor_calibration_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/calibration"
+
+    def identity(self) -> VesselIdentity:
+        return frame_to_record(
+            self.store.select(self.identity_path), VesselIdentity
+        )
+
+    def sensor_keys(self) -> list[str]:
+        return _sensor_keys(self.store, self.root_path)
+
+    def sensors(self) -> list[VesselSensor]:
+        return [
+            read_vessel_sensor(self.store, key) for key in self.sensor_keys()
+        ]
+
+
+@dataclass
+class HDFRawTelemetryBundleSectionReader:
+    """Reads `telemetry/raw/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "telemetry/raw"
+
+    def topic_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/messages"
+
+    def topics(self) -> list[tuple[str, str]]:
+        return _topic_pairs(self.store, self.root_path)
+
+    def sensor_keys(self) -> list[str]:
+        return sorted({sensor_key for sensor_key, _ in self.topics()})
+
+    def read(
+        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        return self.store.select(
+            self.topic_path(sensor_key, topic),
+            where=time_window_to_where(window),
+        )
+
+
+@dataclass
+class HDFProcessedTelemetryBundleSectionReader:
+    """Reads `telemetry/processed/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "telemetry/processed"
+
+    def topic_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/messages"
+
+    def provenance_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/provenance"
+
+    def topics(self) -> list[tuple[str, str]]:
+        return _topic_pairs(self.store, self.root_path)
+
+    def sensor_keys(self) -> list[str]:
+        return sorted({sensor_key for sensor_key, _ in self.topics()})
+
+    def read(
+        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        return self.store.select(
+            self.topic_path(sensor_key, topic),
+            where=time_window_to_where(window),
+        )
+
+    def provenance(self, sensor_key: str, topic: str) -> ProcessedProvenance:
+        return frame_to_record(
+            self.store.select(self.provenance_path(sensor_key, topic)),
+            ProcessedProvenance,
+        )
+
+
+@dataclass
+class HDFTelemetryBundleSectionReader:
+    """Composes the raw and processed telemetry readers."""
+
+    raw: HDFRawTelemetryBundleSectionReader
+    processed: HDFProcessedTelemetryBundleSectionReader
+
+    def topics(self) -> list[tuple[str, str]]:
+        return sorted(set(self.raw.topics()) | set(self.processed.topics()))
+
+
+@dataclass
+class HDFMetoceanBundleSectionReader:
+    """Reads `metocean/*` from an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "metocean"
+
+    def variable_path(self, provider: str, variable: str) -> str:
+        return f"{self.root_path}/{provider}/{variable}"
+
+    def providers(self) -> list[str]:
+        pattern = re.compile(rf"^/{re.escape(self.root_path)}/([^/]+)/([^/]+)$")
+        return sorted(
+            {
+                match.group(1)
+                for path in self.store.keys()
+                if (match := pattern.match(path))
+            }
+        )
+
+    def variables(self, provider: str) -> list[str]:
+        pattern = re.compile(
+            rf"^/{re.escape(self.root_path)}/{re.escape(provider)}/([^/]+)$"
+        )
+        return sorted(
+            match.group(1)
+            for path in self.store.keys()
+            if (match := pattern.match(path))
+        )
+
+    def read(
+        self, provider: str, variable: str, *, window: TimeWindow | None = None
+    ) -> pd.DataFrame:
+        return self.store.select(
+            self.variable_path(provider, variable),
+            where=time_window_to_where(window),
+        )
+
+
+# --- top-level reader and its escape hatch ---
+
+
+@dataclass
+class HDFDeploymentBundleReader:
+    """
+    Concrete `DeploymentBundleReader` backed by a `pandas.HDFStore` opened
+    in read mode.
+
+    Attributes
+    ----------
+    store: Open `HDFStore` handle.
+    header: Parsed once at open time, trusted for the rest of the object's
+        lifetime.
+    """
+
+    store: pd.HDFStore
+    header: DeploymentBundleHeader
+    deployment: HDFDeploymentBundleSectionReader
+    platform: HDFPlatformBundleSectionReader
+    vessel: HDFVesselBundleSectionReader
+    telemetry: HDFTelemetryBundleSectionReader
+    metocean: HDFMetoceanBundleSectionReader
+
+    @property
+    def header_path(self) -> str:
+        return _HEADER_PATH
+
+    @classmethod
+    def open(cls, store: pd.HDFStore) -> "HDFDeploymentBundleReader":
+        """Parse the root `bundle` table and wrap the section readers."""
+        header = frame_to_record(
+            store.select(_HEADER_PATH), DeploymentBundleHeader
+        )
+        return cls(
+            store=store,
+            header=header,
+            deployment=HDFDeploymentBundleSectionReader(store),
+            platform=HDFPlatformBundleSectionReader(store),
+            vessel=HDFVesselBundleSectionReader(store),
+            telemetry=HDFTelemetryBundleSectionReader(
+                raw=HDFRawTelemetryBundleSectionReader(store),
+                processed=HDFProcessedTelemetryBundleSectionReader(store),
+            ),
+            metocean=HDFMetoceanBundleSectionReader(store),
+        )
+
+    # flat, path-first escape hatch -- not part of the storage-agnostic
+    # Protocol, HDFStore-shaped by nature
+
+    def keys(self) -> list[str]:
+        return list(self.store.keys())
+
+    def contains(self, path: str) -> bool:
+        return path in self.store
+
+    def row_count(self, path: str) -> int:
+        storer = self.store.get_storer(path)
+        return int(storer.nrows)
+
+    def read_table(self, path: str) -> pd.DataFrame:
+        return self.store.select(path)
+
+
+@contextmanager
+def open_deployment_bundle_reader(
+    path: Path,
+) -> Iterator[HDFDeploymentBundleReader]:
+    """Open an HDF5 deployment bundle for reading."""
+    with pd.HDFStore(str(path), mode="r") as store:
+        yield HDFDeploymentBundleReader.open(store)
+
+
+def read_platform_sensor(store: pd.HDFStore, sensor_key: str) -> PlatformSensor:
+    """Assemble one `PlatformSensor` from its identity, message_topics,
+    extrinsics, and optional calibration nodes."""
+    reader = HDFPlatformBundleSectionReader(store)
+    return PlatformSensor(
+        key=sensor_key,
+        message_topics=_maybe_read_message_topics(
+            store, reader.sensor_message_topics_path(sensor_key)
+        ),
+        identity=_maybe_read_record(
+            store, reader.sensor_identity_path(sensor_key), SensorIdentity
+        ),
+        extrinsics=_maybe_read_record(
+            store, reader.sensor_extrinsics_path(sensor_key), SensorExtrinsics
+        ),
+        calibration=_maybe_read_calibration(
+            store, reader.sensor_calibration_path(sensor_key)
+        ),
+    )
+
+
+def read_vessel_sensor(store: pd.HDFStore, sensor_key: str) -> VesselSensor:
+    """Assemble one `VesselSensor` from its identity, message_topics,
+    extrinsics, and optional calibration nodes."""
+    reader = HDFVesselBundleSectionReader(store)
+    return VesselSensor(
+        key=sensor_key,
+        message_topics=_maybe_read_message_topics(
+            store, reader.sensor_message_topics_path(sensor_key)
+        ),
+        identity=_maybe_read_record(
+            store, reader.sensor_identity_path(sensor_key), SensorIdentity
+        ),
+        extrinsics=_maybe_read_record(
+            store, reader.sensor_extrinsics_path(sensor_key), SensorExtrinsics
+        ),
+        calibration=_maybe_read_calibration(
+            store, reader.sensor_calibration_path(sensor_key)
+        ),
+    )
+
+
+# --- private helpers ---
+
+_HEADER_PATH: str = "bundle"
+
+
+def _sensor_keys(store: pd.HDFStore, root_path: str) -> list[str]:
+    """List sensor keys under `root_path/sensors/<key>/identity`."""
+    pattern = re.compile(rf"^/{re.escape(root_path)}/sensors/([^/]+)/identity$")
+    return sorted(
+        match.group(1)
+        for path in store.keys()
+        if (match := pattern.match(path))
+    )
+
+
+def _topic_pairs(store: pd.HDFStore, root_path: str) -> list[tuple[str, str]]:
+    """List `(sensor_key, topic)` pairs under `root_path/<key>/<topic>/messages`."""
+    pattern = re.compile(rf"^/{re.escape(root_path)}/([^/]+)/([^/]+)/messages$")
+    return sorted(
+        (match.group(1), match.group(2))
+        for path in store.keys()
+        if (match := pattern.match(path))
+    )
+
+
+def _maybe_read_record[T: BaseModel](
+    store: pd.HDFStore, path: str, cls: type[T]
+) -> T | None:
+    """Read a flat record at `path`, or `None` if the node is absent."""
+    if path not in store:
+        return None
+    return frame_to_record(store.select(path), cls)
+
+
+def _maybe_read_message_topics(store: pd.HDFStore, path: str) -> list[str]:
+    """Read a `message_topics` table at `path`, or `[]` if the node is
+    absent."""
+    if path not in store:
+        return []
+    return frame_to_message_topics(store.select(path))
+
+
+def _maybe_read_calibration(
+    store: pd.HDFStore, path: str
+) -> SensorCalibration | None:
+    """Read a `calibration` table at `path`, or `None` if the node is
+    absent."""
+    if path not in store:
+        return None
+    return frame_to_sensor_calibration(store.select(path))

--- a/src/afft/deployment/bundle_hdf_writers.py
+++ b/src/afft/deployment/bundle_hdf_writers.py
@@ -48,7 +48,7 @@ def normalize_dtypes(
     """
     frame = frame.copy()
     for column, dtype in dtypes.items():
-        if dtype == "datetime64[ns, UTC]":
+        if pd.api.types.pandas_dtype(dtype) == _DATETIME_UTC_DTYPE:
             frame[column] = pd.to_datetime(frame[column], utc=True)
         else:
             frame[column] = frame[column].astype(dtype)
@@ -442,14 +442,18 @@ def open_deployment_bundle_writer(
 
 _HEADER_PATH: str = "bundle"
 
+_DATETIME_UTC_DTYPE: pd.DatetimeTZDtype = pd.DatetimeTZDtype(
+    unit="ns", tz="UTC"
+)
+
 _RAW_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
-    "timestamp": "datetime64[ns, UTC]",
+    "timestamp": str(_DATETIME_UTC_DTYPE),
     "sensor_key": "category",
     "message_topic": "category",
 }
 
 _PROCESSED_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
-    "timestamp": "datetime64[ns, UTC]",
+    "timestamp": str(_DATETIME_UTC_DTYPE),
     "message_topic": "category",
 }
 

--- a/src/afft/deployment/bundle_hdf_writers.py
+++ b/src/afft/deployment/bundle_hdf_writers.py
@@ -1,0 +1,502 @@
+"""Concrete `pandas.HDFStore` writers implementing the deployment bundle
+write `Protocol` interfaces defined in `bundle_protocols.py`."""
+
+from collections.abc import Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterator
+
+import pandas as pd
+
+from pydantic import BaseModel
+
+from .bundle_types import (
+    DeploymentBundleHeader,
+    DeploymentIdentity,
+    DeploymentProvenance,
+    ProcessedProvenance,
+)
+from .common_types import (
+    DeploymentMetadata,
+    PlatformIdentity,
+    PlatformSensor,
+    SensorCalibration,
+    VesselIdentity,
+    VesselSensor,
+)
+
+# --- dtype normalization and put policy helpers ---
+
+
+def normalize_dtypes(
+    frame: pd.DataFrame, dtypes: Mapping[str, str]
+) -> pd.DataFrame:
+    """
+    Cast columns to the HDF5-table-safe dtype set before a `put`/`append`.
+
+    Arguments
+    ---------
+    frame: Frame to normalize; not mutated.
+    dtypes: Column name to target dtype string, e.g. ``"category"`` or
+        ``"datetime64[ns, UTC]"``.
+
+    Returns
+    -------
+    A copy of `frame` with the named columns cast.
+    """
+    frame = frame.copy()
+    for column, dtype in dtypes.items():
+        if dtype == "datetime64[ns, UTC]":
+            frame[column] = pd.to_datetime(frame[column], utc=True)
+        else:
+            frame[column] = frame[column].astype(dtype)
+    return frame
+
+
+def put_once(
+    store: pd.HDFStore,
+    path: str,
+    frame: pd.DataFrame,
+    *,
+    data_columns: list[str] | None = None,
+) -> None:
+    """
+    `store.put` a table at `path`, raising if a node already exists there.
+
+    Arguments
+    ---------
+    store: Open `HDFStore` handle.
+    path: Node path to write.
+    frame: Table to write.
+    data_columns: Columns to index for `where=` queries.
+
+    Raises
+    ------
+    ValueError: If a node already exists at `path`.
+    """
+    if path in store:
+        raise ValueError(f"{path} already exists")
+    store.put(path, frame, format="table", data_columns=data_columns)
+
+
+def put_replacing(
+    store: pd.HDFStore,
+    path: str,
+    frame: pd.DataFrame,
+    *,
+    data_columns: list[str] | None = None,
+) -> None:
+    """
+    `store.remove` any existing node at `path`, then `store.put` the new
+    frame.
+
+    Arguments
+    ---------
+    store: Open `HDFStore` handle.
+    path: Node path to write.
+    frame: Table to write.
+    data_columns: Columns to index for `where=` queries.
+    """
+    if path in store:
+        store.remove(path)
+    store.put(path, frame, format="table", data_columns=data_columns)
+
+
+# --- dataclass / pydantic model -> table conversion ---
+
+
+def record_to_frame(value: BaseModel) -> pd.DataFrame:
+    """
+    Encode a flat pydantic model as a one-row `DataFrame`.
+
+    Only handles models whose fields are all scalar (`str`, `float`, `int`,
+    `bool`, `datetime`) -- a model with a `list`/`dict` field needs its own
+    row-per-item table instead, see `message_topics_to_frame` and
+    `sensor_calibration_to_frame`. `datetime` fields are detected from the
+    model's own field annotations and normalized to `datetime64[ns, UTC]`,
+    since `HDFStore`'s `format="table"` cannot write a naive/mixed-tz object
+    column.
+
+    Arguments
+    ---------
+    value: Model instance to encode.
+
+    Returns
+    -------
+    A one-row `DataFrame`.
+    """
+    frame = pd.DataFrame([value.model_dump()])
+    for name, field in type(value).model_fields.items():
+        if field.annotation is datetime:
+            frame[name] = pd.to_datetime(frame[name], utc=True)
+    return frame
+
+
+def message_topics_to_frame(topics: list[str]) -> pd.DataFrame:
+    """Encode `CatalogProfileSensor.message_topics` as one row per topic."""
+    return pd.DataFrame({"topic": pd.array(topics, dtype="object")})
+
+
+def sensor_calibration_to_frame(value: SensorCalibration) -> pd.DataFrame:
+    """
+    Encode `SensorCalibration` as one row per parameter, `calibration_type`
+    denormalized onto every row so the whole model still lives at a single
+    path.
+    """
+    names = list(value.parameters.keys())
+    values = list(value.parameters.values())
+    return pd.DataFrame(
+        {
+            "calibration_type": pd.Categorical(
+                [value.calibration_type] * len(names)
+            ),
+            "name": pd.array(names, dtype="object"),
+            "value": pd.array(values, dtype="float64"),
+        }
+    )
+
+
+# --- section writers ---
+
+
+@dataclass
+class HDFDeploymentBundleSectionWriter:
+    """
+    Writes `deployment/*` to an open store.
+
+    Each method is write-once -- it raises if the target node already
+    exists.
+    """
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "deployment"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    @property
+    def metadata_path(self) -> str:
+        return f"{self.root_path}/metadata"
+
+    @property
+    def files_path(self) -> str:
+        return f"{self.root_path}/files"
+
+    @property
+    def provenance_path(self) -> str:
+        return f"{self.root_path}/provenance"
+
+    def write_identity(self, value: DeploymentIdentity) -> None:
+        put_once(self.store, self.identity_path, record_to_frame(value))
+
+    def write_metadata(self, value: DeploymentMetadata) -> None:
+        put_once(self.store, self.metadata_path, record_to_frame(value))
+
+    def write_files(self, frame: pd.DataFrame) -> None:
+        frame = normalize_dtypes(frame, _DEPLOYMENT_FILES_REQUIRED_DTYPES)
+        put_once(self.store, self.files_path, frame, data_columns=["role"])
+
+    def write_provenance(self, value: DeploymentProvenance) -> None:
+        put_once(self.store, self.provenance_path, record_to_frame(value))
+
+
+@dataclass
+class HDFPlatformBundleSectionWriter:
+    """
+    Writes `platform/*` to an open store.
+
+    Each method is write-once -- it raises if the target node already
+    exists. A sensor's optional `identity`/`extrinsics`/`calibration` node,
+    or its `message_topics` node when the list is empty, is simply not
+    written rather than written empty; the reader treats a missing node as
+    `None`/`[]`.
+    """
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "platform"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    def sensor_identity_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/identity"
+
+    def sensor_message_topics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
+
+    def sensor_extrinsics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
+
+    def sensor_calibration_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/calibration"
+
+    def write_identity(self, value: PlatformIdentity) -> None:
+        put_once(self.store, self.identity_path, record_to_frame(value))
+
+    def write_sensors(self, values: list[PlatformSensor]) -> None:
+        for sensor in values:
+            _write_sensor(self, sensor)
+
+
+@dataclass
+class HDFVesselBundleSectionWriter:
+    """
+    Writes `vessel/*` to an open store.
+
+    Each method is write-once -- it raises if the target node already
+    exists. A sensor's optional `identity`/`extrinsics`/`calibration` node,
+    or its `message_topics` node when the list is empty, is simply not
+    written rather than written empty; the reader treats a missing node as
+    `None`/`[]`.
+    """
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "vessel"
+
+    @property
+    def identity_path(self) -> str:
+        return f"{self.root_path}/identity"
+
+    def sensor_identity_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/identity"
+
+    def sensor_message_topics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
+
+    def sensor_extrinsics_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
+
+    def sensor_calibration_path(self, sensor_key: str) -> str:
+        return f"{self.root_path}/sensors/{sensor_key}/calibration"
+
+    def write_identity(self, value: VesselIdentity) -> None:
+        put_once(self.store, self.identity_path, record_to_frame(value))
+
+    def write_sensors(self, values: list[VesselSensor]) -> None:
+        for sensor in values:
+            _write_sensor(self, sensor)
+
+
+@dataclass
+class HDFRawTelemetryBundleSectionWriter:
+    """
+    Writes `telemetry/raw/*` to an open store.
+
+    Write-once -- it raises if the target node already exists.
+    """
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "telemetry/raw"
+
+    def topic_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/messages"
+
+    def write(self, sensor_key: str, topic: str, frame: pd.DataFrame) -> None:
+        frame = normalize_dtypes(frame, _RAW_TELEMETRY_REQUIRED_DTYPES)
+        put_once(
+            self.store,
+            self.topic_path(sensor_key, topic),
+            frame,
+            data_columns=list(_RAW_TELEMETRY_REQUIRED_DTYPES),
+        )
+
+
+@dataclass
+class HDFProcessedTelemetryBundleSectionWriter:
+    """Writes `telemetry/processed/*` to an open store."""
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "telemetry/processed"
+
+    def topic_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/messages"
+
+    def provenance_path(self, sensor_key: str, topic: str) -> str:
+        return f"{self.root_path}/{sensor_key}/{topic}/provenance"
+
+    def append_messages(
+        self, sensor_key: str, topic: str, frame: pd.DataFrame
+    ) -> None:
+        dtypes = _processed_telemetry_dtypes(frame)
+        frame = normalize_dtypes(frame, dtypes)
+        self.store.append(
+            self.topic_path(sensor_key, topic),
+            frame,
+            format="table",
+            data_columns=list(dtypes),
+        )
+
+    def replace_messages(
+        self, sensor_key: str, topic: str, frame: pd.DataFrame
+    ) -> None:
+        dtypes = _processed_telemetry_dtypes(frame)
+        frame = normalize_dtypes(frame, dtypes)
+        put_replacing(
+            self.store,
+            self.topic_path(sensor_key, topic),
+            frame,
+            data_columns=list(dtypes),
+        )
+
+    def write_provenance(
+        self, sensor_key: str, topic: str, value: ProcessedProvenance
+    ) -> None:
+        put_replacing(
+            self.store,
+            self.provenance_path(sensor_key, topic),
+            record_to_frame(value),
+        )
+
+
+@dataclass
+class HDFTelemetryBundleSectionWriter:
+    """Composes the raw and processed telemetry writers."""
+
+    raw: HDFRawTelemetryBundleSectionWriter
+    processed: HDFProcessedTelemetryBundleSectionWriter
+
+
+@dataclass
+class HDFMetoceanBundleSectionWriter:
+    """
+    Writes `metocean/*` to an open store.
+
+    Write-once -- it raises if the target node already exists.
+    """
+
+    store: pd.HDFStore
+
+    @property
+    def root_path(self) -> str:
+        return "metocean"
+
+    def variable_path(self, provider: str, variable: str) -> str:
+        return f"{self.root_path}/{provider}/{variable}"
+
+    def write(self, provider: str, variable: str, frame: pd.DataFrame) -> None:
+        put_once(self.store, self.variable_path(provider, variable), frame)
+
+
+# --- top-level writer ---
+
+
+@dataclass
+class HDFDeploymentBundleWriter:
+    """Concrete `DeploymentBundleWriter` backed by a `pandas.HDFStore`
+    opened in write/append mode."""
+
+    store: pd.HDFStore
+    deployment: HDFDeploymentBundleSectionWriter
+    platform: HDFPlatformBundleSectionWriter
+    vessel: HDFVesselBundleSectionWriter
+    telemetry: HDFTelemetryBundleSectionWriter
+    metocean: HDFMetoceanBundleSectionWriter
+
+    @property
+    def header_path(self) -> str:
+        return _HEADER_PATH
+
+    def write_header(self, value: DeploymentBundleHeader) -> None:
+        put_once(self.store, self.header_path, record_to_frame(value))
+
+
+@contextmanager
+def open_deployment_bundle_writer(
+    path: Path,
+) -> Iterator[HDFDeploymentBundleWriter]:
+    """Open an HDF5 deployment bundle for writing."""
+    with pd.HDFStore(str(path), mode="a") as store:
+        yield HDFDeploymentBundleWriter(
+            store=store,
+            deployment=HDFDeploymentBundleSectionWriter(store),
+            platform=HDFPlatformBundleSectionWriter(store),
+            vessel=HDFVesselBundleSectionWriter(store),
+            telemetry=HDFTelemetryBundleSectionWriter(
+                raw=HDFRawTelemetryBundleSectionWriter(store),
+                processed=HDFProcessedTelemetryBundleSectionWriter(store),
+            ),
+            metocean=HDFMetoceanBundleSectionWriter(store),
+        )
+
+
+# --- private helpers ---
+
+_HEADER_PATH: str = "bundle"
+
+_RAW_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
+    "timestamp": "datetime64[ns, UTC]",
+    "sensor_key": "category",
+    "message_topic": "category",
+}
+
+_PROCESSED_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
+    "timestamp": "datetime64[ns, UTC]",
+    "message_topic": "category",
+}
+
+_DEPLOYMENT_FILES_REQUIRED_DTYPES: dict[str, str] = {
+    "role": "category",
+    "path": "object",
+}
+
+
+def _processed_telemetry_dtypes(frame: pd.DataFrame) -> dict[str, str]:
+    """Required processed-telemetry dtypes, including `sensor_key` only
+    when the frame carries that column -- it's required only for a table
+    with one producing sensor."""
+    dtypes = dict(_PROCESSED_TELEMETRY_REQUIRED_DTYPES)
+    if "sensor_key" in frame.columns:
+        dtypes["sensor_key"] = "category"
+    return dtypes
+
+
+def _write_sensor(
+    writer: "HDFPlatformBundleSectionWriter | HDFVesselBundleSectionWriter",
+    sensor: PlatformSensor | VesselSensor,
+) -> None:
+    """Write a sensor's identity/message_topics/extrinsics/calibration
+    nodes, skipping any field that is `None`/empty."""
+    if sensor.identity is not None:
+        put_once(
+            writer.store,
+            writer.sensor_identity_path(sensor.key),
+            record_to_frame(sensor.identity),
+        )
+    if sensor.message_topics:
+        put_once(
+            writer.store,
+            writer.sensor_message_topics_path(sensor.key),
+            message_topics_to_frame(sensor.message_topics),
+        )
+    if sensor.extrinsics is not None:
+        put_once(
+            writer.store,
+            writer.sensor_extrinsics_path(sensor.key),
+            record_to_frame(sensor.extrinsics),
+        )
+    if sensor.calibration is not None:
+        put_once(
+            writer.store,
+            writer.sensor_calibration_path(sensor.key),
+            sensor_calibration_to_frame(sensor.calibration),
+            data_columns=["calibration_type"],
+        )

--- a/src/afft/deployment/bundle_protocols.py
+++ b/src/afft/deployment/bundle_protocols.py
@@ -1,9 +1,6 @@
 """Storage-agnostic read and write interfaces for a deployment bundle."""
 
-from collections.abc import Iterator
-from contextlib import contextmanager
 from datetime import datetime
-from pathlib import Path
 from typing import Protocol
 
 import pandas as pd
@@ -303,47 +300,3 @@ class DeploymentBundleWriter(Protocol):
     vessel: VesselBundleSectionWriter
     telemetry: TelemetryBundleSectionWriter
     metocean: MetoceanBundleSectionWriter
-
-
-@contextmanager
-def open_deployment_bundle_reader(
-    path: Path,
-) -> Iterator[DeploymentBundleReader]:
-    """
-    Open a deployment bundle for reading.
-
-    Arguments
-    ---------
-    path: Path to the deployment bundle file.
-
-    Returns
-    -------
-    A context manager yielding a ``DeploymentBundleReader``.
-    """
-    raise NotImplementedError(
-        "open_deployment_bundle_reader has no concrete implementation yet; "
-        "see afft #208"
-    )
-    yield  # pragma: no cover
-
-
-@contextmanager
-def open_deployment_bundle_writer(
-    path: Path,
-) -> Iterator[DeploymentBundleWriter]:
-    """
-    Open a deployment bundle for writing.
-
-    Arguments
-    ---------
-    path: Path to the deployment bundle file.
-
-    Returns
-    -------
-    A context manager yielding a ``DeploymentBundleWriter``.
-    """
-    raise NotImplementedError(
-        "open_deployment_bundle_writer has no concrete implementation yet; "
-        "see afft #208"
-    )
-    yield  # pragma: no cover

--- a/tests/test_deployment_bundle_hdf_io.py
+++ b/tests/test_deployment_bundle_hdf_io.py
@@ -1,0 +1,357 @@
+"""Round-trip tests for the pandas.HDFStore deployment bundle implementation."""
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from afft.deployment.bundle_factories import (
+    open_deployment_bundle_reader,
+    open_deployment_bundle_writer,
+)
+from afft.deployment.bundle_types import (
+    DeploymentBundleHeader,
+    DeploymentIdentity,
+    DeploymentProvenance,
+    ProcessedProvenance,
+)
+from afft.deployment.common_types import (
+    DeploymentMetadata,
+    PlatformIdentity,
+    PlatformSensor,
+    SensorCalibration,
+    SensorExtrinsics,
+    SensorIdentity,
+    VesselIdentity,
+    VesselSensor,
+)
+
+
+def _header() -> DeploymentBundleHeader:
+    return DeploymentBundleHeader(
+        schema_version="1.0",
+        created_datetime=datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc),
+        builder_version="0.1.0",
+    )
+
+
+def test_write_header_and_deployment_section(tmp_path: Path) -> None:
+    """Round-trips the bundle header and the deployment section's records."""
+    path = tmp_path / "bundle.h5"
+    identity = DeploymentIdentity(
+        deployment_label="qc2hyd_20231021T032349Z",
+        deployment_datetime=datetime(
+            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
+        ),
+    )
+    metadata = DeploymentMetadata(
+        acfr_deployment_label="r20231021_032349_qc2hyd",
+        acfr_campaign_label="r20231021_qc2hyd",
+        acfr_platform_label="sirius",
+        origin_latitude=-33.5,
+        origin_longitude=151.3,
+        magnetic_variation=12.4,
+    )
+    provenance = DeploymentProvenance(deployment_key="qc2hyd_20231021T032349Z")
+    files = pd.DataFrame(
+        {"role": ["stereo_pose"], "path": ["stereo_pose_est.data"]}
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.deployment.write_identity(identity)
+        writer.deployment.write_metadata(metadata)
+        writer.deployment.write_provenance(provenance)
+        writer.deployment.write_files(files)
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.header == _header()
+        assert reader.deployment.identity() == identity
+        assert reader.deployment.metadata() == metadata
+        assert reader.deployment.provenance() == provenance
+        assert reader.deployment.files()["role"].tolist() == ["stereo_pose"]
+
+
+def test_write_once_raises_on_second_write(tmp_path: Path) -> None:
+    """A write-once method raises if the target node already exists."""
+    path = tmp_path / "bundle.h5"
+    identity = DeploymentIdentity(
+        deployment_label="qc2hyd_20231021T032349Z",
+        deployment_datetime=datetime(
+            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
+        ),
+    )
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.deployment.write_identity(identity)
+        with pytest.raises(ValueError):
+            writer.deployment.write_identity(identity)
+
+
+def test_platform_sensor_roster_round_trip(tmp_path: Path) -> None:
+    """
+    Round-trips a platform sensor roster, including a sensor with no
+    extrinsics/calibration and one with an empty message_topics list.
+    """
+    path = tmp_path / "bundle.h5"
+    dvl = PlatformSensor(
+        key="dvl_teledyne_navigator",
+        message_topics=["RDI"],
+        identity=SensorIdentity(
+            label="DVL", vendor="Teledyne RDI", product="Navigator", type="dvl"
+        ),
+        extrinsics=SensorExtrinsics(
+            locx=0.1, locy=0.0, locz=0.2, rotx=0.0, roty=0.0, rotz=0.0
+        ),
+        calibration=None,
+    )
+    camera = PlatformSensor(
+        key="vis_camera",
+        message_topics=[],
+        identity=SensorIdentity(
+            label="VIS camera", vendor="", product="", type="camera"
+        ),
+        extrinsics=None,
+        calibration=SensorCalibration(
+            calibration_type="pinhole",
+            parameters={"fx": 1043.2, "fy": 1043.2, "cx": 512.0, "cy": 384.0},
+        ),
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.platform.write_identity(
+            PlatformIdentity(
+                platform_label="AUV Sirius",
+                platform_class="SEABED",
+                platform_operator="ACFR",
+            )
+        )
+        writer.platform.write_sensors([dvl, camera])
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.platform.sensor_keys() == [
+            "dvl_teledyne_navigator",
+            "vis_camera",
+        ]
+        sensors = {sensor.key: sensor for sensor in reader.platform.sensors()}
+
+        assert sensors["dvl_teledyne_navigator"] == dvl
+        assert sensors["vis_camera"] == camera
+        # message_topics=[] is not written as a node; reads back as [].
+        assert not reader.contains("platform/sensors/vis_camera/message_topics")
+        # extrinsics=None is not written; reads back as None.
+        assert not reader.contains("platform/sensors/vis_camera/extrinsics")
+
+
+def test_vessel_sensor_roster_round_trip(tmp_path: Path) -> None:
+    """Round-trips a vessel sensor roster, mirroring the platform section."""
+    path = tmp_path / "bundle.h5"
+    usbl = VesselSensor(
+        key="usbl_linkquest_transceiver",
+        message_topics=[],
+        identity=SensorIdentity(
+            label="USBL", vendor="LinkQuest", product="TrackLink", type="usbl"
+        ),
+        extrinsics=SensorExtrinsics(
+            locx=0.0, locy=0.0, locz=-1.0, rotx=0.0, roty=0.0, rotz=0.0
+        ),
+        calibration=None,
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.vessel.write_identity(VesselIdentity(vessel_name="RV Linnaeus"))
+        writer.vessel.write_sensors([usbl])
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.vessel.identity() == VesselIdentity(
+            vessel_name="RV Linnaeus"
+        )
+        assert reader.vessel.sensor_keys() == ["usbl_linkquest_transceiver"]
+        assert reader.vessel.sensors() == [usbl]
+
+
+def test_raw_telemetry_round_trip_and_window(tmp_path: Path) -> None:
+    """Round-trips a raw telemetry table and narrows a read with a window."""
+    path = tmp_path / "bundle.h5"
+    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
+    timestamps = [start + timedelta(seconds=index) for index in range(5)]
+    frame = pd.DataFrame(
+        {
+            "timestamp": timestamps,
+            "sensor_key": ["dvl_teledyne_navigator"] * 5,
+            "message_topic": ["RDI"] * 5,
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0],
+        }
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.telemetry.raw.write("dvl_teledyne_navigator", "RDI", frame)
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.telemetry.raw.topics() == [
+            ("dvl_teledyne_navigator", "RDI")
+        ]
+        assert reader.telemetry.raw.sensor_keys() == ["dvl_teledyne_navigator"]
+
+        full = reader.telemetry.raw.read("dvl_teledyne_navigator", "RDI")
+        assert len(full) == 5
+
+        class _Window:
+            start = timestamps[1]
+            end = timestamps[3]
+
+        windowed = reader.telemetry.raw.read(
+            "dvl_teledyne_navigator", "RDI", window=_Window()
+        )
+        assert windowed["value"].tolist() == [2.0, 3.0, 4.0]
+
+
+def test_processed_telemetry_append_replace_and_provenance(
+    tmp_path: Path,
+) -> None:
+    """Appends processed telemetry in two chunks, then replaces it, with
+    provenance written independently of the message writes."""
+    path = tmp_path / "bundle.h5"
+    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
+    first_chunk = pd.DataFrame(
+        {
+            "timestamp": [start, start + timedelta(seconds=1)],
+            "message_topic": ["RDI", "RDI"],
+            "value": [1.0, 2.0],
+        }
+    )
+    second_chunk = pd.DataFrame(
+        {
+            "timestamp": [start + timedelta(seconds=2)],
+            "message_topic": ["RDI"],
+            "value": [3.0],
+        }
+    )
+    replacement = pd.DataFrame(
+        {
+            "timestamp": [start],
+            "message_topic": ["RDI"],
+            "value": [99.0],
+        }
+    )
+    provenance = ProcessedProvenance(
+        run_datetime=datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.telemetry.processed.append_messages(
+            "dvl_teledyne_navigator", "RDI", first_chunk
+        )
+        writer.telemetry.processed.append_messages(
+            "dvl_teledyne_navigator", "RDI", second_chunk
+        )
+        writer.telemetry.processed.write_provenance(
+            "dvl_teledyne_navigator", "RDI", provenance
+        )
+
+    with open_deployment_bundle_reader(path) as reader:
+        appended = reader.telemetry.processed.read(
+            "dvl_teledyne_navigator", "RDI"
+        )
+        assert appended["value"].tolist() == [1.0, 2.0, 3.0]
+        assert (
+            reader.telemetry.processed.provenance(
+                "dvl_teledyne_navigator", "RDI"
+            )
+            == provenance
+        )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.telemetry.processed.replace_messages(
+            "dvl_teledyne_navigator", "RDI", replacement
+        )
+
+    with open_deployment_bundle_reader(path) as reader:
+        replaced = reader.telemetry.processed.read(
+            "dvl_teledyne_navigator", "RDI"
+        )
+        assert replaced["value"].tolist() == [99.0]
+        # provenance is untouched by replace_messages
+        assert (
+            reader.telemetry.processed.provenance(
+                "dvl_teledyne_navigator", "RDI"
+            )
+            == provenance
+        )
+
+
+def test_telemetry_section_topics_union(tmp_path: Path) -> None:
+    """`telemetry.topics()` unions the raw and processed topic sets."""
+    path = tmp_path / "bundle.h5"
+    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
+    raw_frame = pd.DataFrame(
+        {
+            "timestamp": [start],
+            "sensor_key": ["dvl_teledyne_navigator"],
+            "message_topic": ["RDI"],
+        }
+    )
+    processed_frame = pd.DataFrame(
+        {"timestamp": [start], "message_topic": ["DEPTH"]}
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.telemetry.raw.write("dvl_teledyne_navigator", "RDI", raw_frame)
+        writer.telemetry.processed.append_messages(
+            "_derived", "DEPTH", processed_frame
+        )
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.telemetry.topics() == [
+            ("_derived", "DEPTH"),
+            ("dvl_teledyne_navigator", "RDI"),
+        ]
+
+
+def test_metocean_round_trip_and_enumeration(tmp_path: Path) -> None:
+    """Round-trips a metocean table and enumerates providers/variables."""
+    path = tmp_path / "bundle.h5"
+    frame = pd.DataFrame(
+        {
+            "timestamp": [datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)],
+            "sea_level": [0.42],
+        }
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.metocean.write("worldtides", "sea_level", frame)
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.metocean.providers() == ["worldtides"]
+        assert reader.metocean.variables("worldtides") == ["sea_level"]
+        read_back = reader.metocean.read("worldtides", "sea_level")
+        assert read_back["sea_level"].tolist() == [0.42]
+
+
+def test_escape_hatch(tmp_path: Path) -> None:
+    """`keys`/`contains`/`row_count`/`read_table` expose the raw store."""
+    path = tmp_path / "bundle.h5"
+    identity = DeploymentIdentity(
+        deployment_label="qc2hyd_20231021T032349Z",
+        deployment_datetime=datetime(
+            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
+        ),
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_header(_header())
+        writer.deployment.write_identity(identity)
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert "/deployment/identity" in reader.keys()
+        assert reader.contains("deployment/identity")
+        assert not reader.contains("deployment/metadata")
+        assert reader.row_count("deployment/identity") == 1
+        assert len(reader.read_table("deployment/identity")) == 1

--- a/tests/test_deployment_bundle_hdf_io.py
+++ b/tests/test_deployment_bundle_hdf_io.py
@@ -6,10 +6,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from afft.deployment.bundle_factories import (
-    open_deployment_bundle_reader,
-    open_deployment_bundle_writer,
-)
+from afft.deployment.bundle_hdf_readers import open_deployment_bundle_reader
+from afft.deployment.bundle_hdf_writers import open_deployment_bundle_writer
 from afft.deployment.bundle_types import (
     DeploymentBundleHeader,
     DeploymentIdentity,
@@ -201,8 +199,8 @@ def test_raw_telemetry_round_trip_and_window(tmp_path: Path) -> None:
         assert len(full) == 5
 
         class _Window:
-            start = timestamps[1]
-            end = timestamps[3]
+            start: datetime | None = timestamps[1]
+            end: datetime | None = timestamps[3]
 
         windowed = reader.telemetry.raw.read(
             "dvl_teledyne_navigator", "RDI", window=_Window()


### PR DESCRIPTION
## Summary
- Closes #208. Concrete `pandas.HDFStore` implementation of #199's storage-agnostic `DeploymentBundleReader`/`DeploymentBundleWriter` `Protocol` interfaces.
- `bundle_hdf_readers.py` / `bundle_hdf_writers.py` hold the dataclass/pydantic ↔ table conversion (`record_to_frame`/`frame_to_record`, `message_topics_to_frame`, `sensor_calibration_to_frame`), dtype normalization against the required-column spec, path building, and the section reader/writer classes for every layer (`deployment`, `platform`, `vessel`, `telemetry/raw`, `telemetry/processed`, `metocean`).
- `bundle_factories.py` selects and constructs the concrete backend behind `open_deployment_bundle_reader`/`open_deployment_bundle_writer`, keeping `bundle_protocols.py` free of any dependency on the concrete backend.
- `ProcessedTelemetryBundleSectionWriter.append_messages`/`replace_messages` write only the messages table; `write_provenance` is a separate create-or-overwrite method (settled while reviewing #208, before implementation started).
- A sensor's `identity`/`extrinsics`/`calibration` node, or `message_topics` when empty, is written only when present — the reader treats a missing node as `None`/`[]` uniformly.

## Test plan
- [x] `tests/test_deployment_bundle_hdf_io.py` — round-trip coverage for every section, write-once enforcement, window-filtered reads, append/replace/provenance independence, topic-union, and the escape hatch (`keys`/`contains`/`row_count`/`read_table`)
- [x] `ruff check` / `ruff format --check`
- [x] `mypy` (`src` and `tests`, strict)
- [x] `pytest` — 230 passed