### PR TITLE
Convert sensor config and log entry types to pydantic models

### DIFF
--- a/src/afft/sensors/acfr_vision/types.py
+++ b/src/afft/sensors/acfr_vision/types.py
@@ -1,10 +1,11 @@
 """Configuration types for ACFR stereo camera processing."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
 
 
-@dataclass(slots=True, frozen=True)
-class PairStereoImagesConfig:
+class PairStereoImagesConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     left_suffix: str = "LC16"
     right_suffix: str = "RM16"
     label_col: str = "label"

--- a/src/afft/sensors/dvl_teledyne/types.py
+++ b/src/afft/sensors/dvl_teledyne/types.py
@@ -1,10 +1,11 @@
 """Configuration types for Teledyne DVL processing."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
 
 
-@dataclass(slots=True, frozen=True)
-class DvlUncertaintyConfig:
+class DvlUncertaintyConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     # Per-axis velocity uncertainty (m/s). RDI spec: 0.3 cm/s at 1 m/s.
     velocity_x_uncertainty: float = 0.003
     velocity_y_uncertainty: float = 0.003

--- a/src/afft/sensors/pressure_parosci/types.py
+++ b/src/afft/sensors/pressure_parosci/types.py
@@ -1,10 +1,11 @@
 """Configuration types for Paroscientific pressure sensor processing."""
 
-from dataclasses import dataclass
+from pydantic import BaseModel, ConfigDict
 
 
-@dataclass(slots=True, frozen=True)
-class PressureUncertaintyConfig:
+class PressureUncertaintyConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     base_uncertainty: float = 0.005
     depth_scale: float = 0.0
     depth_col: str = "depth"

--- a/src/afft/sensors/usbl_evologics/types.py
+++ b/src/afft/sensors/usbl_evologics/types.py
@@ -2,17 +2,15 @@
 
 import numpy as np
 
-from dataclasses import dataclass
-
 from numpy.typing import NDArray
+from pydantic import BaseModel, ConfigDict
 from scipy.spatial.transform import (
     RigidTransform,
     Rotation,
 )
 
 
-@dataclass(slots=True, frozen=True)
-class EvologicsTransceiverExtrinsics:
+class EvologicsTransceiverExtrinsics(BaseModel):
     """
     Rigid-body extrinsics of the Evologics USBL transceiver in the ship body frame.
 
@@ -29,6 +27,8 @@ class EvologicsTransceiverExtrinsics:
     roty: Pitch in radians (positive: bow up).
     rotz: Yaw in radians (positive clockwise viewed from above).
     """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     locx: float = 0.0
     locy: float = 0.0
@@ -55,8 +55,7 @@ class EvologicsTransceiverExtrinsics:
         )
 
 
-@dataclass(slots=True, frozen=True)
-class EvologicsProcessingConfig:
+class EvologicsProcessingConfig(BaseModel):
     """
     Configuration for the Evologics USBL processing pipeline.
 
@@ -67,6 +66,8 @@ class EvologicsProcessingConfig:
     horizontal_position_std: 1σ horizontal position uncertainty in metres.
     depth_position_std: 1σ depth uncertainty in metres.
     """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     extrinsics: EvologicsTransceiverExtrinsics | None = None
     horizontal_position_std: float = 15.8

