### PR TITLE
Add read-write deployment bundle interface and implementation

### DIFF
--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -21,10 +21,12 @@ from .bundle_types import (
     ProcessedProvenance as ProcessedProvenance,
 )
 from .bundle_protocols import (
+    DeploymentBundleIO as DeploymentBundleIO,
     DeploymentBundleReader as DeploymentBundleReader,
     DeploymentBundleWriter as DeploymentBundleWriter,
 )
 from .bundle_factories import (
+    open_deployment_bundle as open_deployment_bundle,
     open_deployment_bundle_reader as open_deployment_bundle_reader,
     open_deployment_bundle_writer as open_deployment_bundle_writer,
 )

--- a/src/afft/deployment/bundle_factories.py
+++ b/src/afft/deployment/bundle_factories.py
@@ -6,13 +6,50 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
 
+from .bundle_hdf_io import (
+    open_deployment_bundle as _open_hdf_io,
+)
 from .bundle_hdf_readers import (
     open_deployment_bundle_reader as _open_hdf_reader,
 )
 from .bundle_hdf_writers import (
     open_deployment_bundle_writer as _open_hdf_writer,
 )
-from .bundle_protocols import DeploymentBundleReader, DeploymentBundleWriter
+from .bundle_protocols import (
+    DeploymentBundleIO,
+    DeploymentBundleReader,
+    DeploymentBundleWriter,
+)
+
+
+@contextmanager
+def open_deployment_bundle(
+    path: Path,
+) -> Iterator[DeploymentBundleIO]:
+    """
+    Open a deployment bundle for reading and writing.
+
+    Arguments
+    ---------
+    path: Path to the deployment bundle file.
+
+    Returns
+    -------
+    A context manager yielding a ``DeploymentBundleIO``.
+
+    Raises
+    ------
+    NotImplementedError: If `path`'s suffix is not a supported bundle file
+        format.
+    """
+    match path.suffix:
+        case ".h5":
+            with _open_hdf_io(path) as bundle:
+                yield cast(DeploymentBundleIO, bundle)
+        case suffix:
+            raise NotImplementedError(
+                f"unsupported bundle file suffix {suffix!r}: {path}"
+            )
 
 
 @contextmanager

--- a/src/afft/deployment/bundle_hdf_common.py
+++ b/src/afft/deployment/bundle_hdf_common.py
@@ -1,0 +1,79 @@
+"""Helpers shared by the `pandas.HDFStore` deployment bundle reader, writer,
+and read-write implementations."""
+
+import pandas as pd
+
+CONTENTS_KEY: str = "bundle_contents"
+RESERVED_KEYS: frozenset[str] = frozenset({CONTENTS_KEY})
+
+
+def coerce_storable_dtypes(frame: pd.DataFrame) -> pd.DataFrame:
+    """
+    Cast pandas extension dtypes (``Int64``, ``Float64``, ``boolean``,
+    ``string``) to their plain-numpy equivalents, the dtype set
+    `HDFStore.put(..., format="table")` can store.
+
+    Category and timezone-aware datetime columns are left untouched --
+    those are exactly the extension dtypes PyTables supports natively.
+    Column-specific choices (which columns should be `category` or a
+    UTC timestamp) are the caller's responsibility, made before this is
+    called.
+
+    Arguments
+    ---------
+    frame: Frame to coerce; not mutated.
+
+    Returns
+    -------
+    A copy of `frame` with any nullable numeric/boolean/string columns
+    cast to plain numpy dtypes.
+    """
+    frame = frame.copy()
+    for column in frame.columns:
+        dtype = frame[column].dtype
+        if isinstance(dtype, (pd.CategoricalDtype, pd.DatetimeTZDtype)):
+            continue
+        if isinstance(dtype, pd.StringDtype):
+            frame[column] = frame[column].astype(object)
+        elif isinstance(dtype, pd.api.extensions.ExtensionDtype):
+            frame[column] = frame[column].astype(dtype.numpy_dtype)
+    return frame
+
+
+def read_contents(store: pd.HDFStore) -> pd.DataFrame:
+    """Read `bundle_contents`, or an empty frame of the right shape if the
+    bundle has no tables yet."""
+    if CONTENTS_KEY not in store:
+        return pd.DataFrame(
+            {
+                "identifier": pd.array([], dtype="object"),
+                "table_name": pd.array([], dtype="object"),
+            }
+        )
+    return store.select(CONTENTS_KEY)
+
+
+def resolve_table_name(store: pd.HDFStore, key: str) -> str:
+    """Look up the backend-specific `table_name` for `key` in
+    `bundle_contents`.
+
+    Raises
+    ------
+    KeyError: If no frame is registered under `key`.
+    """
+    contents = read_contents(store)
+    matches = contents.loc[contents["identifier"] == key, "table_name"]
+    if matches.empty:
+        raise KeyError(key)
+    return str(matches.iloc[0])
+
+
+def append_contents_row(store: pd.HDFStore, key: str, table_name: str) -> None:
+    """Add one `(identifier, table_name)` row to `bundle_contents`,
+    creating the manifest table if this is the bundle's first frame."""
+    contents = read_contents(store)
+    row = pd.DataFrame({"identifier": [key], "table_name": [table_name]})
+    updated = pd.concat([contents, row], ignore_index=True)
+    if CONTENTS_KEY in store:
+        store.remove(CONTENTS_KEY)
+    store.put(CONTENTS_KEY, updated, format="table")

