### PR TITLE
Add bundle-in/bundle-out processing pipeline

### DIFF
--- a/src/afft/bundle_processing/__init__.py
+++ b/src/afft/bundle_processing/__init__.py
@@ -1,0 +1,32 @@
+"""Package for bundle-in/bundle-out processing pipelines."""
+
+from .types import (
+    Pipeline as Pipeline,
+    PipelineConfig as PipelineConfig,
+    PipelineProcessor as PipelineProcessor,
+    PipelineStep as PipelineStep,
+    PipelineStepConfig as PipelineStepConfig,
+)
+from .registry import (
+    PipelineProcessorRegistry as PipelineProcessorRegistry,
+    RegisteredProcessor as RegisteredProcessor,
+    default_registry as default_registry,
+    register_processor as register_processor,
+)
+from .builders import build_pipeline as build_pipeline
+from .runners import (
+    PipelineStepError as PipelineStepError,
+    run_pipeline as run_pipeline,
+    validate_pipeline as validate_pipeline,
+)
+
+# Imported for their registration side effects: a processor in an unimported
+# module is silently absent from the registry rather than an error.
+from . import common_processors as common_processors
+from . import sensor_processors as sensor_processors
+
+from .common_processors import (
+    DropColumnsConfig as DropColumnsConfig,
+    RenameColumnsConfig as RenameColumnsConfig,
+    SelectColumnsConfig as SelectColumnsConfig,
+)

--- a/src/afft/bundle_processing/builders.py
+++ b/src/afft/bundle_processing/builders.py
@@ -1,0 +1,62 @@
+"""Resolution of a configured pipeline into runnable steps."""
+
+from pydantic import ValidationError
+
+from .registry import PipelineProcessorRegistry, default_registry
+from .types import Pipeline, PipelineConfig, PipelineStep
+
+
+def build_pipeline(
+    config: PipelineConfig,
+    registry: PipelineProcessorRegistry | None = None,
+) -> Pipeline:
+    """
+    Resolve each configured step into a runnable pipeline.
+
+    Arguments
+    ---------
+    config: The pipeline as declared in the config file.
+    registry: Registry to resolve processor names against. Defaults to the
+        process-wide registry the decorators populate.
+
+    Returns
+    -------
+    The resolved steps, in declaration order.
+
+    Raises
+    ------
+    ValueError: If a step names an unknown processor, or its `config` table
+        is not valid for that processor.
+    """
+    registry = registry if registry is not None else default_registry()
+
+    steps: list[PipelineStep] = []
+    for index, step_config in enumerate(config.steps):
+        try:
+            registered = registry.get(step_config.processor)
+        except KeyError:
+            raise ValueError(
+                f"step {index} names unknown processor "
+                f"{step_config.processor!r}; "
+                f"registered processors are {registry.names()}"
+            ) from None
+
+        try:
+            step_config_model = registered.config_type(**step_config.config)
+        except ValidationError as error:
+            raise ValueError(
+                f"step {index} ({step_config.processor}) has an invalid "
+                f"config: {error}"
+            ) from error
+
+        steps.append(
+            PipelineStep(
+                processor_key=step_config.processor,
+                processor=registered.processor,
+                config=step_config_model,
+                inputs=dict(step_config.inputs),
+                output=step_config.output,
+            )
+        )
+
+    return tuple(steps)

