### PR TITLE
Add deployment bundle processing task and CLI command

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -1,5 +1,4 @@
 [afft.tasks.build_deployment_bundle.message_map]
-
 VIS = "ImageCaptureMessageV1"
 SEABIRD = "SeabirdCTDMessageV1"
 AANDERAA_4319 = "AanderaaCTDMessageV1"
@@ -20,3 +19,31 @@ MICRON = "MicronSonarMessageV1"
 MICRON_RETURNS = "MicronSonarMessageV1"
 GPS_GSV = "GpsGsvMessageV1"
 GPS_RMC = "GpsRmcMessageV1"
+
+# Processing pipeline for deployment bundles.
+
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor            = "pair_stereo_images"
+output               = "telemetry/processed/camera_avt_prosilica/VIS/stereo_image_pairs"
+inputs.df            = "telemetry/raw/camera_avt_prosilica/VIS/messages"
+config.left_suffix   = "LC16"
+config.right_suffix  = "RM16"
+config.max_offset_ms = 300.0
+
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor               = "estimate_pressure_uncertainty"
+output                  = "telemetry/processed/pressure_parosci/PAROSCI/messages"
+inputs.df               = "telemetry/raw/pressure_parosci/PAROSCI/messages"
+config.base_uncertainty = 0.1
+config.depth_scale      = 0.0
+
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor                     = "estimate_dvl_uncertainty"
+output                        = "telemetry/processed/dvl_teledyne_navigator/RDI/messages"
+inputs.df                     = "telemetry/raw/dvl_teledyne_navigator/RDI/messages"
+config.velocity_x_uncertainty = 0.003
+config.velocity_y_uncertainty = 0.003
+config.velocity_z_uncertainty = 0.003
+config.roll_uncertainty       = 0.50
+config.pitch_uncertainty      = 0.50
+config.heading_uncertainty    = 2.00

--- a/src/afft/bundle_processing/pipeline_runners.py
+++ b/src/afft/bundle_processing/pipeline_runners.py
@@ -14,6 +14,7 @@ def run_pipeline(
     pipeline: Pipeline,
     source: DeploymentBundleReader,
     target: DeploymentBundleIO,
+    verbose: bool = False,
 ) -> None:
     """
     Seed `target` from `source`, then run each step against `target`.
@@ -24,6 +25,7 @@ def run_pipeline(
     source: Bundle the run starts from; read only, never written.
     target: Bundle the run produces; both the destination of every step and
         the source of every step's inputs.
+    verbose: Log each step's output key as it is written.
 
     Raises
     ------
@@ -47,6 +49,11 @@ def run_pipeline(
                     "replace" if target.has_frame(step.output) else "fail"
                 ),
             )
+            if verbose:
+                logger.info(
+                    f"pipeline step {index} ({step.processor_key}) wrote "
+                    f"{step.output}"
+                )
         except Exception as error:
             logger.error(
                 f"pipeline step {index} ({step.processor_key}) failed: {error}"

--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -7,6 +7,10 @@ from afft.tasks.build_deployment_bundle import (
     read_build_deployment_bundle_config,
     run_build_deployment_bundle,
 )
+from afft.tasks.process_deployment_bundle import (
+    ProcessDeploymentBundleCommand,
+    run_process_deployment_bundle,
+)
 
 
 def dispatch_build_deployment_bundle(
@@ -30,3 +34,21 @@ def dispatch_build_deployment_bundle(
     )
     config = read_build_deployment_bundle_config(command.config_file)
     run_build_deployment_bundle(command, config)
+
+
+def dispatch_process_deployment_bundle(
+    input_file: str | Path,
+    config_file: str | Path,
+    output_file: str | Path,
+    overwrite: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Run the configured processing pipeline over a deployment bundle."""
+    command = ProcessDeploymentBundleCommand(
+        input_file=input_file,
+        config_file=config_file,
+        output_file=output_file,
+        overwrite=overwrite,
+        verbose=verbose,
+    )
+    run_process_deployment_bundle(command)

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -2,7 +2,10 @@
 
 import click
 
-from .actions import dispatch_build_deployment_bundle
+from .actions import (
+    dispatch_build_deployment_bundle,
+    dispatch_process_deployment_bundle,
+)
 
 
 @click.group()
