### PR TITLE
Return a ParseMessageResult from parse_message_lines

### DIFF
--- a/src/afft/seabed/__init__.py
+++ b/src/afft/seabed/__init__.py
@@ -14,6 +14,9 @@ from .message_parser_registry import (
     MessageParserRegistry as MessageParserRegistry,
 )
 from .message_parser_registry import (
+    ParseMessageResult as ParseMessageResult,
+)
+from .message_parser_registry import (
     build_message_parser_registry as build_message_parser_registry,
 )
 from .message_parser_registry import parse_message_lines as parse_message_lines

--- a/src/afft/seabed/message_parser_registry.py
+++ b/src/afft/seabed/message_parser_registry.py
@@ -14,8 +14,6 @@ from .message_interfaces import (
 from .message_parsers import get_message_parser, parse_message_header
 from .message_types import MessageHeader, get_message_type
 
-from afft.utils.log import logger
-
 
 @dataclass(frozen=True)
 class MessageParserRegistryEntry:
@@ -97,9 +95,24 @@ def build_message_parser_registry(
     return registry
 
 
+@dataclass(frozen=True)
+class ParseMessageResult:
+    """
+    Attributes
+    ----------
+    message_groups: Parsed messages grouped by topic.
+    skipped: Per-topic counts of lines with no registered parser.
+    failed: Per-topic counts of lines that failed to parse.
+    """
+
+    message_groups: dict[Topic, list[Message[Any, Any]]]
+    skipped: Counter[Topic]
+    failed: Counter[Topic]
+
+
 def parse_message_lines(
     lines: list[str], registry: MessageParserRegistry
-) -> dict[str, list[Message[Any, Any]]]:
+) -> ParseMessageResult:
     """Parses lines as message types in the given registry."""
 
     message_groups: dict[str, list[Message[Any, Any]]] = dict()
@@ -126,28 +139,6 @@ def parse_message_lines(
             message_groups[header.topic] = list()
         message_groups[header.topic].append(parsed_message)
 
-    if skipped:
-        logger.warning(
-            "Skipped messages with no protocol item ({} topics, {} total):{}".format(
-                len(skipped),
-                sum(skipped.values()),
-                "".join(
-                    f"\n  {topic}: {count}"
-                    for topic, count in sorted(skipped.items())
-                ),
-            )
-        )
-
-    if failed:
-        logger.warning(
-            "Failed to parse messages ({} topics, {} total):{}".format(
-                len(failed),
-                sum(failed.values()),
-                "".join(
-                    f"\n  {topic}: {count}"
-                    for topic, count in sorted(failed.items())
-                ),
-            )
-        )
-
-    return message_groups
+    return ParseMessageResult(
+        message_groups=message_groups, skipped=skipped, failed=failed
+    )

--- a/src/afft/tasks/parse_messages/runner.py
+++ b/src/afft/tasks/parse_messages/runner.py
@@ -30,8 +30,11 @@ def run_parse_messages(
     raw_config: dict[str, Any] = io.read_config(command.config_file)
     config = _load_config(raw_config)
 
-    messages = _parse_messages(command.source_file, config)
-    dataframes = _build_dataframes(messages, config, command.prefix)
+    result = _parse_messages(command.source_file, config)
+    _log_parse_result(result)
+    dataframes = _build_dataframes(
+        result.message_groups, config, command.prefix
+    )
 
     if command.database:
         assert credentials is not None, (
@@ -59,12 +62,38 @@ def _load_config(raw: dict[str, Any]) -> ParseMessageConfig:
 
 def _parse_messages(
     source_file: Path, config: ParseMessageConfig
-) -> MessageGroups:
+) -> seabed.ParseMessageResult:
     lines: list[str] = io.read_lines(source_file)
     registry: seabed.MessageParserRegistry = (
         seabed.build_message_parser_registry(config.message_maps)
     )
     return seabed.parse_message_lines(lines, registry)
+
+
+def _log_parse_result(result: seabed.ParseMessageResult) -> None:
+    if result.skipped:
+        logger.warning(
+            "Skipped messages with no protocol item ({} topics, {} total):{}".format(
+                len(result.skipped),
+                sum(result.skipped.values()),
+                "".join(
+                    f"\n  {topic}: {count}"
+                    for topic, count in sorted(result.skipped.items())
+                ),
+            )
+        )
+
+    if result.failed:
+        logger.warning(
+            "Failed to parse messages ({} topics, {} total):{}".format(
+                len(result.failed),
+                sum(result.failed.values()),
+                "".join(
+                    f"\n  {topic}: {count}"
+                    for topic, count in sorted(result.failed.items())
+                ),
+            )
+        )
 
 
 def _build_dataframes(


### PR DESCRIPTION
## Summary
- `seabed.parse_message_lines` now returns a `ParseMessageResult` (`message_groups`, `skipped`, `failed`) instead of a bare `dict`, and no longer logs directly.
- `parse_messages`'s runner logs the skipped/failed counts itself at the same point, preserving current behavior.

Closes #217