--- a/src/afft/bundle_processing/common_processors.py
+++ b/src/afft/bundle_processing/common_processors.py
@@ -1,0 +1,136 @@
+"""Sensor-agnostic column processors, written directly against
+`PipelineProcessor`."""
+
+from collections.abc import Mapping
+
+import pandas as pd
+
+from pydantic import BaseModel, ConfigDict
+
+from .registry import register_processor
+
+
+class RenameColumnsConfig(BaseModel):
+    """
+    Configuration for `rename_columns`.
+
+    Attributes
+    ----------
+    columns: Maps each existing column name to its new name.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    columns: dict[str, str]
+
+
+class SelectColumnsConfig(BaseModel):
+    """
+    Configuration for `select_columns`.
+
+    Attributes
+    ----------
+    columns: Column names to keep, in the order they should appear.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    columns: list[str]
+
+
+class DropColumnsConfig(BaseModel):
+    """
+    Configuration for `drop_columns`.
+
+    Attributes
+    ----------
+    columns: Column names to remove.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    columns: list[str]
+
+
+@register_processor("rename_columns", config_type=RenameColumnsConfig)
+def rename_columns(
+    frames: Mapping[str, pd.DataFrame],
+    config: RenameColumnsConfig,
+) -> pd.DataFrame:
+    """
+    Rename columns on a single frame.
+
+    Arguments
+    ---------
+    frames: Single-entry mapping holding the frame under `df`.
+    config: Holds the old-name-to-new-name mapping.
+
+    Returns
+    -------
+    The frame with its columns renamed.
+
+    Raises
+    ------
+    KeyError: If a column named for renaming is not in the frame.
+    """
+    frame = frames["df"]
+    missing = [name for name in config.columns if name not in frame.columns]
+    if missing:
+        raise KeyError(f"columns not in frame: {missing}")
+    return frame.rename(columns=dict(config.columns))
+
+
+@register_processor("select_columns", config_type=SelectColumnsConfig)
+def select_columns(
+    frames: Mapping[str, pd.DataFrame],
+    config: SelectColumnsConfig,
+) -> pd.DataFrame:
+    """
+    Keep only the listed columns of a single frame.
+
+    Arguments
+    ---------
+    frames: Single-entry mapping holding the frame under `df`.
+    config: Holds the column names to keep.
+
+    Returns
+    -------
+    The frame reduced to the listed columns, in the listed order.
+
+    Raises
+    ------
+    KeyError: If a column named for keeping is not in the frame.
+    """
+    frame = frames["df"]
+    missing = [name for name in config.columns if name not in frame.columns]
+    if missing:
+        raise KeyError(f"columns not in frame: {missing}")
+    return frame[config.columns]
+
+
+@register_processor("drop_columns", config_type=DropColumnsConfig)
+def drop_columns(
+    frames: Mapping[str, pd.DataFrame],
+    config: DropColumnsConfig,
+) -> pd.DataFrame:
+    """
+    Remove the listed columns from a single frame.
+
+    Arguments
+    ---------
+    frames: Single-entry mapping holding the frame under `df`.
+    config: Holds the column names to remove.
+
+    Returns
+    -------
+    The frame without the listed columns.
+
+    Raises
+    ------
+    KeyError: If a column named for removal is not in the frame.
+    """
+    frame = frames["df"]
+    missing = [name for name in config.columns if name not in frame.columns]
+    if missing:
+        raise KeyError(f"columns not in frame: {missing}")
+    return frame.drop(columns=config.columns)

--- a/src/afft/bundle_processing/registry.py
+++ b/src/afft/bundle_processing/registry.py
@@ -1,0 +1,97 @@
+"""Name-to-processor registry used to resolve configured pipeline steps."""
+
+from dataclasses import dataclass
+from typing import Callable
+
+from pydantic import BaseModel
+
+from .types import PipelineProcessor
+
+
+@dataclass(slots=True, frozen=True)
+class RegisteredProcessor:
+    """
+    A processor and the config type its `config` table is parsed into.
+
+    Attributes
+    ----------
+    processor: The wrapper conforming to `PipelineProcessor`.
+    config_type: Model the step's raw `config` table is constructed as.
+    """
+
+    processor: PipelineProcessor
+    config_type: type[BaseModel]
+
+
+class PipelineProcessorRegistry:
+    """Name-to-processor mapping for pipeline construction."""
+
+    def __init__(self) -> None:
+        self._processors: dict[str, RegisteredProcessor] = {}
+
+    def register(
+        self, name: str, config_type: type[BaseModel]
+    ) -> Callable[[PipelineProcessor], PipelineProcessor]:
+        """
+        Return a decorator registering a processor under `name`.
+
+        The decorated function is returned unchanged, so it stays directly
+        callable and testable without going through the registry.
+
+        Arguments
+        ---------
+        name: Name the processor is configured by.
+        config_type: Model the step's raw `config` table is constructed as.
+
+        Returns
+        -------
+        A decorator that registers its argument and returns it unchanged.
+
+        Raises
+        ------
+        ValueError: If `name` is already registered.
+        """
+
+        def decorator(processor: PipelineProcessor) -> PipelineProcessor:
+            if name in self._processors:
+                raise ValueError(f"processor already registered: {name!r}")
+            self._processors[name] = RegisteredProcessor(
+                processor=processor,
+                config_type=config_type,
+            )
+            return processor
+
+        return decorator
+
+    def get(self, name: str) -> RegisteredProcessor:
+        """
+        Look up a registered processor.
+
+        Arguments
+        ---------
+        name: Name the processor was registered under.
+
+        Returns
+        -------
+        The registered processor and its config type.
+
+        Raises
+        ------
+        KeyError: If no processor is registered under `name`.
+        """
+        if name not in self._processors:
+            raise KeyError(name)
+        return self._processors[name]
+
+    def names(self) -> list[str]:
+        """List every registered processor name, sorted."""
+        return sorted(self._processors)
+
+
+_REGISTRY: PipelineProcessorRegistry = PipelineProcessorRegistry()
+register_processor = _REGISTRY.register
+
+
+def default_registry() -> PipelineProcessorRegistry:
+    """Return the process-wide registry the decorators populate."""
+    return _REGISTRY

--- a/src/afft/bundle_processing/runners.py
+++ b/src/afft/bundle_processing/runners.py
@@ -1,0 +1,84 @@
+"""Execution of a resolved pipeline against a deployment bundle."""
+
+from collections.abc import Set
+
+from afft.deployment import DeploymentBundleIO, DeploymentBundleReader
+from afft.utils.log import logger
+
+from .types import Pipeline
+
+
+class PipelineStepError(RuntimeError):
+    """Raised when a pipeline step fails, naming the step that failed."""
+
+
+def validate_pipeline(pipeline: Pipeline, available: Set[str]) -> None:
+    """
+    Check that every step's inputs are available when that step runs.
+
+    Arguments
+    ---------
+    pipeline: The resolved steps, in run order.
+    available: Keys present before the first step -- the input bundle's.
+
+    Raises
+    ------
+    ValueError: If a step names an input key that no earlier step produces
+        and the input bundle does not hold.
+    """
+    produced: set[str] = set(available)
+    for index, step in enumerate(pipeline):
+        for name, key in step.inputs.items():
+            if key not in produced:
+                raise ValueError(
+                    f"step {index} ({step.processor_key}) reads {name}="
+                    f"{key!r}, which the input bundle does not hold and no "
+                    f"earlier step produces"
+                )
+        produced.add(step.output)
+
+
+def run_pipeline(
+    pipeline: Pipeline,
+    source: DeploymentBundleReader,
+    target: DeploymentBundleIO,
+) -> None:
+    """
+    Seed `target` from `source`, then run each step against `target`.
+
+    Arguments
+    ---------
+    pipeline: The resolved steps, run in order.
+    source: Bundle the run starts from; read only, never written.
+    target: Bundle the run produces; both the destination of every step and
+        the source of every step's inputs.
+
+    Raises
+    ------
+    PipelineStepError: If a step fails, naming the step and chaining the
+        original error as its cause.
+    """
+    for key in source.list_frames():
+        target.write_frame(key, source.read_frame(key))
+
+    for index, step in enumerate(pipeline):
+        try:
+            frames = {
+                name: target.read_frame(key)
+                for name, key in step.inputs.items()
+            }
+            frame = step.processor(frames, step.config)
+            target.write_frame(
+                step.output,
+                frame,
+                if_exists=(
+                    "replace" if target.has_frame(step.output) else "fail"
+                ),
+            )
+        except Exception as error:
+            logger.error(
+                f"pipeline step {index} ({step.processor_key}) failed: {error}"
+            )
+            raise PipelineStepError(
+                f"step {index} ({step.processor_key} -> {step.output}) failed"
+            ) from error

--- a/src/afft/bundle_processing/sensor_processors.py
+++ b/src/afft/bundle_processing/sensor_processors.py
@@ -1,0 +1,53 @@
+"""Pipeline wrappers around the sensor processing functions in
+`afft.sensors`, translating the uniform calling convention into each
+function's natural signature."""
+
+from collections.abc import Mapping
+
+import pandas as pd
+
+from afft.sensors.acfr_vision import (
+    PairStereoImagesConfig,
+    pair_stereo_images,
+)
+from afft.sensors.dvl_teledyne import (
+    DvlUncertaintyConfig,
+    estimate_dvl_uncertainty,
+)
+from afft.sensors.pressure_parosci import (
+    PressureUncertaintyConfig,
+    estimate_pressure_uncertainty,
+)
+
+from .registry import register_processor
+
+
+@register_processor("pair_stereo_images", config_type=PairStereoImagesConfig)
+def step_pair_stereo_images(
+    frames: Mapping[str, pd.DataFrame],
+    config: PairStereoImagesConfig,
+) -> pd.DataFrame:
+    """Pair left/right stereo captures into one frame per trigger."""
+    return pair_stereo_images(frames["df"], config)
+
+
+@register_processor(
+    "estimate_pressure_uncertainty", config_type=PressureUncertaintyConfig
+)
+def step_estimate_pressure_uncertainty(
+    frames: Mapping[str, pd.DataFrame],
+    config: PressureUncertaintyConfig,
+) -> pd.DataFrame:
+    """Add a `depth_uncertainty` column to a pressure frame."""
+    return estimate_pressure_uncertainty(frames["df"], config)
+
+
+@register_processor(
+    "estimate_dvl_uncertainty", config_type=DvlUncertaintyConfig
+)
+def step_estimate_dvl_uncertainty(
+    frames: Mapping[str, pd.DataFrame],
+    config: DvlUncertaintyConfig,
+) -> pd.DataFrame:
+    """Add per-axis velocity and attitude uncertainty columns to a DVL frame."""
+    return estimate_dvl_uncertainty(frames["df"], config)

