### PR TITLE
Record frame dtypes in the bundle manifest

### DIFF
--- a/scripts/shell/bundle_batch_build.sh
+++ b/scripts/shell/bundle_batch_build.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/bash
 
+# Exit on the first failing command, on any unset variable, and on a failure
+# anywhere in a pipeline rather than only in its last command.
+set -euo pipefail
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 DESCRIPTOR_FILE="${REPO_ROOT}/data/deployment_descriptors_v1_subset_enriched.toml"
 CONFIG_FILE="${REPO_ROOT}/config/default.toml"
 
-DEPLOYMENT_DATA_DIR="/data/exos_01/acfr_deployments_v1_subset_fixed"
-OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+DEPLOYMENT_DATA_DIR="${HOME}/data/acfr_deployments_v1_subset_fixed"
+OUTPUT_DIR="${HOME}/data/acfr_deployment_bundles_v1_subset"
 
 DEPLOYMENTS=(
   "qdch0ftq_20100428_020202"

--- a/src/afft/deployment/__init__.py
+++ b/src/afft/deployment/__init__.py
@@ -20,6 +20,10 @@ from .bundle_types import (
     DeploymentProvenance as DeploymentProvenance,
     ProcessedProvenance as ProcessedProvenance,
 )
+from .bundle_common import (
+    decode_frame_dtypes as decode_frame_dtypes,
+    encode_frame_dtypes as encode_frame_dtypes,
+)
 from .bundle_protocols import (
     DeploymentBundleIO as DeploymentBundleIO,
     DeploymentBundleReader as DeploymentBundleReader,

--- a/src/afft/deployment/bundle_common.py
+++ b/src/afft/deployment/bundle_common.py
@@ -1,0 +1,76 @@
+"""Storage-agnostic definitions shared by every deployment bundle backend:
+the `bundle_contents` manifest schema and the frame dtype codec."""
+
+import json
+
+import pandas as pd
+
+CONTENTS_KEY: str = "bundle_contents"
+RESERVED_KEYS: frozenset[str] = frozenset({CONTENTS_KEY})
+
+CONTENTS_COLUMNS: tuple[str, ...] = ("identifier", "table_name", "dtypes")
+
+
+def empty_contents() -> pd.DataFrame:
+    """Build an empty `bundle_contents` manifest with the columns every
+    backend writes."""
+    return pd.DataFrame(
+        {column: pd.array([], dtype="object") for column in CONTENTS_COLUMNS}
+    )
+
+
+def encode_frame_dtypes(frame: pd.DataFrame) -> str:
+    """
+    Encode a frame's column dtypes as a flat JSON object.
+
+    The values are `str(dtype)` -- ``"Int64"``, ``"datetime64[ns, UTC]"``,
+    ``"category"``, and so on -- every one of which `decode_frame_dtypes`
+    accepts back. A `category` dtype records neither its label set nor its
+    ordering; both are re-derived from the stored values on read.
+
+    Arguments
+    ---------
+    frame: Frame whose dtypes to record.
+
+    Returns
+    -------
+    A JSON object mapping column name to dtype string.
+
+    Raises
+    ------
+    ValueError: If a column is an ordered categorical. The encoding cannot
+        represent the ordering, and a backend restoring from it would return
+        an unordered categorical whose comparisons raise rather than order --
+        a silent change of meaning, so it is refused at write time.
+    """
+    ordered = [
+        str(column)
+        for column, dtype in frame.dtypes.items()
+        if isinstance(dtype, pd.CategoricalDtype) and dtype.ordered
+    ]
+    if ordered:
+        raise ValueError(
+            f"ordered categorical columns cannot be recorded: {ordered}"
+        )
+
+    return json.dumps(
+        {str(column): str(dtype) for column, dtype in frame.dtypes.items()}
+    )
+
+
+def decode_frame_dtypes(encoded: str) -> dict[str, object]:
+    """
+    Decode the JSON written by `encode_frame_dtypes` back into pandas dtypes.
+
+    Arguments
+    ---------
+    encoded: JSON object mapping column name to dtype string.
+
+    Returns
+    -------
+    Column name to pandas dtype, suitable for `DataFrame.astype`.
+    """
+    return {
+        column: pd.api.types.pandas_dtype(dtype)
+        for column, dtype in json.loads(encoded).items()
+    }

--- a/src/afft/deployment/bundle_hdf_common.py
+++ b/src/afft/deployment/bundle_hdf_common.py
@@ -3,8 +3,7 @@ and read-write implementations."""
 
 import pandas as pd
 
-CONTENTS_KEY: str = "bundle_contents"
-RESERVED_KEYS: frozenset[str] = frozenset({CONTENTS_KEY})
+from .bundle_common import CONTENTS_KEY, empty_contents
 
 
 def coerce_storable_dtypes(frame: pd.DataFrame) -> pd.DataFrame:
@@ -44,12 +43,7 @@ def read_contents(store: pd.HDFStore) -> pd.DataFrame:
     """Read `bundle_contents`, or an empty frame of the right shape if the
     bundle has no tables yet."""
     if CONTENTS_KEY not in store:
-        return pd.DataFrame(
-            {
-                "identifier": pd.array([], dtype="object"),
-                "table_name": pd.array([], dtype="object"),
-            }
-        )
+        return empty_contents()
     return store.select(CONTENTS_KEY)
 
 
@@ -68,12 +62,41 @@ def resolve_table_name(store: pd.HDFStore, key: str) -> str:
     return str(matches.iloc[0])
 
 
-def append_contents_row(store: pd.HDFStore, key: str, table_name: str) -> None:
-    """Add one `(identifier, table_name)` row to `bundle_contents`,
-    creating the manifest table if this is the bundle's first frame."""
+def upsert_contents_row(
+    store: pd.HDFStore, key: str, table_name: str, dtypes: str
+) -> None:
+    """
+    Write the `bundle_contents` row for `key`, creating the manifest table if
+    this is the bundle's first frame.
+
+    The row is replaced in place if `key` is already registered, so a frame
+    rewritten with a different schema does not leave the manifest describing
+    the previous one, and a replacement does not reorder the manifest.
+
+    Arguments
+    ---------
+    store: Open store to write the manifest into.
+    key: The frame's identifier.
+    table_name: The frame's backend-specific table name.
+    dtypes: The frame's dtypes, encoded by `encode_frame_dtypes`.
+    """
     contents = read_contents(store)
-    row = pd.DataFrame({"identifier": [key], "table_name": [table_name]})
-    updated = pd.concat([contents, row], ignore_index=True)
+    existing = contents.index[contents["identifier"] == key]
+    if len(existing):
+        updated = contents.copy()
+        updated.loc[existing[0], ["table_name", "dtypes"]] = [
+            table_name,
+            dtypes,
+        ]
+    else:
+        row = pd.DataFrame(
+            {
+                "identifier": [key],
+                "table_name": [table_name],
+                "dtypes": [dtypes],
+            }
+        )
+        updated = pd.concat([contents, row], ignore_index=True)
     if CONTENTS_KEY in store:
         store.remove(CONTENTS_KEY)
     store.put(CONTENTS_KEY, updated, format="table")

--- a/src/afft/deployment/bundle_hdf_io.py
+++ b/src/afft/deployment/bundle_hdf_io.py
@@ -8,12 +8,12 @@ from typing import Iterator, Literal
 
 import pandas as pd
 
+from .bundle_common import RESERVED_KEYS, encode_frame_dtypes
 from .bundle_hdf_common import (
-    RESERVED_KEYS,
-    append_contents_row,
     coerce_storable_dtypes,
     read_contents,
     resolve_table_name,
+    upsert_contents_row,
 )
 
 
@@ -55,13 +55,18 @@ class HDFDeploymentBundleIO:
             raise ValueError(f"frame already exists at key: {key!r}")
 
         table_name = key  # HDF: table_name == key verbatim
+
+        # Record the frame's own dtypes, not the ones it is about to be
+        # coerced into -- the coercion is a storage limitation, and what it
+        # discards is unrecoverable once the frame is written.
+        dtypes = encode_frame_dtypes(frame)
+
         frame = coerce_storable_dtypes(frame)
         if exists:
             self.store.remove(table_name)
         self.store.put(table_name, frame, format="table")
 
-        if not exists:
-            append_contents_row(self.store, key, table_name)
+        upsert_contents_row(self.store, key, table_name, dtypes)
 
 
 @contextmanager

--- a/src/afft/deployment/bundle_hdf_readers.py
+++ b/src/afft/deployment/bundle_hdf_readers.py
@@ -8,8 +8,8 @@ from typing import Iterator
 
 import pandas as pd
 
+from .bundle_common import RESERVED_KEYS
 from .bundle_hdf_common import (
-    RESERVED_KEYS,
     read_contents,
     resolve_table_name,
 )

--- a/src/afft/deployment/bundle_hdf_writers.py
+++ b/src/afft/deployment/bundle_hdf_writers.py
@@ -8,11 +8,11 @@ from typing import Iterator, Literal
 
 import pandas as pd
 
+from .bundle_common import RESERVED_KEYS, encode_frame_dtypes
 from .bundle_hdf_common import (
-    RESERVED_KEYS,
-    append_contents_row,
     coerce_storable_dtypes,
     read_contents,
+    upsert_contents_row,
 )
 
 
@@ -42,13 +42,18 @@ class HDFDeploymentBundleWriter:
             raise ValueError(f"frame already exists at key: {key!r}")
 
         table_name = key  # HDF: table_name == key verbatim
+
+        # Record the frame's own dtypes, not the ones it is about to be
+        # coerced into -- the coercion is a storage limitation, and what it
+        # discards is unrecoverable once the frame is written.
+        dtypes = encode_frame_dtypes(frame)
+
         frame = coerce_storable_dtypes(frame)
         if exists:
             self.store.remove(table_name)
         self.store.put(table_name, frame, format="table")
 
-        if not exists:
-            append_contents_row(self.store, key, table_name)
+        upsert_contents_row(self.store, key, table_name, dtypes)
 
 
 @contextmanager

--- a/tests/test_deployment_bundle_common.py
+++ b/tests/test_deployment_bundle_common.py
@@ -1,0 +1,104 @@
+"""Tests for the storage-agnostic bundle manifest schema and dtype codec."""
+
+import json
+
+from datetime import datetime, timezone
+
+import pandas as pd
+import pytest
+
+from afft.deployment.bundle_common import (
+    CONTENTS_COLUMNS,
+    decode_frame_dtypes,
+    empty_contents,
+    encode_frame_dtypes,
+)
+
+
+def _frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": [datetime(2023, 10, 21, 3, tzinfo=timezone.utc)],
+            "count": pd.array([1], dtype="Int64"),
+            "measurement": pd.array([1.5], dtype="Float64"),
+            "flag": pd.array([True], dtype="boolean"),
+            "label": pd.array(["a"], dtype="string"),
+            "role": pd.Series(["sensor"], dtype="category"),
+        }
+    )
+
+
+def test_empty_contents_has_the_manifest_columns() -> None:
+    """An empty manifest carries the columns every backend writes."""
+    contents = empty_contents()
+    assert tuple(contents.columns) == CONTENTS_COLUMNS
+    assert contents.empty
+
+
+def test_encode_records_the_dtype_of_every_column() -> None:
+    """The encoding is a flat column-to-dtype-string JSON object."""
+    encoded = json.loads(encode_frame_dtypes(_frame()))
+    assert encoded == {
+        "timestamp": "datetime64[ns, UTC]",
+        "count": "Int64",
+        "measurement": "Float64",
+        "flag": "boolean",
+        "label": "string",
+        "role": "category",
+    }
+
+
+def test_dtypes_round_trip_through_the_codec() -> None:
+    """Every dtype the encoder writes is one the decoder accepts back."""
+    frame = _frame().drop(columns=["role"])
+    decoded = decode_frame_dtypes(encode_frame_dtypes(frame))
+    assert decoded == dict(frame.dtypes)
+
+
+def test_category_round_trips_without_its_labels() -> None:
+    """`category` records the dtype but not its label set; the labels are
+    re-derived from the stored values on read. Ordering is not lossy here
+    because `encode_frame_dtypes` refuses ordered categoricals outright."""
+    frame = _frame()
+    decoded = decode_frame_dtypes(encode_frame_dtypes(frame))
+
+    assert isinstance(decoded["role"], pd.CategoricalDtype)
+    assert decoded["role"].categories is None
+
+    # Applied to the values, the labels come back anyway.
+    restored = frame.astype({"role": decoded["role"]})
+    assert restored["role"].cat.categories.tolist() == ["sensor"]
+
+
+def test_decoded_dtypes_restore_a_coerced_frame() -> None:
+    """The decoded mapping is usable as an `astype` argument, which is how
+    a backend with a lossy write path would recover the logical dtypes."""
+    frame = _frame()
+    encoded = encode_frame_dtypes(frame)
+
+    coerced = frame.astype(
+        {"count": "int64", "flag": "bool", "label": "object"}
+    )
+    restored = coerced.astype(decode_frame_dtypes(encoded))
+
+    assert dict(restored.dtypes) == dict(frame.dtypes)
+
+
+def test_ordered_categorical_is_refused() -> None:
+    """An ordering the encoding cannot represent is rejected at write time
+    rather than silently dropped."""
+    frame = pd.DataFrame(
+        {
+            "grade": pd.Series(
+                ["low", "high"],
+                dtype=pd.CategoricalDtype(["low", "high"], ordered=True),
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="ordered categorical"):
+        encode_frame_dtypes(frame)
+
+
+def test_empty_frame_encodes_to_an_empty_object() -> None:
+    """A frame with no columns is distinguishable from an absent entry."""
+    assert encode_frame_dtypes(pd.DataFrame()) == "{}"

--- a/tests/test_deployment_bundle_hdf_io.py
+++ b/tests/test_deployment_bundle_hdf_io.py
@@ -1,5 +1,7 @@
 """Round-trip tests for the pandas.HDFStore deployment bundle implementation."""
 
+import json
+
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -129,6 +131,68 @@ def test_contents_manifest_tracks_identifier_and_table_name(
             "bundle",
             "deployment/identity",
         ]
+
+
+def test_contents_manifest_records_pre_coercion_dtypes(
+    tmp_path: Path,
+) -> None:
+    """The manifest records the dtypes the frame was written with, not the
+    plain-numpy ones `coerce_storable_dtypes` reduces them to."""
+    path = tmp_path / "bundle.h5"
+    frame = pd.DataFrame(
+        {
+            "count": pd.array([1], dtype="Int64"),
+            "flag": pd.array([True], dtype="boolean"),
+            "label": pd.array(["a"], dtype="string"),
+        }
+    )
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", frame)
+
+    with open_deployment_bundle_reader(path) as reader:
+        recorded = json.loads(reader.contents()["dtypes"].iloc[0])
+        assert recorded == {
+            "count": "Int64",
+            "flag": "boolean",
+            "label": "string",
+        }
+        # The frame itself still reads back coerced -- the HDF backend
+        # records what it discarded without undoing it.
+        assert reader.read_frame("bundle")["count"].dtype == "int64"
+
+
+def test_replacing_a_frame_updates_its_recorded_dtypes(
+    tmp_path: Path,
+) -> None:
+    """A frame rewritten with a different schema leaves no stale manifest
+    entry describing the previous one."""
+    path = tmp_path / "bundle.h5"
+    original = pd.DataFrame({"count": pd.array([1], dtype="Int64")})
+    replacement = pd.DataFrame({"label": pd.array(["a"], dtype="string")})
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("bundle", original)
+        writer.write_frame("bundle", replacement, if_exists="replace")
+
+    with open_deployment_bundle_reader(path) as reader:
+        contents = reader.contents()
+        assert len(contents) == 1
+        assert json.loads(contents["dtypes"].iloc[0]) == {"label": "string"}
+
+
+def test_replacing_a_frame_preserves_manifest_order(tmp_path: Path) -> None:
+    """Replacing a frame updates its row in place rather than moving it to
+    the end of the manifest."""
+    path = tmp_path / "bundle.h5"
+
+    with open_deployment_bundle_writer(path) as writer:
+        writer.write_frame("first", _frame())
+        writer.write_frame("second", _frame())
+        writer.write_frame("first", _frame(), if_exists="replace")
+
+    with open_deployment_bundle_reader(path) as reader:
+        assert reader.list_frames() == ["first", "second"]
 
 
 def test_write_frame_coerces_extension_dtypes(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds a `dtypes` column to the `bundle_contents` manifest, so a bundle records the pandas dtypes each frame was written with. This settles the manifest schema before the SQLite backend in #222 is written against it.

**Manifest schema**

- `bundle_contents` gains `dtypes`, a flat JSON object mapping column name to pandas dtype string. Both `write_frame` implementations encode `frame.dtypes` **before** `coerce_storable_dtypes` runs, so what is recorded is the logical dtype rather than the plain-numpy one HDF5 reduces it to.
- The HDF5 read path is unchanged and still returns the coerced frame. Recording the dtypes does not make the backend lossless, it makes the loss recoverable — a frame written with `Int64` still reads back `int64`, but the manifest now says `Int64`.
- New `bundle_common.py` holds the format constants, the manifest schema, and the dtype codec. `bundle_hdf_common.py` keeps `coerce_storable_dtypes` and the `HDFStore`-typed accessors. The schema belongs to the format, not to one backend, so it is defined once.

**Manifest rows are upserted**

`append_contents_row` ran only when a frame was new, which was harmless while the row held nothing that could change between writes. With `dtypes` on the row it becomes a bug: a frame rewritten with a different schema would keep a manifest entry describing the previous one. That is not hypothetical — `pipeline_runners` copies every source frame forward and then overwrites the processed keys, which is exactly a schema change.

It is now `upsert_contents_row`, called on every write. The row is updated in place rather than removed and re-appended, so replacing a frame does not reorder the manifest.

**Ordered categoricals are refused**

`encode_frame_dtypes` raises on an ordered categorical. The encoding cannot carry the ordering, and a backend restoring from `"category"` would return an unordered categorical whose comparisons raise rather than order — a silent change of meaning rather than a loss of detail. Declared-but-unused category labels remain lossy and are accepted as such; no frame in the codebase has one, and object-valued manifest entries are a clean additive migration if that changes.

**Compatibility**

None. Bundles written before this change have a two-column manifest and are not readable afterwards. The corpus is rebuilt rather than accommodated, per the issue.

Also gives `bundle_batch_build.sh` the `set -euo pipefail` block the process script already has, so a batch build stops at the failing deployment.

## Verification

- `ruff check`, `ruff format`, and `mypy` clean across `src` and `tests`.
- 321 tests pass, 9 of them new: the codec round-trip, the ordered-categorical refusal, the category label-set limitation, the manifest recording pre-coercion dtypes, and replacement both updating the recorded dtypes and preserving manifest order.
- Checked end to end against a real bundle: a frame written with `Int64`/`boolean`/`category` columns records `{"count": "Int64", "flag": "boolean", "sensor_key": "category"}` in the manifest while reading back as `int64`/`bool`/`category`.

Closes #241