--- a/src/afft/deployment/bundle_hdf_io.py
+++ b/src/afft/deployment/bundle_hdf_io.py
@@ -1,5 +1,5 @@
-"""Concrete `pandas.HDFStore` writer implementing the deployment bundle
-write `Protocol` interface defined in `bundle_protocols.py`."""
+"""Concrete `pandas.HDFStore` bundle implementing the deployment bundle
+read-write `Protocol` interface defined in `bundle_protocols.py`."""
 
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -13,19 +13,32 @@ from .bundle_hdf_common import (
     append_contents_row,
     coerce_storable_dtypes,
     read_contents,
+    resolve_table_name,
 )
 
 
 @dataclass
-class HDFDeploymentBundleWriter:
-    """Concrete `DeploymentBundleWriter` backed by an open `pandas.HDFStore`."""
+class HDFDeploymentBundleIO:
+    """Concrete `DeploymentBundleIO` backed by an open `pandas.HDFStore`."""
 
     store: pd.HDFStore
+
+    def list_frames(self) -> list[str]:
+        return list(self.contents()["identifier"])
 
     def has_frame(self, key: str) -> bool:
         if key in RESERVED_KEYS:
             return False
-        return key in read_contents(self.store)["identifier"].values
+        return key in self.list_frames()
+
+    def read_frame(self, key: str) -> pd.DataFrame:
+        if key in RESERVED_KEYS:
+            raise KeyError(f"{key!r} is reserved; use contents() instead")
+        table_name = resolve_table_name(self.store, key)
+        return self.store.select(table_name)
+
+    def contents(self) -> pd.DataFrame:
+        return read_contents(self.store)
 
     def write_frame(
         self,
@@ -52,9 +65,7 @@ class HDFDeploymentBundleWriter:
 
 
 @contextmanager
-def open_deployment_bundle_writer(
-    path: Path,
-) -> Iterator[HDFDeploymentBundleWriter]:
-    """Open an HDF5 deployment bundle for writing."""
+def open_deployment_bundle(path: Path) -> Iterator[HDFDeploymentBundleIO]:
+    """Open an HDF5 deployment bundle for reading and writing."""
     with pd.HDFStore(str(path), mode="a") as store:
-        yield HDFDeploymentBundleWriter(store=store)
+        yield HDFDeploymentBundleIO(store=store)

--- a/src/afft/deployment/bundle_hdf_readers.py
+++ b/src/afft/deployment/bundle_hdf_readers.py
@@ -8,36 +8,11 @@ from typing import Iterator
 
 import pandas as pd
 
-_CONTENTS_KEY: str = "bundle_contents"
-_RESERVED_KEYS: frozenset[str] = frozenset({_CONTENTS_KEY})
-
-
-def _read_contents(store: pd.HDFStore) -> pd.DataFrame:
-    """Read `bundle_contents`, or an empty frame of the right shape if the
-    bundle has no tables."""
-    if _CONTENTS_KEY not in store:
-        return pd.DataFrame(
-            {
-                "identifier": pd.array([], dtype="object"),
-                "table_name": pd.array([], dtype="object"),
-            }
-        )
-    return store.select(_CONTENTS_KEY)
-
-
-def _resolve_table_name(store: pd.HDFStore, key: str) -> str:
-    """Look up the backend-specific `table_name` for `key` in
-    `bundle_contents`.
-
-    Raises
-    ------
-    KeyError: If no frame is registered under `key`.
-    """
-    contents = _read_contents(store)
-    matches = contents.loc[contents["identifier"] == key, "table_name"]
-    if matches.empty:
-        raise KeyError(key)
-    return str(matches.iloc[0])
+from .bundle_hdf_common import (
+    RESERVED_KEYS,
+    read_contents,
+    resolve_table_name,
+)
 
 
 @dataclass
@@ -50,18 +25,18 @@ class HDFDeploymentBundleReader:
         return list(self.contents()["identifier"])
 
     def has_frame(self, key: str) -> bool:
-        if key in _RESERVED_KEYS:
+        if key in RESERVED_KEYS:
             return False
         return key in self.list_frames()
 
     def read_frame(self, key: str) -> pd.DataFrame:
-        if key in _RESERVED_KEYS:
+        if key in RESERVED_KEYS:
             raise KeyError(f"{key!r} is reserved; use contents() instead")
-        table_name = _resolve_table_name(self.store, key)
+        table_name = resolve_table_name(self.store, key)
         return self.store.select(table_name)
 
     def contents(self) -> pd.DataFrame:
-        return _read_contents(self.store)
+        return read_contents(self.store)
 
 
 @contextmanager

--- a/src/afft/deployment/bundle_protocols.py
+++ b/src/afft/deployment/bundle_protocols.py
@@ -54,3 +54,15 @@ class DeploymentBundleWriter(Protocol):
         is overwritten.
         """
         ...
+
+
+class DeploymentBundleIO(
+    DeploymentBundleReader, DeploymentBundleWriter, Protocol
+):
+    """
+    Read and write interface for a single deployment bundle.
+
+    The union of the read and write interfaces, for consumers that read back
+    what they have written and so need both to refer to the same bundle. A
+    consumer needing only one of the two should depend on that one.
+    """

--- a/tests/test_deployment_bundle_hdf_bundle_io.py
+++ b/tests/test_deployment_bundle_hdf_bundle_io.py
@@ -1,0 +1,108 @@
+"""Round-trip tests for the pandas.HDFStore read-write deployment bundle."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from afft.deployment import (
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
+
+
+def _frame(value: float = 1.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": [datetime(2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc)],
+            "value": [value],
+        }
+    )
+
+
+def test_reads_back_a_frame_written_through_the_same_handle(
+    tmp_path: Path,
+) -> None:
+    """A frame is readable from the same open bundle that wrote it."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame("telemetry/raw/pressure", _frame())
+
+        assert bundle.has_frame("telemetry/raw/pressure")
+        assert bundle.read_frame("telemetry/raw/pressure")[
+            "value"
+        ].tolist() == [1.0]
+
+
+def test_reads_back_a_frame_derived_from_an_earlier_write(
+    tmp_path: Path,
+) -> None:
+    """A frame written from one read is itself readable, as chained steps need."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame("telemetry/raw/pressure", _frame())
+        bundle.write_frame(
+            "telemetry/processed/pressure",
+            bundle.read_frame("telemetry/raw/pressure"),
+        )
+        bundle.write_frame(
+            "telemetry/processed/depth",
+            bundle.read_frame("telemetry/processed/pressure"),
+        )
+
+        assert bundle.list_frames() == [
+            "telemetry/raw/pressure",
+            "telemetry/processed/pressure",
+            "telemetry/processed/depth",
+        ]
+
+
+def test_replaces_a_frame_it_wrote_earlier(tmp_path: Path) -> None:
+    """`if_exists="replace"` overwrites in place without duplicating contents."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame("telemetry/raw/dvl", _frame())
+
+        with pytest.raises(ValueError):
+            bundle.write_frame("telemetry/raw/dvl", _frame(2.0))
+
+        bundle.write_frame(
+            "telemetry/raw/dvl", _frame(2.0), if_exists="replace"
+        )
+
+        assert bundle.read_frame("telemetry/raw/dvl")["value"].tolist() == [2.0]
+        assert bundle.list_frames() == ["telemetry/raw/dvl"]
+
+
+def test_written_bundle_is_readable_by_the_reader(tmp_path: Path) -> None:
+    """What the read-write bundle writes, the read-only reader reads."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame("telemetry/raw/dvl", _frame())
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.list_frames() == ["telemetry/raw/dvl"]
+        assert reader.read_frame("telemetry/raw/dvl")["value"].tolist() == [1.0]
+
+
+def test_read_frame_raises_key_error_for_unknown_key(tmp_path: Path) -> None:
+    """Reading a key that was never written raises `KeyError`."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame("telemetry/raw/dvl", _frame())
+
+        with pytest.raises(KeyError):
+            bundle.read_frame("telemetry/processed/dvl")
+
+
+def test_unsupported_suffix_raises(tmp_path: Path) -> None:
+    """Opening a bundle with an unsupported suffix raises."""
+    with pytest.raises(NotImplementedError):
+        with open_deployment_bundle(tmp_path / "bundle.parquet"):
+            pass

--- a/tests/test_deployment_bundle_protocols.py
+++ b/tests/test_deployment_bundle_protocols.py
@@ -1,0 +1,102 @@
+"""Conformance tests for the deployment bundle protocols."""
+
+from typing import Literal
+
+import pandas as pd
+import pytest
+
+from afft.deployment import (
+    DeploymentBundleIO,
+    DeploymentBundleReader,
+    DeploymentBundleWriter,
+)
+
+
+class InMemoryBundle:
+    """A minimal in-memory bundle satisfying the read and write interfaces."""
+
+    def __init__(self) -> None:
+        self._frames: dict[str, pd.DataFrame] = {}
+
+    def list_frames(self) -> list[str]:
+        return sorted(self._frames)
+
+    def has_frame(self, key: str) -> bool:
+        return key in self._frames
+
+    def read_frame(self, key: str) -> pd.DataFrame:
+        if key not in self._frames:
+            raise KeyError(key)
+        return self._frames[key]
+
+    def contents(self) -> pd.DataFrame:
+        return pd.DataFrame({"key": self.list_frames()})
+
+    def write_frame(
+        self,
+        key: str,
+        frame: pd.DataFrame,
+        *,
+        if_exists: Literal["fail", "replace"] = "fail",
+    ) -> None:
+        if key in self._frames and if_exists == "fail":
+            raise ValueError(f"frame already exists at {key!r}")
+        self._frames[key] = frame
+
+
+def copy_frame(bundle: DeploymentBundleIO, source: str, target: str) -> None:
+    """Read a frame and write it back to another key of the same bundle."""
+    bundle.write_frame(target, bundle.read_frame(source))
+
+
+def read_keys(bundle: DeploymentBundleReader) -> list[str]:
+    return bundle.list_frames()
+
+
+def write_empty(bundle: DeploymentBundleWriter, key: str) -> None:
+    bundle.write_frame(key, pd.DataFrame({"value": [1.0]}))
+
+
+def test_io_supports_reading_back_what_it_wrote() -> None:
+    """A bundle passed as `DeploymentBundleIO` reads its own writes."""
+    bundle = InMemoryBundle()
+    bundle.write_frame("telemetry/raw/pressure", pd.DataFrame({"value": [1.0]}))
+
+    copy_frame(bundle, "telemetry/raw/pressure", "telemetry/processed/pressure")
+
+    assert bundle.has_frame("telemetry/processed/pressure")
+    assert bundle.read_frame("telemetry/processed/pressure")[
+        "value"
+    ].tolist() == [1.0]
+
+
+def test_io_is_accepted_where_a_single_capability_is_expected() -> None:
+    """`DeploymentBundleIO` is usable wherever a reader or writer is."""
+    bundle = InMemoryBundle()
+
+    write_empty(bundle, "telemetry/raw/dvl")
+
+    assert read_keys(bundle) == ["telemetry/raw/dvl"]
+
+
+def test_write_frame_replaces_only_when_asked() -> None:
+    """The write interface's `if_exists` contract holds for chained steps."""
+    bundle = InMemoryBundle()
+    bundle.write_frame(
+        "telemetry/processed/dvl", pd.DataFrame({"value": [1.0]})
+    )
+
+    with pytest.raises(ValueError):
+        bundle.write_frame(
+            "telemetry/processed/dvl", pd.DataFrame({"value": [2.0]})
+        )
+
+    bundle.write_frame(
+        "telemetry/processed/dvl",
+        pd.DataFrame({"value": [2.0]}),
+        if_exists="replace",
+    )
+
+    assert bundle.read_frame("telemetry/processed/dvl")["value"].tolist() == [
+        2.0
+    ]