--- a/src/afft/bundle_processing/types.py
+++ b/src/afft/bundle_processing/types.py
@@ -1,0 +1,73 @@
+"""Types describing a processing pipeline, its steps, and the config they
+are built from."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Callable
+
+import pandas as pd
+
+from pydantic import BaseModel, ConfigDict
+
+type PipelineProcessor = Callable[
+    [Mapping[str, pd.DataFrame], Any], pd.DataFrame
+]
+
+
+@dataclass(slots=True, frozen=True)
+class PipelineStep:
+    """
+    A single resolved step, ready to run.
+
+    Attributes
+    ----------
+    processor_key: Registered name, retained for error messages.
+    processor: The resolved processor.
+    config: The processor's config, already constructed as its typed model.
+    inputs: Maps each processor argument name to the bundle key supplying it.
+    output: Bundle key the resulting frame is written to.
+    """
+
+    processor_key: str
+    processor: PipelineProcessor
+    config: BaseModel
+    inputs: Mapping[str, str]
+    output: str
+
+
+type Pipeline = tuple[PipelineStep, ...]
+
+
+class PipelineStepConfig(BaseModel):
+    """
+    A single step of the processing pipeline, as declared in the config file.
+
+    Attributes
+    ----------
+    processor: Name of the processor, resolved against the processor registry.
+    output: Bundle key the step's resulting frame is written to.
+    inputs: Maps each processor argument name to the bundle key supplying it.
+    config: Raw config table, constructed as the processor's config type by
+        the builder.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    processor: str
+    output: str
+    inputs: dict[str, str]
+    config: dict[str, Any] = {}
+
+
+class PipelineConfig(BaseModel):
+    """
+    The processing pipeline as declared in the config file.
+
+    Attributes
+    ----------
+    steps: The steps to run, in declaration order.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    steps: list[PipelineStepConfig] = []

--- a/tests/test_bundle_processing_builders.py
+++ b/tests/test_bundle_processing_builders.py
@@ -1,0 +1,89 @@
+"""Tests for resolving a configured pipeline into runnable steps."""
+
+import pytest
+
+from afft.bundle_processing import (
+    PipelineConfig,
+    PipelineStepConfig,
+    build_pipeline,
+)
+from afft.sensors.pressure_parosci import PressureUncertaintyConfig
+
+
+def _step_config(**overrides: object) -> PipelineStepConfig:
+    fields: dict[str, object] = {
+        "processor": "estimate_pressure_uncertainty",
+        "output": "telemetry/processed/pressure",
+        "inputs": {"df": "telemetry/raw/pressure"},
+        "config": {"base_uncertainty": 0.1},
+    }
+    fields.update(overrides)
+    return PipelineStepConfig(**fields)
+
+
+def test_resolves_a_step_into_a_runnable_one() -> None:
+    """A configured step comes back with its processor and typed config."""
+    pipeline = build_pipeline(PipelineConfig(steps=[_step_config()]))
+
+    (step,) = pipeline
+    assert step.processor_key == "estimate_pressure_uncertainty"
+    assert isinstance(step.config, PressureUncertaintyConfig)
+    assert step.config.base_uncertainty == 0.1
+    assert step.inputs == {"df": "telemetry/raw/pressure"}
+    assert step.output == "telemetry/processed/pressure"
+
+
+def test_preserves_declaration_order() -> None:
+    """Steps come back in the order they were declared."""
+    config = PipelineConfig(
+        steps=[
+            _step_config(output="first"),
+            _step_config(output="second"),
+        ]
+    )
+
+    pipeline = build_pipeline(config)
+
+    assert [step.output for step in pipeline] == ["first", "second"]
+
+
+def test_applies_processor_config_defaults() -> None:
+    """An omitted config field takes the processor config's own default."""
+    pipeline = build_pipeline(PipelineConfig(steps=[_step_config(config={})]))
+
+    (step,) = pipeline
+    assert isinstance(step.config, PressureUncertaintyConfig)
+    assert step.config.base_uncertainty == 0.005
+
+
+def test_an_unknown_processor_is_a_load_time_error() -> None:
+    """A misspelled processor name fails at build, naming what is available."""
+    config = PipelineConfig(steps=[_step_config(processor="no_such_thing")])
+
+    with pytest.raises(ValueError, match="unknown processor"):
+        build_pipeline(config)
+
+
+def test_an_unknown_config_field_is_a_load_time_error() -> None:
+    """`extra="forbid"` turns a stray config key into a build failure."""
+    config = PipelineConfig(
+        steps=[_step_config(config={"base_uncertanty": 0.1})]
+    )
+
+    with pytest.raises(ValueError, match="invalid config"):
+        build_pipeline(config)
+
+
+def test_a_later_step_failing_reports_its_index() -> None:
+    """The error names which step is at fault, not just that one is."""
+    config = PipelineConfig(
+        steps=[_step_config(), _step_config(processor="no_such_thing")]
+    )
+
+    with pytest.raises(ValueError, match="step 1"):
+        build_pipeline(config)
+
+
+def test_an_empty_pipeline_builds() -> None:
+    """No steps is a valid pipeline, not an error."""
+    assert build_pipeline(PipelineConfig()) == ()

