### PR TITLE
Add overwrite flag to bundle build command and a batch build script

### DIFF
--- a/scripts/shell/batch_build_bundles.sh
+++ b/scripts/shell/batch_build_bundles.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DESCRIPTOR_FILE="${REPO_ROOT}/data/deployment_descriptors_v1_subset_enriched.toml"
+CONFIG_FILE="${REPO_ROOT}/config/default.toml"
+
+DEPLOYMENT_DATA_DIR="/data/exos_01/acfr_deployments_v1_subset_fixed"
+OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+
+DEPLOYMENTS=(
+  "qdch0ftq_20100428_020202"
+  "qdch0ftq_20110415_020103"
+  "qdch0ftq_20120430_002423"
+  "qdch0ftq_20130406_023610"
+  "qdchdmy1_20110416_005411"
+  "qdchdmy1_20120501_071203"
+  "qdchdmy1_20130406_081713"
+  "qdchdmy1_20170525_234624"
+  "r23685bc_20100605_021022"
+  "r23685bc_20120530_233021"
+  "r23685bc_20140616_225022"
+  "r29mrd5h_20090612_225306"
+  "r29mrd5h_20110612_033752"
+  "r29mrd5h_20130611_002419"
+  "r7jjskxq_20101023_210332"
+  "r7jjskxq_20121013_060425"
+  "r7jjskxq_20131022_004934"
+)
+
+for deployment in "${DEPLOYMENTS[@]}"; do
+  uv run afft bundle build \
+    --descriptor-file "${DESCRIPTOR_FILE}" \
+    --data-dir "${DEPLOYMENT_DATA_DIR}/${deployment}_deployment_data" \
+    --config "${CONFIG_FILE}" \
+    --deployment-label "${deployment}" \
+    --output "${OUTPUT_DIR}/${deployment}_deployment_bundle.h5"
+done

--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -15,6 +15,7 @@ def dispatch_build_deployment_bundle(
     data_dir: str | Path,
     config_file: str | Path,
     output_file: str | Path,
+    overwrite: bool = False,
     verbose: bool = False,
 ) -> None:
     """Build a deployment bundle from a descriptor and its raw message logs."""
@@ -24,6 +25,7 @@ def dispatch_build_deployment_bundle(
         data_dir=Path(data_dir),
         config_file=Path(config_file),
         output_file=Path(output_file),
+        overwrite=overwrite,
         verbose=verbose,
     )
     config = read_build_deployment_bundle_config(command.config_file)

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -49,6 +49,12 @@ def bundle_group(context: click.Context) -> None:
     help="path to write the deployment bundle to",
 )
 @click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="overwrite the output file if it already exists",
+)
+@click.option(
     "--verbose",
     is_flag=True,
     default=False,
@@ -60,6 +66,7 @@ def build(
     data_dir: str,
     config_file: str,
     output_file: str,
+    overwrite: bool,
     verbose: bool,
 ) -> None:
     """Build a deployment bundle from a descriptor and its raw message logs."""
@@ -69,5 +76,6 @@ def build(
         data_dir,
         config_file,
         output_file,
+        overwrite,
         verbose,
     )

--- a/src/afft/tasks/build_deployment_bundle/task_helpers.py
+++ b/src/afft/tasks/build_deployment_bundle/task_helpers.py
@@ -128,7 +128,8 @@ def validate_build_deployment_bundle_input(
     FileNotFoundError: If ``data_dir`` or the output directory does not
         exist, or if no raw message logs are found.
     ValueError: If ``data_dir``'s name does not match the deployment label,
-        the descriptor is unenriched, or the output file already exists.
+        the descriptor is unenriched, or the output file already exists and
+        ``command.overwrite`` is not set.
     """
     if not command.data_dir.is_dir():
         raise FileNotFoundError(
@@ -161,7 +162,11 @@ def validate_build_deployment_bundle_input(
             f"output directory does not exist: {command.output_file.parent}"
         )
     if command.output_file.exists():
-        raise ValueError(f"output file already exists: {command.output_file}")
+        if not command.overwrite:
+            raise ValueError(
+                f"output file already exists: {command.output_file}"
+            )
+        command.output_file.unlink()
 
     return files
 

--- a/src/afft/tasks/build_deployment_bundle/types.py
+++ b/src/afft/tasks/build_deployment_bundle/types.py
@@ -33,6 +33,7 @@ class BuildDeploymentBundleCommand:
     config_file: Path to the shared task config TOML file
         (``config/default.toml``).
     output_file: Path to write the deployment bundle to.
+    overwrite: Overwrite ``output_file`` if it already exists.
     verbose: Log diagnostics warnings after the run completes.
     """
 
@@ -41,6 +42,7 @@ class BuildDeploymentBundleCommand:
     data_dir: Path
     config_file: Path
     output_file: Path
+    overwrite: bool = False
     verbose: bool = False
 
 


### PR DESCRIPTION
## Summary
- Add an `--overwrite` flag to the `bundle build` CLI command and `build_deployment_bundle` task, allowing an existing output file to be replaced instead of raising
- Add `scripts/shell/batch_build_bundles.sh` to build bundles for a set of deployments from a descriptor file, resolving the descriptor and config paths relative to the script location