### PR DESCRIPTION
## Summary

Adds `DeploymentBundleIO`, the union of the existing `DeploymentBundleReader` and `DeploymentBundleWriter` protocols, for consumers that read back what they have written and so need both to refer to the same bundle. Expressed as two separate parameters that would be a convention the caller has to honour; as one protocol it is structural. The narrow protocols are unchanged and remain the right dependency for every existing consumer.

Nothing satisfied the protocol, so this also adds a backing implementation:

- `HDFDeploymentBundleIO` in a new `bundle_hdf_io.py` — a standalone class implementing both interfaces directly, not a subclass of the existing reader and writer. The protocols are structural, so inheriting would only couple this implementation to theirs, and would leave `has_frame` resolved by MRO rather than by choice.
- `open_deployment_bundle` in `bundle_factories.py`, dispatching on file suffix like the existing reader and writer factories.

Helpers shared by the three implementations — the contents-table reader, the table-name resolver, the dtype coercion, and the reserved-key set — move to a new package-internal `bundle_hdf_common.py`. Several were already duplicated between the reader and writer modules; a third implementation would have made that a third copy. The reader and writer now import them instead of defining them, with behaviour otherwise unchanged.

`HDFDeploymentBundleIO` is not re-exported from `afft.deployment`, matching the existing HDF reader and writer classes.

Tests cover reading back a frame written through the same handle, chaining a write off an earlier read, replace-versus-fail on an existing key, cross-readability with the read-only reader, and the unsupported-suffix error. Ruff, mypy, and the full suite pass; 261 tests, up from 252.

Closes #232