--- a/tests/test_bundle_processing_common_processors.py
+++ b/tests/test_bundle_processing_common_processors.py
@@ -1,0 +1,76 @@
+"""Tests for the sensor-agnostic column processors."""
+
+import pandas as pd
+import pytest
+
+from pydantic import BaseModel
+
+from afft.bundle_processing import (
+    DropColumnsConfig,
+    PipelineProcessor,
+    RenameColumnsConfig,
+    SelectColumnsConfig,
+)
+from afft.bundle_processing.common_processors import (
+    drop_columns,
+    rename_columns,
+    select_columns,
+)
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {"timestamp": [1.0, 2.0], "depth": [3.0, 4.0], "extra": [5.0, 6.0]}
+    )
+
+
+def test_rename_columns_renames_the_listed_columns() -> None:
+    """Listed columns are renamed and the rest are left alone."""
+    config = RenameColumnsConfig(columns={"depth": "depth_m"})
+
+    result = rename_columns({"df": _frame()}, config)
+
+    assert list(result.columns) == ["timestamp", "depth_m", "extra"]
+
+
+def test_select_columns_keeps_the_listed_order() -> None:
+    """The result holds exactly the listed columns, in the listed order."""
+    config = SelectColumnsConfig(columns=["depth", "timestamp"])
+
+    result = select_columns({"df": _frame()}, config)
+
+    assert list(result.columns) == ["depth", "timestamp"]
+
+
+def test_drop_columns_removes_the_listed_columns() -> None:
+    """Listed columns are removed and the rest survive."""
+    config = DropColumnsConfig(columns=["extra"])
+
+    result = drop_columns({"df": _frame()}, config)
+
+    assert list(result.columns) == ["timestamp", "depth"]
+
+
+@pytest.mark.parametrize(
+    ("processor", "config"),
+    [
+        (rename_columns, RenameColumnsConfig(columns={"absent": "renamed"})),
+        (select_columns, SelectColumnsConfig(columns=["absent"])),
+        (drop_columns, DropColumnsConfig(columns=["absent"])),
+    ],
+)
+def test_naming_an_absent_column_raises(
+    processor: PipelineProcessor, config: BaseModel
+) -> None:
+    """A column that is not in the frame is an error, not a silent no-op."""
+    with pytest.raises(KeyError, match="absent"):
+        processor({"df": _frame()}, config)
+
+
+def test_processors_do_not_mutate_their_input() -> None:
+    """A processor returns a new frame rather than editing the one it read."""
+    frame = _frame()
+
+    drop_columns({"df": frame}, DropColumnsConfig(columns=["extra"]))
+
+    assert "extra" in frame.columns

