### PR TITLE
Rewrite deployment bundle interfaces around generic keyed frames

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -22,22 +22,7 @@ from .bundle_types import (
 )
 from .bundle_protocols import (
     DeploymentBundleReader as DeploymentBundleReader,
-    DeploymentBundleSectionReader as DeploymentBundleSectionReader,
-    DeploymentBundleSectionWriter as DeploymentBundleSectionWriter,
     DeploymentBundleWriter as DeploymentBundleWriter,
-    MetoceanBundleSectionReader as MetoceanBundleSectionReader,
-    MetoceanBundleSectionWriter as MetoceanBundleSectionWriter,
-    PlatformBundleSectionReader as PlatformBundleSectionReader,
-    PlatformBundleSectionWriter as PlatformBundleSectionWriter,
-    ProcessedTelemetryBundleSectionReader as ProcessedTelemetryBundleSectionReader,
-    ProcessedTelemetryBundleSectionWriter as ProcessedTelemetryBundleSectionWriter,
-    RawTelemetryBundleSectionReader as RawTelemetryBundleSectionReader,
-    RawTelemetryBundleSectionWriter as RawTelemetryBundleSectionWriter,
-    TelemetryBundleSectionReader as TelemetryBundleSectionReader,
-    TelemetryBundleSectionWriter as TelemetryBundleSectionWriter,
-    TimeWindow as TimeWindow,
-    VesselBundleSectionReader as VesselBundleSectionReader,
-    VesselBundleSectionWriter as VesselBundleSectionWriter,
 )
 from .bundle_factories import (
     open_deployment_bundle_reader as open_deployment_bundle_reader,

--- a/src/afft/deployment/bundle_factories.py
+++ b/src/afft/deployment/bundle_factories.py
@@ -14,26 +14,6 @@ from .bundle_hdf_writers import (
 )
 from .bundle_protocols import DeploymentBundleReader, DeploymentBundleWriter
 
-_SUPPORTED_SUFFIXES: frozenset[str] = frozenset({".h5"})
-
-
-def _check_suffix(path: Path) -> None:
-    """
-    Raise if `path`'s suffix is not a supported bundle file format.
-
-    Arguments
-    ---------
-    path: Path to the deployment bundle file.
-
-    Raises
-    ------
-    ValueError: If `path`'s suffix is not supported.
-    """
-    if path.suffix not in _SUPPORTED_SUFFIXES:
-        raise ValueError(
-            f"unsupported bundle file suffix {path.suffix!r}: {path}"
-        )
-
 
 @contextmanager
 def open_deployment_bundle_reader(
@@ -49,10 +29,20 @@ def open_deployment_bundle_reader(
     Returns
     -------
     A context manager yielding a ``DeploymentBundleReader``.
+
+    Raises
+    ------
+    NotImplementedError: If `path`'s suffix is not a supported bundle file
+        format.
     """
-    _check_suffix(path)
-    with _open_hdf_reader(path) as reader:
-        yield cast(DeploymentBundleReader, reader)
+    match path.suffix:
+        case ".h5":
+            with _open_hdf_reader(path) as reader:
+                yield cast(DeploymentBundleReader, reader)
+        case suffix:
+            raise NotImplementedError(
+                f"unsupported bundle file suffix {suffix!r}: {path}"
+            )
 
 
 @contextmanager
@@ -69,7 +59,17 @@ def open_deployment_bundle_writer(
     Returns
     -------
     A context manager yielding a ``DeploymentBundleWriter``.
+
+    Raises
+    ------
+    NotImplementedError: If `path`'s suffix is not a supported bundle file
+        format.
     """
-    _check_suffix(path)
-    with _open_hdf_writer(path) as writer:
-        yield cast(DeploymentBundleWriter, writer)
+    match path.suffix:
+        case ".h5":
+            with _open_hdf_writer(path) as writer:
+                yield cast(DeploymentBundleWriter, writer)
+        case suffix:
+            raise NotImplementedError(
+                f"unsupported bundle file suffix {suffix!r}: {path}"
+            )

--- a/src/afft/deployment/bundle_factories.py
+++ b/src/afft/deployment/bundle_factories.py
@@ -14,6 +14,26 @@ from .bundle_hdf_writers import (
 )
 from .bundle_protocols import DeploymentBundleReader, DeploymentBundleWriter
 
+_SUPPORTED_SUFFIXES: frozenset[str] = frozenset({".h5"})
+
+
+def _check_suffix(path: Path) -> None:
+    """
+    Raise if `path`'s suffix is not a supported bundle file format.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Raises
+    ------
+    ValueError: If `path`'s suffix is not supported.
+    """
+    if path.suffix not in _SUPPORTED_SUFFIXES:
+        raise ValueError(
+            f"unsupported bundle file suffix {path.suffix!r}: {path}"
+        )
+
 
 @contextmanager
 def open_deployment_bundle_reader(
@@ -30,6 +50,7 @@ def open_deployment_bundle_reader(
     -------
     A context manager yielding a ``DeploymentBundleReader``.
     """
+    _check_suffix(path)
     with _open_hdf_reader(path) as reader:
         yield cast(DeploymentBundleReader, reader)
 
@@ -49,5 +70,6 @@ def open_deployment_bundle_writer(
     -------
     A context manager yielding a ``DeploymentBundleWriter``.
     """
+    _check_suffix(path)
     with _open_hdf_writer(path) as writer:
         yield cast(DeploymentBundleWriter, writer)

--- a/src/afft/deployment/bundle_hdf_readers.py
+++ b/src/afft/deployment/bundle_hdf_readers.py
@@ -1,7 +1,5 @@
-"""Concrete `pandas.HDFStore` readers implementing the deployment bundle
-read `Protocol` interfaces defined in `bundle_protocols.py`."""
-
-import re
+"""Concrete `pandas.HDFStore` reader implementing the deployment bundle
+read `Protocol` interface defined in `bundle_protocols.py`."""
 
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -10,392 +8,60 @@ from typing import Iterator
 
 import pandas as pd
 
-from pydantic import BaseModel
-
-from .bundle_protocols import TimeWindow
-from .bundle_types import (
-    DeploymentBundleHeader,
-    DeploymentIdentity,
-    DeploymentProvenance,
-    ProcessedProvenance,
-)
-from .common_types import (
-    DeploymentMetadata,
-    PlatformIdentity,
-    PlatformSensor,
-    SensorCalibration,
-    SensorExtrinsics,
-    SensorIdentity,
-    VesselIdentity,
-    VesselSensor,
-)
-
-# --- dataclass / pydantic model <- table conversion ---
+_CONTENTS_KEY: str = "bundle_contents"
+_RESERVED_KEYS: frozenset[str] = frozenset({_CONTENTS_KEY})
 
 
-def frame_to_record[T: BaseModel](frame: pd.DataFrame, cls: type[T]) -> T:
-    """
-    Decode a one-row `DataFrame` back into an instance of `cls`.
+def _read_contents(store: pd.HDFStore) -> pd.DataFrame:
+    """Read `bundle_contents`, or an empty frame of the right shape if the
+    bundle has no tables."""
+    if _CONTENTS_KEY not in store:
+        return pd.DataFrame(
+            {
+                "identifier": pd.array([], dtype="object"),
+                "table_name": pd.array([], dtype="object"),
+            }
+        )
+    return store.select(_CONTENTS_KEY)
 
-    Arguments
-    ---------
-    frame: One-row `DataFrame` to decode.
-    cls: Model class to validate into.
 
-    Returns
-    -------
-    The decoded model instance.
+def _resolve_table_name(store: pd.HDFStore, key: str) -> str:
+    """Look up the backend-specific `table_name` for `key` in
+    `bundle_contents`.
 
     Raises
     ------
-    ValueError: If `frame` does not have exactly one row.
+    KeyError: If no frame is registered under `key`.
     """
-    if len(frame) != 1:
-        raise ValueError(f"expected exactly one row, got {len(frame)}")
-    return cls.model_validate(frame.iloc[0].to_dict())
-
-
-def frame_to_message_topics(frame: pd.DataFrame) -> list[str]:
-    """Decode a `message_topics` table back into an ordered list."""
-    return [str(topic) for topic in frame["topic"]]
-
-
-def frame_to_sensor_calibration(frame: pd.DataFrame) -> SensorCalibration:
-    """Decode a `calibration` table back into a `SensorCalibration`."""
-    if frame.empty:
-        raise ValueError("calibration table has no rows")
-    calibration_type = str(frame["calibration_type"].iloc[0])
-    parameters = dict(zip(frame["name"], frame["value"], strict=True))
-    return SensorCalibration(
-        calibration_type=calibration_type, parameters=parameters
-    )
-
-
-def time_window_to_where(window: TimeWindow | None) -> str | None:
-    """
-    Translate a `TimeWindow` into a PyTables `where=` predicate string
-    against the `timestamp` column, or `None` for no predicate.
-    """
-    if window is None:
-        return None
-    terms: list[str] = []
-    if window.start is not None:
-        terms.append(f"timestamp >= '{window.start.isoformat()}'")
-    if window.end is not None:
-        terms.append(f"timestamp <= '{window.end.isoformat()}'")
-    if not terms:
-        return None
-    return " & ".join(terms)
-
-
-# --- section readers ---
-
-
-@dataclass
-class HDFDeploymentBundleSectionReader:
-    """Reads `deployment/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "deployment"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    @property
-    def metadata_path(self) -> str:
-        return f"{self.root_path}/metadata"
-
-    @property
-    def files_path(self) -> str:
-        return f"{self.root_path}/files"
-
-    @property
-    def provenance_path(self) -> str:
-        return f"{self.root_path}/provenance"
-
-    def identity(self) -> DeploymentIdentity:
-        return frame_to_record(
-            self.store.select(self.identity_path), DeploymentIdentity
-        )
-
-    def metadata(self) -> DeploymentMetadata:
-        return frame_to_record(
-            self.store.select(self.metadata_path), DeploymentMetadata
-        )
-
-    def provenance(self) -> DeploymentProvenance:
-        return frame_to_record(
-            self.store.select(self.provenance_path), DeploymentProvenance
-        )
-
-    def files(self) -> pd.DataFrame:
-        return self.store.select(self.files_path)
-
-
-@dataclass
-class HDFPlatformBundleSectionReader:
-    """Reads `platform/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "platform"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    def sensor_identity_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/identity"
-
-    def sensor_message_topics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
-
-    def sensor_extrinsics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
-
-    def sensor_calibration_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/calibration"
-
-    def identity(self) -> PlatformIdentity:
-        return frame_to_record(
-            self.store.select(self.identity_path), PlatformIdentity
-        )
-
-    def sensor_keys(self) -> list[str]:
-        return _sensor_keys(self.store, self.root_path)
-
-    def sensors(self) -> list[PlatformSensor]:
-        return [
-            read_platform_sensor(self.store, key) for key in self.sensor_keys()
-        ]
-
-
-@dataclass
-class HDFVesselBundleSectionReader:
-    """Reads `vessel/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "vessel"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    def sensor_identity_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/identity"
-
-    def sensor_message_topics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
-
-    def sensor_extrinsics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
-
-    def sensor_calibration_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/calibration"
-
-    def identity(self) -> VesselIdentity:
-        return frame_to_record(
-            self.store.select(self.identity_path), VesselIdentity
-        )
-
-    def sensor_keys(self) -> list[str]:
-        return _sensor_keys(self.store, self.root_path)
-
-    def sensors(self) -> list[VesselSensor]:
-        return [
-            read_vessel_sensor(self.store, key) for key in self.sensor_keys()
-        ]
-
-
-@dataclass
-class HDFRawTelemetryBundleSectionReader:
-    """Reads `telemetry/raw/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "telemetry/raw"
-
-    def topic_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/messages"
-
-    def topics(self) -> list[tuple[str, str]]:
-        return _topic_pairs(self.store, self.root_path)
-
-    def sensor_keys(self) -> list[str]:
-        return sorted({sensor_key for sensor_key, _ in self.topics()})
-
-    def read(
-        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        return self.store.select(
-            self.topic_path(sensor_key, topic),
-            where=time_window_to_where(window),
-        )
-
-
-@dataclass
-class HDFProcessedTelemetryBundleSectionReader:
-    """Reads `telemetry/processed/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "telemetry/processed"
-
-    def topic_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/messages"
-
-    def provenance_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/provenance"
-
-    def topics(self) -> list[tuple[str, str]]:
-        return _topic_pairs(self.store, self.root_path)
-
-    def sensor_keys(self) -> list[str]:
-        return sorted({sensor_key for sensor_key, _ in self.topics()})
-
-    def read(
-        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        return self.store.select(
-            self.topic_path(sensor_key, topic),
-            where=time_window_to_where(window),
-        )
-
-    def provenance(self, sensor_key: str, topic: str) -> ProcessedProvenance:
-        return frame_to_record(
-            self.store.select(self.provenance_path(sensor_key, topic)),
-            ProcessedProvenance,
-        )
-
-
-@dataclass
-class HDFTelemetryBundleSectionReader:
-    """Composes the raw and processed telemetry readers."""
-
-    raw: HDFRawTelemetryBundleSectionReader
-    processed: HDFProcessedTelemetryBundleSectionReader
-
-    def topics(self) -> list[tuple[str, str]]:
-        return sorted(set(self.raw.topics()) | set(self.processed.topics()))
-
-
-@dataclass
-class HDFMetoceanBundleSectionReader:
-    """Reads `metocean/*` from an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "metocean"
-
-    def variable_path(self, provider: str, variable: str) -> str:
-        return f"{self.root_path}/{provider}/{variable}"
-
-    def providers(self) -> list[str]:
-        pattern = re.compile(rf"^/{re.escape(self.root_path)}/([^/]+)/([^/]+)$")
-        return sorted(
-            {
-                match.group(1)
-                for path in self.store.keys()
-                if (match := pattern.match(path))
-            }
-        )
-
-    def variables(self, provider: str) -> list[str]:
-        pattern = re.compile(
-            rf"^/{re.escape(self.root_path)}/{re.escape(provider)}/([^/]+)$"
-        )
-        return sorted(
-            match.group(1)
-            for path in self.store.keys()
-            if (match := pattern.match(path))
-        )
-
-    def read(
-        self, provider: str, variable: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        return self.store.select(
-            self.variable_path(provider, variable),
-            where=time_window_to_where(window),
-        )
-
-
-# --- top-level reader and its escape hatch ---
+    contents = _read_contents(store)
+    matches = contents.loc[contents["identifier"] == key, "table_name"]
+    if matches.empty:
+        raise KeyError(key)
+    return str(matches.iloc[0])
 
 
 @dataclass
 class HDFDeploymentBundleReader:
-    """
-    Concrete `DeploymentBundleReader` backed by a `pandas.HDFStore` opened
-    in read mode.
-
-    Attributes
-    ----------
-    store: Open `HDFStore` handle.
-    header: Parsed once at open time, trusted for the rest of the object's
-        lifetime.
-    """
+    """Concrete `DeploymentBundleReader` backed by an open `pandas.HDFStore`."""
 
     store: pd.HDFStore
-    header: DeploymentBundleHeader
-    deployment: HDFDeploymentBundleSectionReader
-    platform: HDFPlatformBundleSectionReader
-    vessel: HDFVesselBundleSectionReader
-    telemetry: HDFTelemetryBundleSectionReader
-    metocean: HDFMetoceanBundleSectionReader
 
-    @property
-    def header_path(self) -> str:
-        return _HEADER_PATH
+    def list_frames(self) -> list[str]:
+        return list(self.contents()["identifier"])
 
-    @classmethod
-    def open(cls, store: pd.HDFStore) -> "HDFDeploymentBundleReader":
-        """Parse the root `bundle` table and wrap the section readers."""
-        header = frame_to_record(
-            store.select(_HEADER_PATH), DeploymentBundleHeader
-        )
-        return cls(
-            store=store,
-            header=header,
-            deployment=HDFDeploymentBundleSectionReader(store),
-            platform=HDFPlatformBundleSectionReader(store),
-            vessel=HDFVesselBundleSectionReader(store),
-            telemetry=HDFTelemetryBundleSectionReader(
-                raw=HDFRawTelemetryBundleSectionReader(store),
-                processed=HDFProcessedTelemetryBundleSectionReader(store),
-            ),
-            metocean=HDFMetoceanBundleSectionReader(store),
-        )
+    def has_frame(self, key: str) -> bool:
+        if key in _RESERVED_KEYS:
+            return False
+        return key in self.list_frames()
 
-    # flat, path-first escape hatch -- not part of the storage-agnostic
-    # Protocol, HDFStore-shaped by nature
+    def read_frame(self, key: str) -> pd.DataFrame:
+        if key in _RESERVED_KEYS:
+            raise KeyError(f"{key!r} is reserved; use contents() instead")
+        table_name = _resolve_table_name(self.store, key)
+        return self.store.select(table_name)
 
-    def keys(self) -> list[str]:
-        return list(self.store.keys())
-
-    def contains(self, path: str) -> bool:
-        return path in self.store
-
-    def row_count(self, path: str) -> int:
-        storer = self.store.get_storer(path)
-        return int(storer.nrows)
-
-    def read_table(self, path: str) -> pd.DataFrame:
-        return self.store.select(path)
+    def contents(self) -> pd.DataFrame:
+        return _read_contents(self.store)
 
 
 @contextmanager
@@ -404,98 +70,4 @@ def open_deployment_bundle_reader(
 ) -> Iterator[HDFDeploymentBundleReader]:
     """Open an HDF5 deployment bundle for reading."""
     with pd.HDFStore(str(path), mode="r") as store:
-        yield HDFDeploymentBundleReader.open(store)
-
-
-def read_platform_sensor(store: pd.HDFStore, sensor_key: str) -> PlatformSensor:
-    """Assemble one `PlatformSensor` from its identity, message_topics,
-    extrinsics, and optional calibration nodes."""
-    reader = HDFPlatformBundleSectionReader(store)
-    return PlatformSensor(
-        key=sensor_key,
-        message_topics=_maybe_read_message_topics(
-            store, reader.sensor_message_topics_path(sensor_key)
-        ),
-        identity=_maybe_read_record(
-            store, reader.sensor_identity_path(sensor_key), SensorIdentity
-        ),
-        extrinsics=_maybe_read_record(
-            store, reader.sensor_extrinsics_path(sensor_key), SensorExtrinsics
-        ),
-        calibration=_maybe_read_calibration(
-            store, reader.sensor_calibration_path(sensor_key)
-        ),
-    )
-
-
-def read_vessel_sensor(store: pd.HDFStore, sensor_key: str) -> VesselSensor:
-    """Assemble one `VesselSensor` from its identity, message_topics,
-    extrinsics, and optional calibration nodes."""
-    reader = HDFVesselBundleSectionReader(store)
-    return VesselSensor(
-        key=sensor_key,
-        message_topics=_maybe_read_message_topics(
-            store, reader.sensor_message_topics_path(sensor_key)
-        ),
-        identity=_maybe_read_record(
-            store, reader.sensor_identity_path(sensor_key), SensorIdentity
-        ),
-        extrinsics=_maybe_read_record(
-            store, reader.sensor_extrinsics_path(sensor_key), SensorExtrinsics
-        ),
-        calibration=_maybe_read_calibration(
-            store, reader.sensor_calibration_path(sensor_key)
-        ),
-    )
-
-
-# --- private helpers ---
-
-_HEADER_PATH: str = "bundle"
-
-
-def _sensor_keys(store: pd.HDFStore, root_path: str) -> list[str]:
-    """List sensor keys under `root_path/sensors/<key>/identity`."""
-    pattern = re.compile(rf"^/{re.escape(root_path)}/sensors/([^/]+)/identity$")
-    return sorted(
-        match.group(1)
-        for path in store.keys()
-        if (match := pattern.match(path))
-    )
-
-
-def _topic_pairs(store: pd.HDFStore, root_path: str) -> list[tuple[str, str]]:
-    """List `(sensor_key, topic)` pairs under `root_path/<key>/<topic>/messages`."""
-    pattern = re.compile(rf"^/{re.escape(root_path)}/([^/]+)/([^/]+)/messages$")
-    return sorted(
-        (match.group(1), match.group(2))
-        for path in store.keys()
-        if (match := pattern.match(path))
-    )
-
-
-def _maybe_read_record[T: BaseModel](
-    store: pd.HDFStore, path: str, cls: type[T]
-) -> T | None:
-    """Read a flat record at `path`, or `None` if the node is absent."""
-    if path not in store:
-        return None
-    return frame_to_record(store.select(path), cls)
-
-
-def _maybe_read_message_topics(store: pd.HDFStore, path: str) -> list[str]:
-    """Read a `message_topics` table at `path`, or `[]` if the node is
-    absent."""
-    if path not in store:
-        return []
-    return frame_to_message_topics(store.select(path))
-
-
-def _maybe_read_calibration(
-    store: pd.HDFStore, path: str
-) -> SensorCalibration | None:
-    """Read a `calibration` table at `path`, or `None` if the node is
-    absent."""
-    if path not in store:
-        return None
-    return frame_to_sensor_calibration(store.select(path))
+        yield HDFDeploymentBundleReader(store=store)

--- a/src/afft/deployment/bundle_hdf_writers.py
+++ b/src/afft/deployment/bundle_hdf_writers.py
@@ -1,422 +1,107 @@
-"""Concrete `pandas.HDFStore` writers implementing the deployment bundle
-write `Protocol` interfaces defined in `bundle_protocols.py`."""
+"""Concrete `pandas.HDFStore` writer implementing the deployment bundle
+write `Protocol` interface defined in `bundle_protocols.py`."""
 
-from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Literal
 
 import pandas as pd
 
-from pydantic import BaseModel
-
-from .bundle_types import (
-    DeploymentBundleHeader,
-    DeploymentIdentity,
-    DeploymentProvenance,
-    ProcessedProvenance,
-)
-from .common_types import (
-    DeploymentMetadata,
-    PlatformIdentity,
-    PlatformSensor,
-    SensorCalibration,
-    VesselIdentity,
-    VesselSensor,
-)
-
-# --- dtype normalization and put policy helpers ---
+_CONTENTS_KEY: str = "bundle_contents"
+_RESERVED_KEYS: frozenset[str] = frozenset({_CONTENTS_KEY})
 
 
-def normalize_dtypes(
-    frame: pd.DataFrame, dtypes: Mapping[str, str]
-) -> pd.DataFrame:
+def _coerce_storable_dtypes(frame: pd.DataFrame) -> pd.DataFrame:
     """
-    Cast columns to the HDF5-table-safe dtype set before a `put`/`append`.
+    Cast pandas extension dtypes (``Int64``, ``Float64``, ``boolean``,
+    ``string``) to their plain-numpy equivalents, the dtype set
+    `HDFStore.put(..., format="table")` can store.
+
+    Category and timezone-aware datetime columns are left untouched --
+    those are exactly the extension dtypes PyTables supports natively.
+    Column-specific choices (which columns should be `category` or a
+    UTC timestamp) are the caller's responsibility, made before this is
+    called.
 
     Arguments
     ---------
-    frame: Frame to normalize; not mutated.
-    dtypes: Column name to target dtype string, e.g. ``"category"`` or
-        ``"datetime64[ns, UTC]"``.
+    frame: Frame to coerce; not mutated.
 
     Returns
     -------
-    A copy of `frame` with the named columns cast.
+    A copy of `frame` with any nullable numeric/boolean/string columns
+    cast to plain numpy dtypes.
     """
     frame = frame.copy()
-    for column, dtype in dtypes.items():
-        if pd.api.types.pandas_dtype(dtype) == _DATETIME_UTC_DTYPE:
-            frame[column] = pd.to_datetime(frame[column], utc=True)
-        else:
-            frame[column] = frame[column].astype(dtype)
+    for column in frame.columns:
+        dtype = frame[column].dtype
+        if isinstance(dtype, (pd.CategoricalDtype, pd.DatetimeTZDtype)):
+            continue
+        if isinstance(dtype, pd.StringDtype):
+            frame[column] = frame[column].astype(object)
+        elif isinstance(dtype, pd.api.extensions.ExtensionDtype):
+            frame[column] = frame[column].astype(dtype.numpy_dtype)
     return frame
 
 
-def put_once(
-    store: pd.HDFStore,
-    path: str,
-    frame: pd.DataFrame,
-    *,
-    data_columns: list[str] | None = None,
-) -> None:
-    """
-    `store.put` a table at `path`, raising if a node already exists there.
-
-    Arguments
-    ---------
-    store: Open `HDFStore` handle.
-    path: Node path to write.
-    frame: Table to write.
-    data_columns: Columns to index for `where=` queries.
-
-    Raises
-    ------
-    ValueError: If a node already exists at `path`.
-    """
-    if path in store:
-        raise ValueError(f"{path} already exists")
-    store.put(path, frame, format="table", data_columns=data_columns)
-
-
-def put_replacing(
-    store: pd.HDFStore,
-    path: str,
-    frame: pd.DataFrame,
-    *,
-    data_columns: list[str] | None = None,
-) -> None:
-    """
-    `store.remove` any existing node at `path`, then `store.put` the new
-    frame.
-
-    Arguments
-    ---------
-    store: Open `HDFStore` handle.
-    path: Node path to write.
-    frame: Table to write.
-    data_columns: Columns to index for `where=` queries.
-    """
-    if path in store:
-        store.remove(path)
-    store.put(path, frame, format="table", data_columns=data_columns)
-
-
-# --- dataclass / pydantic model -> table conversion ---
-
-
-def record_to_frame(value: BaseModel) -> pd.DataFrame:
-    """
-    Encode a flat pydantic model as a one-row `DataFrame`.
-
-    Only handles models whose fields are all scalar (`str`, `float`, `int`,
-    `bool`, `datetime`) -- a model with a `list`/`dict` field needs its own
-    row-per-item table instead, see `message_topics_to_frame` and
-    `sensor_calibration_to_frame`. `datetime` fields are detected from the
-    model's own field annotations and normalized to `datetime64[ns, UTC]`,
-    since `HDFStore`'s `format="table"` cannot write a naive/mixed-tz object
-    column.
-
-    Arguments
-    ---------
-    value: Model instance to encode.
-
-    Returns
-    -------
-    A one-row `DataFrame`.
-    """
-    frame = pd.DataFrame([value.model_dump()])
-    for name, field in type(value).model_fields.items():
-        if field.annotation is datetime:
-            frame[name] = pd.to_datetime(frame[name], utc=True)
-    return frame
-
-
-def message_topics_to_frame(topics: list[str]) -> pd.DataFrame:
-    """Encode `CatalogProfileSensor.message_topics` as one row per topic."""
-    return pd.DataFrame({"topic": pd.array(topics, dtype="object")})
-
-
-def sensor_calibration_to_frame(value: SensorCalibration) -> pd.DataFrame:
-    """
-    Encode `SensorCalibration` as one row per parameter, `calibration_type`
-    denormalized onto every row so the whole model still lives at a single
-    path.
-    """
-    names = list(value.parameters.keys())
-    values = list(value.parameters.values())
-    return pd.DataFrame(
-        {
-            "calibration_type": pd.Categorical(
-                [value.calibration_type] * len(names)
-            ),
-            "name": pd.array(names, dtype="object"),
-            "value": pd.array(values, dtype="float64"),
-        }
-    )
-
-
-# --- section writers ---
-
-
-@dataclass
-class HDFDeploymentBundleSectionWriter:
-    """
-    Writes `deployment/*` to an open store.
-
-    Each method is write-once -- it raises if the target node already
-    exists.
-    """
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "deployment"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    @property
-    def metadata_path(self) -> str:
-        return f"{self.root_path}/metadata"
-
-    @property
-    def files_path(self) -> str:
-        return f"{self.root_path}/files"
-
-    @property
-    def provenance_path(self) -> str:
-        return f"{self.root_path}/provenance"
-
-    def write_identity(self, value: DeploymentIdentity) -> None:
-        put_once(self.store, self.identity_path, record_to_frame(value))
-
-    def write_metadata(self, value: DeploymentMetadata) -> None:
-        put_once(self.store, self.metadata_path, record_to_frame(value))
-
-    def write_files(self, frame: pd.DataFrame) -> None:
-        frame = normalize_dtypes(frame, _DEPLOYMENT_FILES_REQUIRED_DTYPES)
-        put_once(self.store, self.files_path, frame, data_columns=["role"])
-
-    def write_provenance(self, value: DeploymentProvenance) -> None:
-        put_once(self.store, self.provenance_path, record_to_frame(value))
-
-
-@dataclass
-class HDFPlatformBundleSectionWriter:
-    """
-    Writes `platform/*` to an open store.
-
-    Each method is write-once -- it raises if the target node already
-    exists. A sensor's optional `identity`/`extrinsics`/`calibration` node,
-    or its `message_topics` node when the list is empty, is simply not
-    written rather than written empty; the reader treats a missing node as
-    `None`/`[]`.
-    """
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "platform"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    def sensor_identity_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/identity"
-
-    def sensor_message_topics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
-
-    def sensor_extrinsics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
-
-    def sensor_calibration_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/calibration"
-
-    def write_identity(self, value: PlatformIdentity) -> None:
-        put_once(self.store, self.identity_path, record_to_frame(value))
-
-    def write_sensors(self, values: list[PlatformSensor]) -> None:
-        for sensor in values:
-            _write_sensor(self, sensor)
-
-
-@dataclass
-class HDFVesselBundleSectionWriter:
-    """
-    Writes `vessel/*` to an open store.
-
-    Each method is write-once -- it raises if the target node already
-    exists. A sensor's optional `identity`/`extrinsics`/`calibration` node,
-    or its `message_topics` node when the list is empty, is simply not
-    written rather than written empty; the reader treats a missing node as
-    `None`/`[]`.
-    """
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "vessel"
-
-    @property
-    def identity_path(self) -> str:
-        return f"{self.root_path}/identity"
-
-    def sensor_identity_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/identity"
-
-    def sensor_message_topics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/message_topics"
-
-    def sensor_extrinsics_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/extrinsics"
-
-    def sensor_calibration_path(self, sensor_key: str) -> str:
-        return f"{self.root_path}/sensors/{sensor_key}/calibration"
-
-    def write_identity(self, value: VesselIdentity) -> None:
-        put_once(self.store, self.identity_path, record_to_frame(value))
-
-    def write_sensors(self, values: list[VesselSensor]) -> None:
-        for sensor in values:
-            _write_sensor(self, sensor)
-
-
-@dataclass
-class HDFRawTelemetryBundleSectionWriter:
-    """
-    Writes `telemetry/raw/*` to an open store.
-
-    Write-once -- it raises if the target node already exists.
-    """
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "telemetry/raw"
-
-    def topic_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/messages"
-
-    def write(self, sensor_key: str, topic: str, frame: pd.DataFrame) -> None:
-        frame = normalize_dtypes(frame, _RAW_TELEMETRY_REQUIRED_DTYPES)
-        put_once(
-            self.store,
-            self.topic_path(sensor_key, topic),
-            frame,
-            data_columns=list(_RAW_TELEMETRY_REQUIRED_DTYPES),
+def _read_contents(store: pd.HDFStore) -> pd.DataFrame:
+    """Read `bundle_contents`, or an empty frame of the right shape if the
+    bundle has no tables yet."""
+    if _CONTENTS_KEY not in store:
+        return pd.DataFrame(
+            {
+                "identifier": pd.array([], dtype="object"),
+                "table_name": pd.array([], dtype="object"),
+            }
         )
+    return store.select(_CONTENTS_KEY)
 
 
-@dataclass
-class HDFProcessedTelemetryBundleSectionWriter:
-    """Writes `telemetry/processed/*` to an open store."""
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "telemetry/processed"
-
-    def topic_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/messages"
-
-    def provenance_path(self, sensor_key: str, topic: str) -> str:
-        return f"{self.root_path}/{sensor_key}/{topic}/provenance"
-
-    def append_messages(
-        self, sensor_key: str, topic: str, frame: pd.DataFrame
-    ) -> None:
-        dtypes = _processed_telemetry_dtypes(frame)
-        frame = normalize_dtypes(frame, dtypes)
-        self.store.append(
-            self.topic_path(sensor_key, topic),
-            frame,
-            format="table",
-            data_columns=list(dtypes),
-        )
-
-    def replace_messages(
-        self, sensor_key: str, topic: str, frame: pd.DataFrame
-    ) -> None:
-        dtypes = _processed_telemetry_dtypes(frame)
-        frame = normalize_dtypes(frame, dtypes)
-        put_replacing(
-            self.store,
-            self.topic_path(sensor_key, topic),
-            frame,
-            data_columns=list(dtypes),
-        )
-
-    def write_provenance(
-        self, sensor_key: str, topic: str, value: ProcessedProvenance
-    ) -> None:
-        put_replacing(
-            self.store,
-            self.provenance_path(sensor_key, topic),
-            record_to_frame(value),
-        )
-
-
-@dataclass
-class HDFTelemetryBundleSectionWriter:
-    """Composes the raw and processed telemetry writers."""
-
-    raw: HDFRawTelemetryBundleSectionWriter
-    processed: HDFProcessedTelemetryBundleSectionWriter
-
-
-@dataclass
-class HDFMetoceanBundleSectionWriter:
-    """
-    Writes `metocean/*` to an open store.
-
-    Write-once -- it raises if the target node already exists.
-    """
-
-    store: pd.HDFStore
-
-    @property
-    def root_path(self) -> str:
-        return "metocean"
-
-    def variable_path(self, provider: str, variable: str) -> str:
-        return f"{self.root_path}/{provider}/{variable}"
-
-    def write(self, provider: str, variable: str, frame: pd.DataFrame) -> None:
-        put_once(self.store, self.variable_path(provider, variable), frame)
-
-
-# --- top-level writer ---
+def _append_contents_row(store: pd.HDFStore, key: str, table_name: str) -> None:
+    """Add one `(identifier, table_name)` row to `bundle_contents`,
+    creating the manifest table if this is the bundle's first frame."""
+    contents = _read_contents(store)
+    row = pd.DataFrame({"identifier": [key], "table_name": [table_name]})
+    updated = pd.concat([contents, row], ignore_index=True)
+    if _CONTENTS_KEY in store:
+        store.remove(_CONTENTS_KEY)
+    store.put(_CONTENTS_KEY, updated, format="table")
 
 
 @dataclass
 class HDFDeploymentBundleWriter:
-    """Concrete `DeploymentBundleWriter` backed by a `pandas.HDFStore`
-    opened in write/append mode."""
+    """Concrete `DeploymentBundleWriter` backed by an open `pandas.HDFStore`."""
 
     store: pd.HDFStore
-    deployment: HDFDeploymentBundleSectionWriter
-    platform: HDFPlatformBundleSectionWriter
-    vessel: HDFVesselBundleSectionWriter
-    telemetry: HDFTelemetryBundleSectionWriter
-    metocean: HDFMetoceanBundleSectionWriter
 
-    @property
-    def header_path(self) -> str:
-        return _HEADER_PATH
+    def has_frame(self, key: str) -> bool:
+        if key in _RESERVED_KEYS:
+            return False
+        return key in _read_contents(self.store)["identifier"].values
 
-    def write_header(self, value: DeploymentBundleHeader) -> None:
-        put_once(self.store, self.header_path, record_to_frame(value))
+    def write_frame(
+        self,
+        key: str,
+        frame: pd.DataFrame,
+        *,
+        if_exists: Literal["fail", "replace"] = "fail",
+    ) -> None:
+        if key in _RESERVED_KEYS:
+            raise ValueError(f"{key!r} is reserved and managed automatically")
+
+        exists = self.has_frame(key)
+        if exists and if_exists == "fail":
+            raise ValueError(f"frame already exists at key: {key!r}")
+
+        table_name = key  # HDF: table_name == key verbatim
+        frame = _coerce_storable_dtypes(frame)
+        if exists:
+            self.store.remove(table_name)
+        self.store.put(table_name, frame, format="table")
+
+        if not exists:
+            _append_contents_row(self.store, key, table_name)
 
 
 @contextmanager
@@ -425,82 +110,4 @@ def open_deployment_bundle_writer(
 ) -> Iterator[HDFDeploymentBundleWriter]:
     """Open an HDF5 deployment bundle for writing."""
     with pd.HDFStore(str(path), mode="a") as store:
-        yield HDFDeploymentBundleWriter(
-            store=store,
-            deployment=HDFDeploymentBundleSectionWriter(store),
-            platform=HDFPlatformBundleSectionWriter(store),
-            vessel=HDFVesselBundleSectionWriter(store),
-            telemetry=HDFTelemetryBundleSectionWriter(
-                raw=HDFRawTelemetryBundleSectionWriter(store),
-                processed=HDFProcessedTelemetryBundleSectionWriter(store),
-            ),
-            metocean=HDFMetoceanBundleSectionWriter(store),
-        )
-
-
-# --- private helpers ---
-
-_HEADER_PATH: str = "bundle"
-
-_DATETIME_UTC_DTYPE: pd.DatetimeTZDtype = pd.DatetimeTZDtype(
-    unit="ns", tz="UTC"
-)
-
-_RAW_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
-    "timestamp": str(_DATETIME_UTC_DTYPE),
-    "sensor_key": "category",
-    "message_topic": "category",
-}
-
-_PROCESSED_TELEMETRY_REQUIRED_DTYPES: dict[str, str] = {
-    "timestamp": str(_DATETIME_UTC_DTYPE),
-    "message_topic": "category",
-}
-
-_DEPLOYMENT_FILES_REQUIRED_DTYPES: dict[str, str] = {
-    "role": "category",
-    "path": "object",
-}
-
-
-def _processed_telemetry_dtypes(frame: pd.DataFrame) -> dict[str, str]:
-    """Required processed-telemetry dtypes, including `sensor_key` only
-    when the frame carries that column -- it's required only for a table
-    with one producing sensor."""
-    dtypes = dict(_PROCESSED_TELEMETRY_REQUIRED_DTYPES)
-    if "sensor_key" in frame.columns:
-        dtypes["sensor_key"] = "category"
-    return dtypes
-
-
-def _write_sensor(
-    writer: "HDFPlatformBundleSectionWriter | HDFVesselBundleSectionWriter",
-    sensor: PlatformSensor | VesselSensor,
-) -> None:
-    """Write a sensor's identity/message_topics/extrinsics/calibration
-    nodes, skipping any field that is `None`/empty."""
-    if sensor.identity is not None:
-        put_once(
-            writer.store,
-            writer.sensor_identity_path(sensor.key),
-            record_to_frame(sensor.identity),
-        )
-    if sensor.message_topics:
-        put_once(
-            writer.store,
-            writer.sensor_message_topics_path(sensor.key),
-            message_topics_to_frame(sensor.message_topics),
-        )
-    if sensor.extrinsics is not None:
-        put_once(
-            writer.store,
-            writer.sensor_extrinsics_path(sensor.key),
-            record_to_frame(sensor.extrinsics),
-        )
-    if sensor.calibration is not None:
-        put_once(
-            writer.store,
-            writer.sensor_calibration_path(sensor.key),
-            sensor_calibration_to_frame(sensor.calibration),
-            data_columns=["calibration_type"],
-        )
+        yield HDFDeploymentBundleWriter(store=store)

--- a/src/afft/deployment/bundle_protocols.py
+++ b/src/afft/deployment/bundle_protocols.py
@@ -1,302 +1,56 @@
 """Storage-agnostic read and write interfaces for a deployment bundle."""
 
-from datetime import datetime
-from typing import Protocol
+from typing import Literal, Protocol
 
 import pandas as pd
-
-from .bundle_types import (
-    DeploymentBundleHeader,
-    DeploymentIdentity,
-    DeploymentProvenance,
-    ProcessedProvenance,
-)
-from .common_types import (
-    DeploymentMetadata,
-    PlatformIdentity,
-    PlatformSensor,
-    VesselIdentity,
-    VesselSensor,
-)
-
-
-class TimeWindow(Protocol):
-    """
-    A time range for narrowing a telemetry or metocean read, replacing a
-    PyTables ``where=`` string so the interface never speaks PyTables query
-    syntax.
-
-    Attributes
-    ----------
-    start: Start of the window; unbounded below when ``None``.
-    end: End of the window; unbounded above when ``None``.
-    """
-
-    start: datetime | None
-    end: datetime | None
-
-
-class DeploymentBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``deployment`` section."""
-
-    def identity(self) -> DeploymentIdentity:
-        """Read ``deployment/identity``."""
-        ...
-
-    def metadata(self) -> DeploymentMetadata:
-        """Read ``deployment/metadata``."""
-        ...
-
-    def provenance(self) -> DeploymentProvenance:
-        """Read ``deployment/provenance``."""
-        ...
-
-    def files(self) -> pd.DataFrame:
-        """Read ``deployment/files``."""
-        ...
-
-
-class PlatformBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``platform`` section."""
-
-    def identity(self) -> PlatformIdentity:
-        """Read ``platform/identity``."""
-        ...
-
-    def sensor_keys(self) -> list[str]:
-        """List the platform's sensor keys."""
-        ...
-
-    def sensors(self) -> list[PlatformSensor]:
-        """
-        Read the platform's sensor roster.
-
-        Each returned sensor already carries its identity, message topics,
-        extrinsics, and calibration.
-        """
-        ...
-
-
-class VesselBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``vessel`` section."""
-
-    def identity(self) -> VesselIdentity:
-        """Read ``vessel/identity``."""
-        ...
-
-    def sensor_keys(self) -> list[str]:
-        """List the vessel's sensor keys."""
-        ...
-
-    def sensors(self) -> list[VesselSensor]:
-        """
-        Read the vessel's sensor roster.
-
-        Each returned sensor already carries its identity, message topics,
-        extrinsics, and calibration.
-        """
-        ...
-
-
-class RawTelemetryBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``telemetry/raw`` section."""
-
-    def topics(self) -> list[tuple[str, str]]:
-        """List the ``(sensor_key, message_topic)`` pairs present."""
-        ...
-
-    def sensor_keys(self) -> list[str]:
-        """List the sensor keys with raw telemetry present."""
-        ...
-
-    def read(
-        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        """Read one raw telemetry table, optionally narrowed to a window."""
-        ...
-
-
-class ProcessedTelemetryBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``telemetry/processed`` section."""
-
-    def topics(self) -> list[tuple[str, str]]:
-        """List the ``(sensor_key, message_topic)`` pairs present."""
-        ...
-
-    def sensor_keys(self) -> list[str]:
-        """List the sensor keys with processed telemetry present, including ``"_derived"``."""
-        ...
-
-    def read(
-        self, sensor_key: str, topic: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        """Read one processed telemetry table, optionally narrowed to a window."""
-        ...
-
-    def provenance(self, sensor_key: str, topic: str) -> ProcessedProvenance:
-        """Read the provenance of one processed telemetry table."""
-        ...
-
-
-class TelemetryBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``telemetry`` section."""
-
-    raw: RawTelemetryBundleSectionReader
-    processed: ProcessedTelemetryBundleSectionReader
-
-    def topics(self) -> list[tuple[str, str]]:
-        """List the ``(sensor_key, message_topic)`` pairs present across raw and processed."""
-        ...
-
-
-class MetoceanBundleSectionReader(Protocol):
-    """Read accessor for a bundle's ``metocean`` section."""
-
-    def providers(self) -> list[str]:
-        """List the metocean providers present."""
-        ...
-
-    def variables(self, provider: str) -> list[str]:
-        """List the variables present for one provider."""
-        ...
-
-    def read(
-        self, provider: str, variable: str, *, window: TimeWindow | None = None
-    ) -> pd.DataFrame:
-        """Read one metocean table, optionally narrowed to a window."""
-        ...
 
 
 class DeploymentBundleReader(Protocol):
     """Read interface for a deployment bundle."""
 
-    header: DeploymentBundleHeader
-    deployment: DeploymentBundleSectionReader
-    platform: PlatformBundleSectionReader
-    vessel: VesselBundleSectionReader
-    telemetry: TelemetryBundleSectionReader
-    metocean: MetoceanBundleSectionReader
-
-
-class DeploymentBundleSectionWriter(Protocol):
-    """
-    Write primitives for a bundle's ``deployment`` section.
-
-    Each method is write-once — it raises if the target node already exists.
-    """
-
-    def write_identity(self, value: DeploymentIdentity) -> None:
-        """Write ``deployment/identity``."""
+    def list_frames(self) -> list[str]:
+        """List the keys of every frame the bundle holds."""
         ...
 
-    def write_metadata(self, value: DeploymentMetadata) -> None:
-        """Write ``deployment/metadata``."""
+    def has_frame(self, key: str) -> bool:
+        """Return whether a frame exists at `key`."""
         ...
 
-    def write_files(self, frame: pd.DataFrame) -> None:
-        """Write ``deployment/files``."""
+    def read_frame(self, key: str) -> pd.DataFrame:
+        """
+        Read the frame stored at `key`.
+
+        Raises
+        ------
+        KeyError: If no frame exists at `key`.
+        """
         ...
 
-    def write_provenance(self, value: DeploymentProvenance) -> None:
-        """Write ``deployment/provenance``."""
-        ...
-
-
-class PlatformBundleSectionWriter(Protocol):
-    """
-    Write primitives for a bundle's ``platform`` section.
-
-    Each method is write-once — it raises if the target node already exists.
-    """
-
-    def write_identity(self, value: PlatformIdentity) -> None:
-        """Write ``platform/identity``."""
-        ...
-
-    def write_sensors(self, values: list[PlatformSensor]) -> None:
-        """Write the platform's sensor roster."""
-        ...
-
-
-class VesselBundleSectionWriter(Protocol):
-    """
-    Write primitives for a bundle's ``vessel`` section.
-
-    Each method is write-once — it raises if the target node already exists.
-    """
-
-    def write_identity(self, value: VesselIdentity) -> None:
-        """Write ``vessel/identity``."""
-        ...
-
-    def write_sensors(self, values: list[VesselSensor]) -> None:
-        """Write the vessel's sensor roster."""
-        ...
-
-
-class RawTelemetryBundleSectionWriter(Protocol):
-    """
-    Write primitive for a bundle's ``telemetry/raw`` section.
-
-    Write-once — it raises if the target node already exists.
-    """
-
-    def write(self, sensor_key: str, topic: str, frame: pd.DataFrame) -> None:
-        """Write one raw telemetry table."""
-        ...
-
-
-class ProcessedTelemetryBundleSectionWriter(Protocol):
-    """Write primitives for a bundle's ``telemetry/processed`` section."""
-
-    def append_messages(
-        self, sensor_key: str, topic: str, frame: pd.DataFrame
-    ) -> None:
-        """Append rows to one processed telemetry table."""
-        ...
-
-    def replace_messages(
-        self, sensor_key: str, topic: str, frame: pd.DataFrame
-    ) -> None:
-        """Replace one processed telemetry table."""
-        ...
-
-    def write_provenance(
-        self, sensor_key: str, topic: str, value: ProcessedProvenance
-    ) -> None:
-        """Write the provenance for one processed telemetry table, creating
-        it if absent or overwriting it if present."""
-        ...
-
-
-class TelemetryBundleSectionWriter(Protocol):
-    """Write primitives for a bundle's ``telemetry`` section."""
-
-    raw: RawTelemetryBundleSectionWriter
-    processed: ProcessedTelemetryBundleSectionWriter
-
-
-class MetoceanBundleSectionWriter(Protocol):
-    """
-    Write primitive for a bundle's ``metocean`` section.
-
-    Write-once — it raises if the target node already exists.
-    """
-
-    def write(self, provider: str, variable: str, frame: pd.DataFrame) -> None:
-        """Write one metocean table."""
+    def contents(self) -> pd.DataFrame:
+        """Read the bundle's `bundle_contents` manifest table directly."""
         ...
 
 
 class DeploymentBundleWriter(Protocol):
     """Write interface for a deployment bundle."""
 
-    def write_header(self, value: DeploymentBundleHeader) -> None:
-        """Write the root ``bundle`` table."""
+    def has_frame(self, key: str) -> bool:
+        """Return whether a frame exists at `key`."""
         ...
 
-    deployment: DeploymentBundleSectionWriter
-    platform: PlatformBundleSectionWriter
-    vessel: VesselBundleSectionWriter
-    telemetry: TelemetryBundleSectionWriter
-    metocean: MetoceanBundleSectionWriter
+    def write_frame(
+        self,
+        key: str,
+        frame: pd.DataFrame,
+        *,
+        if_exists: Literal["fail", "replace"] = "fail",
+    ) -> None:
+        """
+        Write `frame` to the bundle at `key`, creating or updating its
+        `bundle_contents` entry.
+
+        Raises if `key` already exists and `if_exists="fail"` (the
+        default). With `if_exists="replace"`, any existing frame at `key`
+        is overwritten.
+        """
+        ...

--- a/tests/test_deployment_bundle_hdf_io.py
+++ b/tests/test_deployment_bundle_hdf_io.py
@@ -1,6 +1,6 @@
 """Round-trip tests for the pandas.HDFStore deployment bundle implementation."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -8,348 +8,149 @@ import pytest
 
 from afft.deployment.bundle_hdf_readers import open_deployment_bundle_reader
 from afft.deployment.bundle_hdf_writers import open_deployment_bundle_writer
-from afft.deployment.bundle_types import (
-    DeploymentBundleHeader,
-    DeploymentIdentity,
-    DeploymentProvenance,
-    ProcessedProvenance,
-)
-from afft.deployment.common_types import (
-    DeploymentMetadata,
-    PlatformIdentity,
-    PlatformSensor,
-    SensorCalibration,
-    SensorExtrinsics,
-    SensorIdentity,
-    VesselIdentity,
-    VesselSensor,
-)
 
 
-def _header() -> DeploymentBundleHeader:
-    return DeploymentBundleHeader(
-        schema_version="1.0",
-        created_datetime=datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc),
-        builder_version="0.1.0",
-    )
-
-
-def test_write_header_and_deployment_section(tmp_path: Path) -> None:
-    """Round-trips the bundle header and the deployment section's records."""
-    path = tmp_path / "bundle.h5"
-    identity = DeploymentIdentity(
-        deployment_label="qc2hyd_20231021T032349Z",
-        deployment_datetime=datetime(
-            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
-        ),
-    )
-    metadata = DeploymentMetadata(
-        acfr_deployment_label="r20231021_032349_qc2hyd",
-        acfr_campaign_label="r20231021_qc2hyd",
-        acfr_platform_label="sirius",
-        origin_latitude=-33.5,
-        origin_longitude=151.3,
-        magnetic_variation=12.4,
-    )
-    provenance = DeploymentProvenance(deployment_key="qc2hyd_20231021T032349Z")
-    files = pd.DataFrame(
-        {"role": ["stereo_pose"], "path": ["stereo_pose_est.data"]}
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.deployment.write_identity(identity)
-        writer.deployment.write_metadata(metadata)
-        writer.deployment.write_provenance(provenance)
-        writer.deployment.write_files(files)
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert reader.header == _header()
-        assert reader.deployment.identity() == identity
-        assert reader.deployment.metadata() == metadata
-        assert reader.deployment.provenance() == provenance
-        assert reader.deployment.files()["role"].tolist() == ["stereo_pose"]
-
-
-def test_write_once_raises_on_second_write(tmp_path: Path) -> None:
-    """A write-once method raises if the target node already exists."""
-    path = tmp_path / "bundle.h5"
-    identity = DeploymentIdentity(
-        deployment_label="qc2hyd_20231021T032349Z",
-        deployment_datetime=datetime(
-            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
-        ),
-    )
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.deployment.write_identity(identity)
-        with pytest.raises(ValueError):
-            writer.deployment.write_identity(identity)
-
-
-def test_platform_sensor_roster_round_trip(tmp_path: Path) -> None:
-    """
-    Round-trips a platform sensor roster, including a sensor with no
-    extrinsics/calibration and one with an empty message_topics list.
-    """
-    path = tmp_path / "bundle.h5"
-    dvl = PlatformSensor(
-        key="dvl_teledyne_navigator",
-        message_topics=["RDI"],
-        identity=SensorIdentity(
-            label="DVL", vendor="Teledyne RDI", product="Navigator", type="dvl"
-        ),
-        extrinsics=SensorExtrinsics(
-            locx=0.1, locy=0.0, locz=0.2, rotx=0.0, roty=0.0, rotz=0.0
-        ),
-        calibration=None,
-    )
-    camera = PlatformSensor(
-        key="vis_camera",
-        message_topics=[],
-        identity=SensorIdentity(
-            label="VIS camera", vendor="", product="", type="camera"
-        ),
-        extrinsics=None,
-        calibration=SensorCalibration(
-            calibration_type="pinhole",
-            parameters={"fx": 1043.2, "fy": 1043.2, "cx": 512.0, "cy": 384.0},
-        ),
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.platform.write_identity(
-            PlatformIdentity(
-                platform_label="AUV Sirius",
-                platform_class="SEABED",
-                platform_operator="ACFR",
-            )
-        )
-        writer.platform.write_sensors([dvl, camera])
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert reader.platform.sensor_keys() == [
-            "dvl_teledyne_navigator",
-            "vis_camera",
-        ]
-        sensors = {sensor.key: sensor for sensor in reader.platform.sensors()}
-
-        assert sensors["dvl_teledyne_navigator"] == dvl
-        assert sensors["vis_camera"] == camera
-        # message_topics=[] is not written as a node; reads back as [].
-        assert not reader.contains("platform/sensors/vis_camera/message_topics")
-        # extrinsics=None is not written; reads back as None.
-        assert not reader.contains("platform/sensors/vis_camera/extrinsics")
-
-
-def test_vessel_sensor_roster_round_trip(tmp_path: Path) -> None:
-    """Round-trips a vessel sensor roster, mirroring the platform section."""
-    path = tmp_path / "bundle.h5"
-    usbl = VesselSensor(
-        key="usbl_linkquest_transceiver",
-        message_topics=[],
-        identity=SensorIdentity(
-            label="USBL", vendor="LinkQuest", product="TrackLink", type="usbl"
-        ),
-        extrinsics=SensorExtrinsics(
-            locx=0.0, locy=0.0, locz=-1.0, rotx=0.0, roty=0.0, rotz=0.0
-        ),
-        calibration=None,
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.vessel.write_identity(VesselIdentity(vessel_name="RV Linnaeus"))
-        writer.vessel.write_sensors([usbl])
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert reader.vessel.identity() == VesselIdentity(
-            vessel_name="RV Linnaeus"
-        )
-        assert reader.vessel.sensor_keys() == ["usbl_linkquest_transceiver"]
-        assert reader.vessel.sensors() == [usbl]
-
-
-def test_raw_telemetry_round_trip_and_window(tmp_path: Path) -> None:
-    """Round-trips a raw telemetry table and narrows a read with a window."""
-    path = tmp_path / "bundle.h5"
-    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
-    timestamps = [start + timedelta(seconds=index) for index in range(5)]
-    frame = pd.DataFrame(
-        {
-            "timestamp": timestamps,
-            "sensor_key": ["dvl_teledyne_navigator"] * 5,
-            "message_topic": ["RDI"] * 5,
-            "value": [1.0, 2.0, 3.0, 4.0, 5.0],
-        }
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.telemetry.raw.write("dvl_teledyne_navigator", "RDI", frame)
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert reader.telemetry.raw.topics() == [
-            ("dvl_teledyne_navigator", "RDI")
-        ]
-        assert reader.telemetry.raw.sensor_keys() == ["dvl_teledyne_navigator"]
-
-        full = reader.telemetry.raw.read("dvl_teledyne_navigator", "RDI")
-        assert len(full) == 5
-
-        class _Window:
-            start: datetime | None = timestamps[1]
-            end: datetime | None = timestamps[3]
-
-        windowed = reader.telemetry.raw.read(
-            "dvl_teledyne_navigator", "RDI", window=_Window()
-        )
-        assert windowed["value"].tolist() == [2.0, 3.0, 4.0]
-
-
-def test_processed_telemetry_append_replace_and_provenance(
-    tmp_path: Path,
-) -> None:
-    """Appends processed telemetry in two chunks, then replaces it, with
-    provenance written independently of the message writes."""
-    path = tmp_path / "bundle.h5"
-    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
-    first_chunk = pd.DataFrame(
-        {
-            "timestamp": [start, start + timedelta(seconds=1)],
-            "message_topic": ["RDI", "RDI"],
-            "value": [1.0, 2.0],
-        }
-    )
-    second_chunk = pd.DataFrame(
-        {
-            "timestamp": [start + timedelta(seconds=2)],
-            "message_topic": ["RDI"],
-            "value": [3.0],
-        }
-    )
-    replacement = pd.DataFrame(
-        {
-            "timestamp": [start],
-            "message_topic": ["RDI"],
-            "value": [99.0],
-        }
-    )
-    provenance = ProcessedProvenance(
-        run_datetime=datetime(2026, 8, 5, 12, 0, 0, tzinfo=timezone.utc)
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.telemetry.processed.append_messages(
-            "dvl_teledyne_navigator", "RDI", first_chunk
-        )
-        writer.telemetry.processed.append_messages(
-            "dvl_teledyne_navigator", "RDI", second_chunk
-        )
-        writer.telemetry.processed.write_provenance(
-            "dvl_teledyne_navigator", "RDI", provenance
-        )
-
-    with open_deployment_bundle_reader(path) as reader:
-        appended = reader.telemetry.processed.read(
-            "dvl_teledyne_navigator", "RDI"
-        )
-        assert appended["value"].tolist() == [1.0, 2.0, 3.0]
-        assert (
-            reader.telemetry.processed.provenance(
-                "dvl_teledyne_navigator", "RDI"
-            )
-            == provenance
-        )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.telemetry.processed.replace_messages(
-            "dvl_teledyne_navigator", "RDI", replacement
-        )
-
-    with open_deployment_bundle_reader(path) as reader:
-        replaced = reader.telemetry.processed.read(
-            "dvl_teledyne_navigator", "RDI"
-        )
-        assert replaced["value"].tolist() == [99.0]
-        # provenance is untouched by replace_messages
-        assert (
-            reader.telemetry.processed.provenance(
-                "dvl_teledyne_navigator", "RDI"
-            )
-            == provenance
-        )
-
-
-def test_telemetry_section_topics_union(tmp_path: Path) -> None:
-    """`telemetry.topics()` unions the raw and processed topic sets."""
-    path = tmp_path / "bundle.h5"
-    start = datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)
-    raw_frame = pd.DataFrame(
-        {
-            "timestamp": [start],
-            "sensor_key": ["dvl_teledyne_navigator"],
-            "message_topic": ["RDI"],
-        }
-    )
-    processed_frame = pd.DataFrame(
-        {"timestamp": [start], "message_topic": ["DEPTH"]}
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.telemetry.raw.write("dvl_teledyne_navigator", "RDI", raw_frame)
-        writer.telemetry.processed.append_messages(
-            "_derived", "DEPTH", processed_frame
-        )
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert reader.telemetry.topics() == [
-            ("_derived", "DEPTH"),
-            ("dvl_teledyne_navigator", "RDI"),
-        ]
-
-
-def test_metocean_round_trip_and_enumeration(tmp_path: Path) -> None:
-    """Round-trips a metocean table and enumerates providers/variables."""
-    path = tmp_path / "bundle.h5"
-    frame = pd.DataFrame(
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame(
         {
             "timestamp": [datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)],
-            "sea_level": [0.42],
+            "value": [1.0],
+        }
+    )
+
+
+def test_write_and_read_frame_round_trip(tmp_path: Path) -> None:
+    """A written frame reads back with the same contents."""
+    path = tmp_path / "bundle.h5"
+    frame = _frame()
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("telemetry/raw/dvl_teledyne_navigator/RDI", frame)
+
+    with open_deployment_bundle_reader(path) as reader:
+        read_back = reader.read_frame(
+            "telemetry/raw/dvl_teledyne_navigator/RDI"
+        )
+        assert read_back["value"].tolist() == [1.0]
+
+
+def test_has_frame_and_list_frames(tmp_path: Path) -> None:
+    """`has_frame` and `list_frames` reflect what has been written."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        assert not writer.has_frame("bundle")
+        writer.write_frame("bundle", _frame())
+        writer.write_frame("deployment/identity", _frame())
+        assert writer.has_frame("bundle")
+        assert writer.has_frame("deployment/identity")
+        assert not writer.has_frame("deployment/metadata")
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.has_frame("bundle")
+        assert not reader.has_frame("deployment/metadata")
+        assert reader.list_frames() == ["bundle", "deployment/identity"]
+
+
+def test_write_frame_fails_on_existing_key_by_default(tmp_path: Path) -> None:
+    """`write_frame` raises if `key` already exists and `if_exists="fail"`."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", _frame())
+        with pytest.raises(ValueError):
+            writer.write_frame("bundle", _frame())
+
+
+def test_write_frame_replace_overwrites_existing_key(tmp_path: Path) -> None:
+    """`write_frame(..., if_exists="replace")` overwrites an existing frame."""
+    path = tmp_path / "bundle.h5"
+    replacement = pd.DataFrame(
+        {"timestamp": [_frame()["timestamp"][0]], "value": [2.0]}
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", _frame())
+        writer.write_frame("bundle", replacement, if_exists="replace")
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.read_frame("bundle")["value"].tolist() == [2.0]
+        assert reader.list_frames() == ["bundle"]
+
+
+def test_read_frame_raises_key_error_for_unknown_key(tmp_path: Path) -> None:
+    """Reading a key that was never written raises `KeyError`."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", _frame())
+
+    with open_deployment_bundle_reader(path) as reader:
+        with pytest.raises(KeyError):
+            reader.read_frame("deployment/identity")
+
+
+def test_bundle_contents_is_reserved(tmp_path: Path) -> None:
+    """`bundle_contents` cannot be read, written, or reported present through
+    the ordinary frame methods -- only `contents()` exposes it."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", _frame())
+        assert not writer.has_frame("bundle_contents")
+        with pytest.raises(ValueError):
+            writer.write_frame("bundle_contents", _frame())
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert not reader.has_frame("bundle_contents")
+        assert "bundle_contents" not in reader.list_frames()
+        with pytest.raises(KeyError):
+            reader.read_frame("bundle_contents")
+
+
+def test_contents_manifest_tracks_identifier_and_table_name(
+    tmp_path: Path,
+) -> None:
+    """`contents()` lists one row per written frame, with `identifier` and
+    `table_name` equal for the HDF backend."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", _frame())
+        writer.write_frame("deployment/identity", _frame())
+
+    with open_deployment_bundle_reader(path) as reader:
+        contents = reader.contents()
+        assert contents["identifier"].tolist() == [
+            "bundle",
+            "deployment/identity",
+        ]
+        assert contents["table_name"].tolist() == [
+            "bundle",
+            "deployment/identity",
+        ]
+
+
+def test_write_frame_coerces_extension_dtypes(tmp_path: Path) -> None:
+    """Pandas nullable extension dtypes are coerced to plain-numpy dtypes
+    before the underlying `HDFStore.put`, since `format="table"` can't
+    store them directly."""
+    path = tmp_path / "bundle.h5"
+    frame = pd.DataFrame(
+        {
+            "count": pd.array([1, 2, 3], dtype="Int64"),
+            "measurement": pd.array([1.5, 2.5, 3.5], dtype="Float64"),
+            "flag": pd.array([True, False, True], dtype="boolean"),
+            "label": pd.array(["a", "b", "c"], dtype="string"),
         }
     )
 
     with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.metocean.write("worldtides", "sea_level", frame)
+        writer.write_frame("telemetry/raw/example/TOPIC", frame)
 
     with open_deployment_bundle_reader(path) as reader:
-        assert reader.metocean.providers() == ["worldtides"]
-        assert reader.metocean.variables("worldtides") == ["sea_level"]
-        read_back = reader.metocean.read("worldtides", "sea_level")
-        assert read_back["sea_level"].tolist() == [0.42]
-
-
-def test_escape_hatch(tmp_path: Path) -> None:
-    """`keys`/`contains`/`row_count`/`read_table` expose the raw store."""
-    path = tmp_path / "bundle.h5"
-    identity = DeploymentIdentity(
-        deployment_label="qc2hyd_20231021T032349Z",
-        deployment_datetime=datetime(
-            2023, 10, 21, 3, 23, 49, tzinfo=timezone.utc
-        ),
-    )
-
-    with open_deployment_bundle_writer(path) as writer:
-        writer.write_header(_header())
-        writer.deployment.write_identity(identity)
-
-    with open_deployment_bundle_reader(path) as reader:
-        assert "/deployment/identity" in reader.keys()
-        assert reader.contains("deployment/identity")
-        assert not reader.contains("deployment/metadata")
-        assert reader.row_count("deployment/identity") == 1
-        assert len(reader.read_table("deployment/identity")) == 1
+        read_back = reader.read_frame("telemetry/raw/example/TOPIC")
+        assert read_back["count"].tolist() == [1, 2, 3]
+        assert read_back["measurement"].tolist() == [1.5, 2.5, 3.5]
+        assert read_back["flag"].tolist() == [True, False, True]
+        assert read_back["label"].tolist() == ["a", "b", "c"]


### PR DESCRIPTION
## Summary
- Replace the fixed, typed-section `DeploymentBundleReader`/`DeploymentBundleWriter` Protocols with a generic keyed-frame interface: `list_frames`/`has_frame`/`read_frame`/`contents` on the reader, `has_frame`/`write_frame` (with `if_exists="fail"|"replace"`) on the writer.
- Rewrite the HDF backend around a `bundle_contents` manifest table (modeled on GeoPackage's `gpkg_contents`) that the writer maintains automatically; `bundle_contents` itself is a reserved key.
- Add a universal `_coerce_storable_dtypes` pass in the writer for pandas nullable extension dtypes (`Int64`, `Float64`, `boolean`, `string`), leaving `category`/tz-aware datetime columns untouched.
- Add a `.h5`-only suffix check in `bundle_factories.py`'s reader/writer entry points.
- Rewrite `tests/test_deployment_bundle_hdf_io.py` against the new interface.

`src/afft/tasks/build_deployment_bundle/builders.py` still targets the old typed-section API and is intentionally left broken here — its rewrite is #226, landing directly after this PR. That cascades into collection errors for `test_build_deployment_bundle.py` and several unrelated test modules that import `afft.cli.entrypoint` (whose import chain reaches the builder); everything else passes, and lint/format/mypy are clean on all changed files.

## Test plan
- [x] `ruff format`/`ruff check` clean on changed files
- [x] `mypy` (strict) clean on changed files
- [x] `pytest tests/test_deployment_bundle_hdf_io.py` — 8/8 passing
- [x] Full suite passes except the builder-dependent modules noted above, expected to be fixed by #226

Closes #225