### PR TITLE
Fix progress bar corruption in Squidle media collector

### DIFF
--- a/src/afft/tasks/collect_squidle_media/image_downloader.py
+++ b/src/afft/tasks/collect_squidle_media/image_downloader.py
@@ -9,8 +9,6 @@ import httpx
 from rich.console import Console
 from rich.progress import Progress, TaskID
 
-from afft.utils.log import logger
-
 from .types import (
     CollectSquidleMediaCommand,
     DeploymentImagesDownload,
@@ -78,7 +76,6 @@ def download_image(
     except Exception as error:  # isolate per-image failures
         image.status = ImageDownloadStatus.FAILED
         image.error = str(error)
-        logger.warning(f"download failed {image.destination.name!r}: {error}")
 
 
 def download_deployment(

--- a/src/afft/tasks/collect_squidle_media/media_retriever.py
+++ b/src/afft/tasks/collect_squidle_media/media_retriever.py
@@ -11,7 +11,6 @@ from rich.console import Console
 from rich.progress import Progress, TaskID
 
 from afft.squidle import Deployment, SquidleClient
-from afft.utils.log import logger
 
 from .types import CollectSquidleMediaCommand, DeploymentState, TaskState
 
@@ -45,8 +44,6 @@ def fetch_media_items(
         entry.media = client.fetch_media(entry.squidle_deployment.id)
     except Exception as error:  # isolate API/export failures per deployment
         entry.error = str(error)
-        label: str = entry.deployment_info.metadata.acfr_deployment_label
-        logger.warning(f"media retrieval failed for {label!r}: {error}")
     return entry
 
 
@@ -185,6 +182,6 @@ def retrieve_deployment_media(
             except KeyboardInterrupt:
                 # Cancel not-yet-started work so Ctrl+C does not block on the
                 # whole queue; only in-flight retrievals still drain.
-                logger.warning("media retrieval interrupted; cancelling")
+                console.print("media retrieval interrupted; cancelling")
                 executor.shutdown(wait=False, cancel_futures=True)
                 raise


### PR DESCRIPTION
## Summary

- Per-item `logger.warning` calls in `download_image` (`image_downloader.py`) and `fetch_media_items` (`media_retriever.py`) ran on worker threads while a `rich.progress.Progress` bar was live, racing its redraw of the terminal and corrupting the display.
- These warnings were redundant: failures are already recorded on `image.error` / `entry.error` and surfaced afterward via the phase summary and `run_report.json`.
- Removed the redundant live warnings; routed the one remaining message that must appear while a bar is still open (the `KeyboardInterrupt` cancellation notice) through the shared `Console` instead of raw `logger.warning`, so it interleaves correctly with the progress display.

Fixes #158

## Test plan

- [x] `uv run ruff check` passes on both changed files
- [x] Manually run the Squidle media collector against a batch with some failing downloads/retrievals and confirm the progress bar renders cleanly