### PR TITLE
Re-export Topic and MessageTypeName from afft.seabed

### DIFF
--- a/src/afft/seabed/__init__.py
+++ b/src/afft/seabed/__init__.py
@@ -10,6 +10,8 @@ from .localizer_types import SensorPoseEntry as SensorPoseEntry
 from .localizer_types import ShipSensorConfig as ShipSensorConfig
 from .message_interfaces import Message as Message
 from .message_interfaces import MessageParser as MessageParser
+from .message_interfaces import MessageTypeName as MessageTypeName
+from .message_interfaces import Topic as Topic
 from .message_parser_registry import (
     MessageParserRegistry as MessageParserRegistry,
 )


### PR DESCRIPTION
## Summary
- Re-exports `Topic` and `MessageTypeName` from `afft.seabed`'s `__init__.py`, matching the existing pattern for other `message_interfaces` exports.

Prerequisite noted in #200's design for the deployment bundle builder, which needs to import these type aliases from `afft.seabed` directly.