@@ -74,6 +77,57 @@ def build(
         descriptor_file,
         deployment_label,
         data_dir,
+        config_file,
+        output_file,
+        overwrite,
+        verbose,
+    )
+
+
+@bundle_group.command()
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment bundle to process",
+)
+@click.option(
+    "--config",
+    "config_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the shared task config TOML file",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    required=True,
+    help="path to write the processed deployment bundle to",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="overwrite the output file if it already exists",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="log each step's output key as it is written",
+)
+def process(
+    input_file: str,
+    config_file: str,
+    output_file: str,
+    overwrite: bool,
+    verbose: bool,
+) -> None:
+    """Run the configured processing pipeline over a deployment bundle."""
+    dispatch_process_deployment_bundle(
+        input_file,
         config_file,
         output_file,
         overwrite,

--- a/src/afft/tasks/process_deployment_bundle/__init__.py
+++ b/src/afft/tasks/process_deployment_bundle/__init__.py
@@ -1,0 +1,15 @@
+"""Task for running a processing pipeline over a deployment bundle."""
+
+from .task_helpers import (
+    read_process_deployment_bundle_config as read_process_deployment_bundle_config,
+    validate_process_deployment_bundle_input as validate_process_deployment_bundle_input,
+)
+from .task_runners import (
+    run_process_deployment_bundle as run_process_deployment_bundle,
+)
+from .task_types import (
+    ProcessDeploymentBundleCommand as ProcessDeploymentBundleCommand,
+    ProcessDeploymentBundleResult as ProcessDeploymentBundleResult,
+)
+
+__all__ = []

--- a/src/afft/tasks/process_deployment_bundle/task_helpers.py
+++ b/src/afft/tasks/process_deployment_bundle/task_helpers.py
@@ -1,0 +1,70 @@
+"""Supporting functions for the process deployment bundle task: config
+loading and input validation."""
+
+from pathlib import Path
+from typing import Any
+
+import afft.io as io
+
+from afft.bundle_processing import PipelineConfig
+
+from .task_types import ProcessDeploymentBundleCommand
+
+
+def read_process_deployment_bundle_config(
+    config_file: Path,
+) -> PipelineConfig:
+    """
+    Read the processing pipeline section from the shared task config file.
+
+    Arguments
+    ---------
+    config_file: Path to the shared task config TOML file.
+
+    Returns
+    -------
+    The pipeline as declared in the config file.
+    """
+    raw: dict[str, Any] = io.read_config(config_file)
+    section: dict[str, Any] = raw["afft"]["tasks"]["process_deployment_bundle"]
+
+    return PipelineConfig(**section["pipeline"])
+
+
+def validate_process_deployment_bundle_input(
+    command: ProcessDeploymentBundleCommand,
+) -> None:
+    """
+    Validate the task's inputs before any expensive work runs.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Raises
+    ------
+    FileNotFoundError: If the input bundle or the output directory does not
+        exist.
+    ValueError: If the output file resolves to the input file, or if it
+        already exists and ``command.overwrite`` is not set.
+    """
+    if not command.input_file.is_file():
+        raise FileNotFoundError(
+            f"input bundle does not exist: {command.input_file}"
+        )
+
+    if not command.output_file.parent.is_dir():
+        raise FileNotFoundError(
+            f"output directory does not exist: {command.output_file.parent}"
+        )
+
+    input_path: Path = command.input_file.resolve()
+    output_path: Path = command.output_file.resolve()
+    if output_path == input_path:
+        raise ValueError(
+            f"output file is the input file: {output_path} -- a run would "
+            f"overwrite the bundle it reads from"
+        )
+
+    if command.output_file.exists() and not command.overwrite:
+        raise ValueError(f"output file already exists: {command.output_file}")

--- a/src/afft/tasks/process_deployment_bundle/task_runners.py
+++ b/src/afft/tasks/process_deployment_bundle/task_runners.py
@@ -1,0 +1,90 @@
+"""Runner for the process deployment bundle task."""
+
+import os
+
+from pathlib import Path
+
+from afft.bundle_processing import (
+    Pipeline,
+    PipelineConfig,
+    build_pipeline,
+    run_pipeline,
+    validate_pipeline,
+)
+from afft.deployment import (
+    DeploymentBundleIO,
+    DeploymentBundleReader,
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
+from afft.utils.log import logger
+
+from .task_helpers import (
+    read_process_deployment_bundle_config,
+    validate_process_deployment_bundle_input,
+)
+from .task_types import (
+    ProcessDeploymentBundleCommand,
+    ProcessDeploymentBundleResult,
+)
+
+
+def run_process_deployment_bundle(
+    command: ProcessDeploymentBundleCommand,
+) -> ProcessDeploymentBundleResult:
+    """
+    Run the configured processing pipeline over one deployment bundle.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The run's result, naming the keys the pipeline's steps wrote.
+
+    Raises
+    ------
+    FileNotFoundError: If the input bundle or the output directory does not
+        exist.
+    ValueError: If the output file is the input file, if it already exists
+        and ``overwrite`` is not set, or if the pipeline is not runnable
+        against the input bundle.
+    PipelineStepError: If a step fails. Propagates from ``run_pipeline``
+        uncaught; the staged output is removed first.
+    """
+    validate_process_deployment_bundle_input(command)
+
+    config: PipelineConfig = read_process_deployment_bundle_config(
+        command.config_file
+    )
+    pipeline: Pipeline = build_pipeline(config)
+
+    logger.info("-------------------------------------")
+    logger.info("Process Deployment Bundle")
+    logger.info(f"  input file:  {command.input_file}")
+    logger.info(f"  output file: {command.output_file}")
+    logger.info(f"  steps:       {len(pipeline)}")
+    logger.info("-------------------------------------")
+
+    output_file: Path = command.output_file
+    staged: Path = output_file.with_suffix(".partial" + output_file.suffix)
+    try:
+        reader: DeploymentBundleReader
+        target: DeploymentBundleIO
+        with open_deployment_bundle_reader(command.input_file) as reader:
+            validate_pipeline(pipeline, set(reader.list_frames()))
+            with open_deployment_bundle(staged) as target:
+                run_pipeline(pipeline, reader, target, verbose=command.verbose)
+        os.replace(staged, output_file)
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+
+    logger.info(f"wrote processed deployment bundle to {output_file}")
+
+    return ProcessDeploymentBundleResult(
+        input_file=command.input_file,
+        output_file=output_file,
+        output_keys=tuple(step.output for step in pipeline),
+    )

--- a/src/afft/tasks/process_deployment_bundle/task_types.py
+++ b/src/afft/tasks/process_deployment_bundle/task_types.py
@@ -1,0 +1,43 @@
+"""Data types for the process deployment bundle task."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ProcessDeploymentBundleCommand(BaseModel):
+    """
+    Attributes
+    ----------
+    input_file: Path to the source deployment bundle, read but never written.
+    config_file: Path to the shared task config TOML file
+        (``config/default.toml``).
+    output_file: Path to write the processed deployment bundle to. Must
+        differ from ``input_file``.
+    overwrite: Overwrite ``output_file`` if it already exists.
+    verbose: Log each step's output key as it is written.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    config_file: Path
+    output_file: Path
+    overwrite: bool = False
+    verbose: bool = False
+
+
+class ProcessDeploymentBundleResult(BaseModel):
+    """
+    Attributes
+    ----------
+    input_file: Path the run read from.
+    output_file: Path the completed bundle was moved to.
+    output_keys: Bundle keys the pipeline's steps wrote, in run order.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    output_file: Path
+    output_keys: tuple[str, ...]

--- a/tests/test_tasks_process_deployment_bundle.py
+++ b/tests/test_tasks_process_deployment_bundle.py
@@ -1,0 +1,200 @@
+"""Tests for the process deployment bundle task."""
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from afft.bundle_processing import PipelineStepError
+from afft.deployment import (
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
+from afft.tasks.process_deployment_bundle import (
+    ProcessDeploymentBundleCommand,
+    ProcessDeploymentBundleResult,
+    run_process_deployment_bundle,
+)
+from afft.utils.log import logger
+
+RENAME_STEP: str = """
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor = "rename_columns"
+output = "telemetry/processed/pressure/messages"
+inputs.df = "telemetry/raw/pressure/messages"
+config.columns.value = "pressure"
+"""
+
+MISSING_INPUT_STEP: str = """
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor = "rename_columns"
+output = "telemetry/processed/pressure/messages"
+inputs.df = "telemetry/raw/absent/messages"
+config.columns.value = "pressure"
+"""
+
+MISSING_COLUMN_STEP: str = """
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor = "rename_columns"
+output = "telemetry/processed/pressure/messages"
+inputs.df = "telemetry/raw/pressure/messages"
+config.columns.absent = "pressure"
+"""
+
+
+def _config_file(directory: Path, body: str) -> Path:
+    config_file: Path = directory / "task.toml"
+    config_file.write_text(body)
+    return config_file
+
+
+def _input_bundle(path: Path) -> Path:
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame(
+            "telemetry/raw/pressure/messages",
+            pd.DataFrame({"value": [1.0, 2.0]}),
+        )
+    return path
+
+
+def _command(
+    tmp_path: Path, body: str, **overrides: Any
+) -> ProcessDeploymentBundleCommand:
+    arguments: dict[str, Any] = {
+        "input_file": _input_bundle(tmp_path / "in.h5"),
+        "config_file": _config_file(tmp_path, body),
+        "output_file": tmp_path / "out.h5",
+    }
+    arguments.update(overrides)
+    return ProcessDeploymentBundleCommand(**arguments)
+
+
+def _staged(output_file: Path) -> Path:
+    return output_file.with_suffix(".partial" + output_file.suffix)
+
+
+def test_writes_the_processed_bundle(tmp_path: Path) -> None:
+    """A successful run leaves the processed bundle at the output path."""
+    command = _command(tmp_path, RENAME_STEP)
+
+    result = run_process_deployment_bundle(command)
+
+    assert isinstance(result, ProcessDeploymentBundleResult)
+    with open_deployment_bundle_reader(tmp_path / "out.h5") as reader:
+        frame = reader.read_frame("telemetry/processed/pressure/messages")
+    assert frame["pressure"].tolist() == [1.0, 2.0]
+
+
+def test_reports_the_keys_the_steps_wrote(tmp_path: Path) -> None:
+    """The result names each step's output key, in run order."""
+    command = _command(tmp_path, RENAME_STEP)
+
+    result = run_process_deployment_bundle(command)
+
+    assert result.output_keys == ("telemetry/processed/pressure/messages",)
+
+
+def test_a_successful_run_leaves_no_staged_file(tmp_path: Path) -> None:
+    """The staged file is moved into place, not left beside the output."""
+    command = _command(tmp_path, RENAME_STEP)
+
+    run_process_deployment_bundle(command)
+
+    assert not _staged(tmp_path / "out.h5").exists()
+
+
+def test_a_failed_step_leaves_neither_output_nor_staged_file(
+    tmp_path: Path,
+) -> None:
+    """A run that dies mid-pipeline leaves nothing behind."""
+    command = _command(tmp_path, MISSING_COLUMN_STEP)
+
+    with pytest.raises(PipelineStepError):
+        run_process_deployment_bundle(command)
+
+    assert not (tmp_path / "out.h5").exists()
+    assert not _staged(tmp_path / "out.h5").exists()
+
+
+def test_a_failed_run_leaves_the_input_untouched(tmp_path: Path) -> None:
+    """The input bundle survives a failed run unchanged."""
+    command = _command(tmp_path, MISSING_COLUMN_STEP)
+
+    with pytest.raises(PipelineStepError):
+        run_process_deployment_bundle(command)
+
+    with open_deployment_bundle_reader(tmp_path / "in.h5") as reader:
+        assert reader.read_frame("telemetry/raw/pressure/messages")[
+            "value"
+        ].tolist() == [1.0, 2.0]
+
+
+def test_an_unreachable_input_key_fails_before_the_run(
+    tmp_path: Path,
+) -> None:
+    """`validate_pipeline` rejects the pipeline before anything is written."""
+    command = _command(tmp_path, MISSING_INPUT_STEP)
+
+    with pytest.raises(ValueError, match="step 0"):
+        run_process_deployment_bundle(command)
+
+    assert not (tmp_path / "out.h5").exists()
+    assert not _staged(tmp_path / "out.h5").exists()
+
+
+def test_rejects_an_output_that_resolves_to_the_input(
+    tmp_path: Path,
+) -> None:
+    """A differently spelled path naming the input is still the input."""
+    command = _command(
+        tmp_path,
+        RENAME_STEP,
+        output_file=tmp_path / "sub" / ".." / "in.h5",
+    )
+    (tmp_path / "sub").mkdir()
+
+    with pytest.raises(ValueError, match="output file is the input file"):
+        run_process_deployment_bundle(command)
+
+
+def test_rejects_an_existing_output_without_overwrite(
+    tmp_path: Path,
+) -> None:
+    """An existing output is an error unless `overwrite` is set."""
+    (tmp_path / "out.h5").write_text("existing")
+    command = _command(tmp_path, RENAME_STEP)
+
+    with pytest.raises(ValueError, match="already exists"):
+        run_process_deployment_bundle(command)
+
+    assert (tmp_path / "out.h5").read_text() == "existing"
+
+
+def test_overwrite_replaces_an_existing_output(tmp_path: Path) -> None:
+    """With `overwrite`, the existing output is replaced by the run's."""
+    (tmp_path / "out.h5").write_text("existing")
+    command = _command(tmp_path, RENAME_STEP, overwrite=True)
+
+    run_process_deployment_bundle(command)
+
+    with open_deployment_bundle_reader(tmp_path / "out.h5") as reader:
+        assert reader.has_frame("telemetry/processed/pressure/messages")
+
+
+def test_verbose_logs_each_step_output_key(tmp_path: Path) -> None:
+    """`verbose` reports each step's output key as it is written."""
+    command = _command(tmp_path, RENAME_STEP, verbose=True)
+
+    messages: list[str] = []
+    handler_id: int = logger.add(messages.append, level="INFO")
+    try:
+        run_process_deployment_bundle(command)
+    finally:
+        logger.remove(handler_id)
+
+    assert any(
+        "telemetry/processed/pressure/messages" in message
+        and "wrote" in message
+        for message in messages
+    )


### PR DESCRIPTION
## Summary

Adds `afft.tasks.process_deployment_bundle`, the task layer around the storage-agnostic pipeline from #235, and exposes it as `afft bundle process` alongside `afft bundle build`.

- **`task_types.py`** — pydantic `ProcessDeploymentBundleCommand` and `ProcessDeploymentBundleResult`. The result has no consumer yet; it exists so the run's outcome is available to future callers rather than only to the log.
- **`task_helpers.py`** — reads the pipeline from `[afft.tasks.process_deployment_bundle.pipeline]` in the shared task config, and validates the command's inputs up front.
- **`task_runners.py`** — validate, read config, `build_pipeline`, `validate_pipeline` against the input bundle's keys, then the staged run.
- **`cli/bundle/`** — the `process` command and its dispatch.

Three things worth review attention:

**`validate_pipeline` is called by this layer.** `run_pipeline` does not validate for its callers, which is what #238 made explicit by moving the function out of the runner module. Without the call, a mistyped input key surfaces as a `PipelineStepError` at step *n*, after the seed pass and *n-1* frames have been written and then discarded.

**The run is staged.** It writes `<name>.partial.h5` beside the destination and moves it into place with `os.replace` only after the last step returns, so a failed run never leaves a plausible-looking partial bundle at the output path — a file holding every raw frame and a subset of processed ones reads as complete to anything that opens it later. The marker precedes the extension so the staged path still ends in `.h5`, which is what the bundle factories dispatch on. Cleanup is on `BaseException`, so an interrupted run tidies up too.

**The output is rejected when it resolves to the input.** `out.h5`, `/abs/path/out.h5`, and a symlink to it all name one file but compare unequal as strings, so the comparison is made after `resolve()`. Without it the final `os.replace` clobbers the bundle the run read from — the expensive artifact, since reproducing it means re-running the build over the raw logs.

Step failures are logged by the pipeline runner and propagate uncaught, matching `afft bundle build`; nothing is caught at the CLI boundary.

Also carried here: a `verbose` parameter on `run_pipeline`, logging each step's output key as it is written. The task layer cannot provide this itself — it hands the whole pipeline over and regains control only at the end — and the default keeps existing callers unaffected. `config/default.toml` gains the three-step pipeline section this command reads.

Tests cover the output and its `output_keys`, the staged file's absence after both success and failure, the input surviving a failed run, an unreachable input key rejected before anything is written, the resolved-path and `--overwrite` rejections, and `verbose` logging. They drive the real `rename_columns` processor through a temp TOML config, so config reading and registry resolution are exercised end to end.

Closes #234