--- a/tests/test_bundle_processing_registry.py
+++ b/tests/test_bundle_processing_registry.py
@@ -1,0 +1,91 @@
+"""Tests for the pipeline processor registry."""
+
+from collections.abc import Mapping
+
+import pandas as pd
+import pytest
+
+from pydantic import BaseModel, ConfigDict
+
+from afft.bundle_processing import (
+    PipelineProcessorRegistry,
+    default_registry,
+)
+
+
+class _Config(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    factor: float = 1.0
+
+
+def _processor(
+    frames: Mapping[str, pd.DataFrame], config: _Config
+) -> pd.DataFrame:
+    return frames["df"]
+
+
+def test_registers_and_resolves_a_processor() -> None:
+    """A registered processor is retrievable with its config type."""
+    registry = PipelineProcessorRegistry()
+    registry.register("scale", config_type=_Config)(_processor)
+
+    registered = registry.get("scale")
+
+    assert registered.processor is _processor
+    assert registered.config_type is _Config
+
+
+def test_returns_the_decorated_function_unchanged() -> None:
+    """Decorating leaves the function directly callable."""
+    registry = PipelineProcessorRegistry()
+
+    decorated = registry.register("scale", config_type=_Config)(_processor)
+
+    assert decorated is _processor
+
+
+def test_rejects_a_duplicate_name() -> None:
+    """Registering a name twice is an error rather than a silent replace."""
+    registry = PipelineProcessorRegistry()
+    registry.register("scale", config_type=_Config)(_processor)
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.register("scale", config_type=_Config)(_processor)
+
+
+def test_raises_key_error_for_an_unknown_name() -> None:
+    """An unregistered name raises rather than returning None."""
+    registry = PipelineProcessorRegistry()
+
+    with pytest.raises(KeyError):
+        registry.get("missing")
+
+
+def test_lists_names_sorted() -> None:
+    """Names come back sorted, independent of registration order."""
+    registry = PipelineProcessorRegistry()
+    registry.register("zulu", config_type=_Config)(_processor)
+    registry.register("alpha", config_type=_Config)(_processor)
+
+    assert registry.names() == ["alpha", "zulu"]
+
+
+def test_a_local_registry_does_not_leak_into_the_default_one() -> None:
+    """Test registries are isolated from the process-wide one."""
+    registry = PipelineProcessorRegistry()
+    registry.register("only-here", config_type=_Config)(_processor)
+
+    assert "only-here" not in default_registry().names()
+
+
+def test_default_registry_holds_every_shipped_processor() -> None:
+    """Importing the package registers all processors it defines."""
+    assert default_registry().names() == [
+        "drop_columns",
+        "estimate_dvl_uncertainty",
+        "estimate_pressure_uncertainty",
+        "pair_stereo_images",
+        "rename_columns",
+        "select_columns",
+    ]

--- a/tests/test_bundle_processing_runners.py
+++ b/tests/test_bundle_processing_runners.py
@@ -1,0 +1,263 @@
+"""Tests for running a resolved pipeline against a deployment bundle."""
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pydantic import BaseModel, ConfigDict
+
+from afft.bundle_processing import (
+    Pipeline,
+    PipelineStep,
+    PipelineStepError,
+    run_pipeline,
+    validate_pipeline,
+)
+from afft.deployment import (
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
+
+
+class _ScaleConfig(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    factor: float = 2.0
+
+
+def _scale(
+    frames: Mapping[str, pd.DataFrame], config: _ScaleConfig
+) -> pd.DataFrame:
+    frame = frames["df"].copy()
+    frame["value"] = frame["value"] * config.factor
+    return frame
+
+
+def _fail(
+    frames: Mapping[str, pd.DataFrame], config: _ScaleConfig
+) -> pd.DataFrame:
+    raise RuntimeError("processor exploded")
+
+
+def _step(
+    output: str,
+    source_key: str = "telemetry/raw/pressure",
+    processor_key: str = "scale",
+    factor: float = 2.0,
+) -> PipelineStep:
+    return PipelineStep(
+        processor_key=processor_key,
+        processor=_scale if processor_key == "scale" else _fail,
+        config=_ScaleConfig(factor=factor),
+        inputs={"df": source_key},
+        output=output,
+    )
+
+
+def _source_bundle(path: Path) -> None:
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame(
+            "telemetry/raw/pressure",
+            pd.DataFrame({"value": [1.0, 2.0]}),
+        )
+        bundle.write_frame(
+            "deployment/identity",
+            pd.DataFrame({"label": ["dive-01"]}),
+        )
+
+
+def _run(source: Path, target: Path, pipeline: Pipeline) -> None:
+    with open_deployment_bundle_reader(source) as reader:
+        with open_deployment_bundle(target) as bundle:
+            run_pipeline(pipeline, reader, bundle)
+
+
+def test_seeds_every_input_key_into_the_target(tmp_path: Path) -> None:
+    """The output holds every key the input held, even with no steps."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    _run(source, target, ())
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert sorted(reader.list_frames()) == [
+            "deployment/identity",
+            "telemetry/raw/pressure",
+        ]
+
+
+def test_writes_a_processed_frame_alongside_the_seeded_ones(
+    tmp_path: Path,
+) -> None:
+    """A step's output is added without disturbing the inherited keys."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    _run(source, target, (_step("telemetry/processed/pressure"),))
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert reader.has_frame("telemetry/raw/pressure")
+        assert reader.read_frame("telemetry/processed/pressure")[
+            "value"
+        ].tolist() == [2.0, 4.0]
+
+
+def test_a_step_reads_an_earlier_steps_output(tmp_path: Path) -> None:
+    """Steps chain: a later step consumes what an earlier one produced."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (
+        _step("telemetry/processed/once"),
+        _step(
+            "telemetry/processed/twice", source_key="telemetry/processed/once"
+        ),
+    )
+    _run(source, target, pipeline)
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert reader.read_frame("telemetry/processed/twice")[
+            "value"
+        ].tolist() == [4.0, 8.0]
+
+
+def test_a_step_may_overwrite_an_inherited_key(tmp_path: Path) -> None:
+    """Overwriting a key the input supplied is supported, not an error."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    _run(source, target, (_step("telemetry/raw/pressure"),))
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert reader.read_frame("telemetry/raw/pressure")[
+            "value"
+        ].tolist() == [2.0, 4.0]
+
+
+def test_a_step_reads_an_earlier_steps_overwrite(tmp_path: Path) -> None:
+    """A later step sees the overwritten value, not the original."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (
+        _step("telemetry/raw/pressure"),
+        _step("telemetry/processed/pressure"),
+    )
+    _run(source, target, pipeline)
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert reader.read_frame("telemetry/processed/pressure")[
+            "value"
+        ].tolist() == [4.0, 8.0]
+
+
+def test_the_source_bundle_is_left_untouched(tmp_path: Path) -> None:
+    """A run that overwrites a key changes the target only."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    _run(source, target, (_step("telemetry/raw/pressure"),))
+
+    with open_deployment_bundle_reader(source) as reader:
+        assert reader.read_frame("telemetry/raw/pressure")[
+            "value"
+        ].tolist() == [1.0, 2.0]
+
+
+def test_a_failing_step_raises_naming_the_step(tmp_path: Path) -> None:
+    """The wrapped error names the step index and processor."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (
+        _step("telemetry/processed/first"),
+        _step("telemetry/processed/second", processor_key="boom"),
+    )
+
+    with pytest.raises(PipelineStepError, match="step 1 .boom"):
+        _run(source, target, pipeline)
+
+
+def test_a_failing_step_chains_the_original_error(tmp_path: Path) -> None:
+    """The original exception survives as the cause."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (_step("telemetry/processed/x", processor_key="boom"),)
+
+    with pytest.raises(PipelineStepError) as excinfo:
+        _run(source, target, pipeline)
+
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "processor exploded" in str(excinfo.value.__cause__)
+
+
+def test_a_missing_input_key_fails_as_that_step(tmp_path: Path) -> None:
+    """A step naming an absent bundle key fails as that step, not opaquely."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (_step("telemetry/processed/x", source_key="telemetry/absent"),)
+
+    with pytest.raises(PipelineStepError, match="step 0"):
+        _run(source, target, pipeline)
+
+
+def test_a_run_stops_at_the_first_failure(tmp_path: Path) -> None:
+    """Fail-fast: no step after a failing one runs."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    pipeline = (
+        _step("telemetry/processed/first", processor_key="boom"),
+        _step("telemetry/processed/second"),
+    )
+
+    with pytest.raises(PipelineStepError):
+        _run(source, target, pipeline)
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert not reader.has_frame("telemetry/processed/second")
+
+
+def test_validate_accepts_inputs_the_source_holds() -> None:
+    """A step reading a key the input bundle holds validates."""
+    validate_pipeline(
+        (_step("telemetry/processed/pressure"),),
+        {"telemetry/raw/pressure"},
+    )
+
+
+def test_validate_accepts_inputs_an_earlier_step_produces() -> None:
+    """A step reading an earlier step's output validates."""
+    pipeline = (
+        _step("telemetry/processed/once"),
+        _step(
+            "telemetry/processed/twice", source_key="telemetry/processed/once"
+        ),
+    )
+
+    validate_pipeline(pipeline, {"telemetry/raw/pressure"})
+
+
+def test_validate_rejects_an_unreachable_input() -> None:
+    """A key neither held nor produced fails before the run starts."""
+    pipeline = (_step("out", source_key="telemetry/absent"),)
+
+    with pytest.raises(ValueError, match="step 0"):
+        validate_pipeline(pipeline, {"telemetry/raw/pressure"})
+
+
+def test_validate_rejects_a_forward_reference() -> None:
+    """Reading a key a *later* step produces fails: order is significant."""
+    pipeline = (
+        _step(
+            "telemetry/processed/once", source_key="telemetry/processed/twice"
+        ),
+        _step("telemetry/processed/twice"),
+    )
+
+    with pytest.raises(ValueError, match="step 0"):
+        validate_pipeline(pipeline, {"telemetry/raw/pressure"})


### PR DESCRIPTION
## Summary

Adds `afft.bundle_processing`, the bundle-in/bundle-out processing pipeline.

- `types.py` — `PipelineProcessor`, `PipelineStep`, `Pipeline`, and the `PipelineStepConfig`/`PipelineConfig` models a pipeline is declared as.
- `registry.py` — `PipelineProcessorRegistry` and the `register_processor` decorator, recording each processor's config type so it can be validated before the run.
- `common_processors.py` — `rename_columns`, `select_columns`, `drop_columns`. Each raises `KeyError` on a column the frame does not hold, rather than silently doing nothing as pandas would.
- `sensor_processors.py` — wrappers over the existing `afft.sensors` functions, unchanged themselves.
- `builders.py` — `build_pipeline`, resolving processor names and constructing typed configs up front so a bad name or config field fails at load rather than mid-run.
- `runners.py` — `run_pipeline`, `validate_pipeline`, `PipelineStepError`.

The output bundle is the pipeline's state: seeded from the input, then mutated step by step. It holds every key the input holds, and a step may consume the current value of any key, whether from the input, an earlier step's output, or an earlier step's overwrite of an inherited key. The runner reads and writes one `DeploymentBundleIO` and keeps no frame cache, so a step always sees the most recent write rather than a stale pre-overwrite frame.

Steps fail fast: a failure is logged and re-raised as a `PipelineStepError` naming the step index and processor, chaining the original error as its cause.

Three points where the issue left the choice open: `default_registry()` is a public accessor so `builders.py` need not import a private name across modules; `build_pipeline` takes an optional `registry` so the registry's test-isolation rationale is usable from a test; and the duplicate-name check sits inside the decorator, where registration actually happens.

The task package and `afft bundle process` command are #234 and are not in this PR.

Closes #201