--- a/src/afft/sensors/usbl_linkquest/__init__.py
+++ b/src/afft/sensors/usbl_linkquest/__init__.py
@@ -11,8 +11,8 @@ from .processors import (
 )
 
 from .types import (
-    TrackLinkFixEntry as TrackLinkFixEntry,
-    TrackLinkRawEntry as TrackLinkRawEntry,
+    TrackLinkFixLogEntry as TrackLinkFixLogEntry,
+    TrackLinkRawLogEntry as TrackLinkRawLogEntry,
     TrackLinkProcessingFromLogsConfig as TrackLinkProcessingFromLogsConfig,
     TrackLinkProcessingFromMessagesConfig as TrackLinkProcessingFromMessagesConfig,
     TrackLinkResolvePositionFromLogsConfig as TrackLinkResolvePositionFromLogsConfig,

--- a/src/afft/sensors/usbl_linkquest/parsers.py
+++ b/src/afft/sensors/usbl_linkquest/parsers.py
@@ -1,6 +1,5 @@
 """Parser for the LinkQuest TrackLink USBL raw log format."""
 
-import dataclasses
 import re
 
 from datetime import datetime, timezone
@@ -10,7 +9,7 @@ import pandas as pd
 
 from afft.utils.log import logger
 
-from .types import TrackLinkFixEntry, TrackLinkRawEntry
+from .types import TrackLinkFixLogEntry, TrackLinkRawLogEntry
 
 
 _FIX_RE: re.Pattern[str] = re.compile(
@@ -43,19 +42,19 @@ def parse_fix_entries(path: Path) -> pd.DataFrame:
     ship_heading, ship_roll, ship_pitch, target_bearing_angle,
     target_slant_range.
     """
-    entries: list[TrackLinkFixEntry] = []
+    entries: list[TrackLinkFixLogEntry] = []
 
     with open(path) as file:
         for line in file:
             if not line.startswith("USBL_FIX:"):
                 continue
-            entry: TrackLinkFixEntry | None = _parse_fix_line(line)
+            entry: TrackLinkFixLogEntry | None = _parse_fix_line(line)
             if entry is None:
                 continue
             entries.append(entry)
 
     dataframe: pd.DataFrame = pd.DataFrame(
-        [dataclasses.asdict(entry) for entry in entries]
+        [entry.model_dump() for entry in entries]
     )
     if not dataframe.empty:
         dataframe["timestamp"] = dataframe["unix_timestamp"].apply(_unix_to_iso)
@@ -74,18 +73,18 @@ def parse_raw_entries(path: Path) -> pd.DataFrame:
     DataFrame with columns: unix_timestamp, flag1, flag2, target_x,
     target_y, target_z.
     """
-    entries: list[TrackLinkRawEntry] = []
+    entries: list[TrackLinkRawLogEntry] = []
 
     with open(path) as file:
         for line in file:
             if not line.startswith("USBL_RAW:"):
                 continue
-            entry: TrackLinkRawEntry | None = _parse_raw_line(line)
+            entry: TrackLinkRawLogEntry | None = _parse_raw_line(line)
             if entry is None:
                 continue
             entries.append(entry)
 
-    return pd.DataFrame([dataclasses.asdict(entry) for entry in entries])
+    return pd.DataFrame([entry.model_dump() for entry in entries])
 
 
 def parse_novatel_entries(path: Path) -> pd.DataFrame:
@@ -216,12 +215,12 @@ def parse_tracklink_log(path: Path) -> pd.DataFrame:
     )
 
 
-def _parse_fix_line(line: str) -> TrackLinkFixEntry | None:
-    """Parse a single USBL_FIX line into a TrackLinkFixEntry."""
+def _parse_fix_line(line: str) -> TrackLinkFixLogEntry | None:
+    """Parse a single USBL_FIX line into a TrackLinkFixLogEntry."""
     match: re.Match[str] | None = _FIX_RE.match(line)
     if match is None:
         return None
-    return TrackLinkFixEntry(
+    return TrackLinkFixLogEntry(
         unix_timestamp=float(match["timestamp"]),
         ship_latitude=float(match["ship_latitude"]),
         ship_longitude=float(match["ship_longitude"]),
@@ -233,13 +232,13 @@ def _parse_fix_line(line: str) -> TrackLinkFixEntry | None:
     )
 
 
-def _parse_raw_line(line: str) -> TrackLinkRawEntry | None:
-    """Parse a single USBL_RAW line into a TrackLinkRawEntry."""
+def _parse_raw_line(line: str) -> TrackLinkRawLogEntry | None:
+    """Parse a single USBL_RAW line into a TrackLinkRawLogEntry."""
     match: re.Match[str] | None = _RAW_RE.match(line)
     if match is None:
         return None
     flag1_str: str | None = match["flag1"]
-    return TrackLinkRawEntry(
+    return TrackLinkRawLogEntry(
         unix_timestamp=float(match["timestamp"]),
         flag1=int(flag1_str) if flag1_str is not None else None,
         flag2=int(match["flag2"]),

--- a/src/afft/sensors/usbl_linkquest/types.py
+++ b/src/afft/sensors/usbl_linkquest/types.py
@@ -2,17 +2,15 @@
 
 import numpy as np
 
-from dataclasses import dataclass, field
-
 from numpy.typing import NDArray
+from pydantic import BaseModel, ConfigDict
 from scipy.spatial.transform import (
     RigidTransform,
     Rotation,
 )
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkFixEntry:
+class TrackLinkFixLogEntry(BaseModel):
     """
     Parsed USBL_FIX entry from a TrackLink log file.
 
@@ -29,6 +27,8 @@ class TrackLinkFixEntry:
     target_slant_range: Slant range to target in metres.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     unix_timestamp: float
     ship_latitude: float
     ship_longitude: float
@@ -39,8 +39,7 @@ class TrackLinkFixEntry:
     target_slant_range: float
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkRawEntry:
+class TrackLinkRawLogEntry(BaseModel):
     """
     Parsed USBL_RAW entry from a TrackLink log file.
 
@@ -59,6 +58,8 @@ class TrackLinkRawEntry:
     target_z: Target offset in metres along the down direction (positive down).
     """
 
+    model_config = ConfigDict(frozen=True)
+
     unix_timestamp: float
     flag1: int | None
     flag2: int
@@ -67,8 +68,7 @@ class TrackLinkRawEntry:
     target_z: float
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkTransceiverExtrinsics:
+class TrackLinkTransceiverExtrinsics(BaseModel):
     """
     Rigid-body extrinsics of the USBL transceiver in the ship body frame.
 
@@ -85,6 +85,8 @@ class TrackLinkTransceiverExtrinsics:
     roty: Pitch in radians (positive: bow up).
     rotz: Yaw in radians (positive clockwise viewed from above).
     """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     locx: float = 0.0
     locy: float = 0.0
@@ -111,8 +113,7 @@ class TrackLinkTransceiverExtrinsics:
         )
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkResolvePositionFromMessagesConfig:
+class TrackLinkResolvePositionFromMessagesConfig(BaseModel):
     """
     Configuration for the USBL position resolution step from AUV messages.
 
@@ -139,6 +140,8 @@ class TrackLinkResolvePositionFromMessagesConfig:
         to zero offset and zero rotation when not provided.
     """
 
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     timestamp_col: str = "timestamp"
     bearing_col: str = "target_bearing_angle"
     range_col: str = "target_slant_range"
@@ -152,8 +155,7 @@ class TrackLinkResolvePositionFromMessagesConfig:
     extrinsics: TrackLinkTransceiverExtrinsics | None = None
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkResolvePositionFromLogsConfig:
+class TrackLinkResolvePositionFromLogsConfig(BaseModel):
     """
     Configuration for the USBL position resolution step from log entries.
 
@@ -179,6 +181,8 @@ class TrackLinkResolvePositionFromLogsConfig:
         to zero offset and zero rotation when not provided.
     """
 
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     timestamp_col: str = "timestamp"
     target_x_col: str = "target_x"
     target_y_col: str = "target_y"
@@ -193,8 +197,7 @@ class TrackLinkResolvePositionFromLogsConfig:
     extrinsics: TrackLinkTransceiverExtrinsics | None = None
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkUncertaintyConfig:
+class TrackLinkUncertaintyConfig(BaseModel):
     """
     Deployment-calibrated uncertainty values for TrackLink USBL processing.
 
@@ -204,12 +207,13 @@ class TrackLinkUncertaintyConfig:
     depth_position_std: 1σ depth uncertainty in metres.
     """
 
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
     horizontal_position_std: float = 15.8
     depth_position_std: float = 5.0
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkProcessingFromMessagesConfig:
+class TrackLinkProcessingFromMessagesConfig(BaseModel):
     """
     Combined configuration for the TrackLink USBL processing pipeline from AUV messages.
 
@@ -219,16 +223,15 @@ class TrackLinkProcessingFromMessagesConfig:
     uncertainty: Configuration for uncertainty estimation.
     """
 
-    resolve: TrackLinkResolvePositionFromMessagesConfig = field(
-        default_factory=TrackLinkResolvePositionFromMessagesConfig
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    resolve: TrackLinkResolvePositionFromMessagesConfig = (
+        TrackLinkResolvePositionFromMessagesConfig()
     )
-    uncertainty: TrackLinkUncertaintyConfig = field(
-        default_factory=TrackLinkUncertaintyConfig
-    )
+    uncertainty: TrackLinkUncertaintyConfig = TrackLinkUncertaintyConfig()
 
 
-@dataclass(slots=True, frozen=True)
-class TrackLinkProcessingFromLogsConfig:
+class TrackLinkProcessingFromLogsConfig(BaseModel):
     """
     Combined configuration for the TrackLink USBL processing pipeline from log entries.
 
@@ -238,9 +241,9 @@ class TrackLinkProcessingFromLogsConfig:
     uncertainty: Configuration for uncertainty estimation.
     """
 
-    resolve: TrackLinkResolvePositionFromLogsConfig = field(
-        default_factory=TrackLinkResolvePositionFromLogsConfig
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    resolve: TrackLinkResolvePositionFromLogsConfig = (
+        TrackLinkResolvePositionFromLogsConfig()
     )
-    uncertainty: TrackLinkUncertaintyConfig = field(
-        default_factory=TrackLinkUncertaintyConfig
-    )
+    uncertainty: TrackLinkUncertaintyConfig = TrackLinkUncertaintyConfig()


### PR DESCRIPTION
## Summary

Converts the configuration types in `afft.sensors` from frozen dataclasses to `pydantic.BaseModel`, aligning them with the convention already used across `afft.deployment`, `afft.seabed` and several `afft.tasks` packages.

- Configuration and extrinsics types use `ConfigDict(frozen=True, extra="forbid")`. The `extra="forbid"` is a deliberate departure from the existing models: these configs are populated from a user-edited TOML file, so a mistyped key must fail at construction rather than being silently dropped.
- Nested configs (`TrackLinkProcessingFrom*Config`) now build their sub-models from plain nested dicts, which dataclasses could not do. This removes the caveat recorded in #201 and #229. `field(default_factory=...)` is replaced by bare model defaults.
- Renames `TrackLinkFixEntry` → `TrackLinkFixLogEntry` and `TrackLinkRawEntry` → `TrackLinkRawLogEntry`, since both represent entries parsed from the TrackLink USBL log files. They are not populated from user config, so they keep pydantic's default `extra` behaviour.
- Replaces `dataclasses.asdict` with `model_dump()` in the TrackLink parsers and drops the now-unused `import dataclasses`. `model_dump()` preserves field declaration order, so the resulting DataFrame column order is unchanged.

### Verification

- `ruff format` and `ruff check` pass.
- `pytest` — 158 passed.
- Nested construction, `extra="forbid"` rejection, int-to-float coercion and `model_dump()` column order were each checked directly against the converted types.

### Pre-existing failures, not from this branch

`tasks/build_deployment_bundle/builders.py` imports four names that `afft.deployment` no longer exports. This produces 9 mypy errors and blocks collection of seven test files. Both are identical on `dev` with this branch stashed, so they are unrelated to this change and are left untouched.

Closes #230