### PR TITLE
Add a bundle list command

### DIFF
--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -2,6 +2,14 @@
 
 from pathlib import Path
 
+import pandas as pd
+
+from afft.deployment import (
+    decode_frame_dtypes,
+    open_deployment_bundle_reader,
+)
+from afft.utils.log import logger
+
 from afft.tasks.build_deployment_bundle import (
     BuildDeploymentBundleCommand,
     read_build_deployment_bundle_config,
@@ -34,6 +42,38 @@ def dispatch_build_deployment_bundle(
     )
     config = read_build_deployment_bundle_config(command.config_file)
     run_build_deployment_bundle(command, config)
+
+
+def dispatch_list_deployment_bundle(
+    input_file: str | Path,
+    dtypes: bool = False,
+) -> None:
+    """
+    List the frames a deployment bundle holds, as recorded in its
+    `bundle_contents` manifest.
+
+    Arguments
+    ---------
+    input_file: Path to the deployment bundle to list.
+    dtypes: Also log each frame's recorded column dtypes.
+    """
+    input_file = Path(input_file)
+    with open_deployment_bundle_reader(input_file) as reader:
+        contents: pd.DataFrame = reader.contents()
+
+    logger.info("-------------------------------------")
+    logger.info("Deployment Bundle Contents")
+    logger.info(f"  input file: {input_file}")
+    logger.info(f"  frames:     {len(contents)}")
+    logger.info("-------------------------------------")
+
+    for row in contents.itertuples(index=False):
+        logger.info(f"{row.identifier}")
+        if row.table_name != row.identifier:
+            logger.info(f"  table: {row.table_name}")
+        if dtypes:
+            for column, dtype in decode_frame_dtypes(row.dtypes).items():
+                logger.info(f"  {column}: {dtype}")
 
 
 def dispatch_process_deployment_bundle(

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -4,6 +4,7 @@ import click
 
 from .actions import (
     dispatch_build_deployment_bundle,
+    dispatch_list_deployment_bundle,
     dispatch_process_deployment_bundle,
 )
 
@@ -82,6 +83,25 @@ def build(
         overwrite,
         verbose,
     )
+
+
+@bundle_group.command("list")
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment bundle to list",
+)
+@click.option(
+    "--dtypes",
+    is_flag=True,
+    default=False,
+    help="also list each frame's recorded column dtypes",
+)
+def list_contents(input_file: str, dtypes: bool) -> None:
+    """List the frames a deployment bundle holds."""
+    dispatch_list_deployment_bundle(input_file, dtypes)
 
 
 @bundle_group.command()


### PR DESCRIPTION
## Summary

Adds `afft bundle list --input <bundle>`, which logs the frames a deployment bundle holds straight from its `bundle_contents` manifest.

- `--dtypes` additionally logs each frame's recorded column dtypes. That is the only way to see what a frame was written with, since the HDF5 read path returns the coerced dtypes rather than the recorded ones.
- The action opens the reader and reads the manifest directly rather than going through a task module. There is nothing to configure, stage, or diagnose, so a task would be indirection without a purpose.
- `table_name` is logged only when it differs from `identifier`, which on the HDF5 backend is never. It is there for #222, where table-name sanitisation could make the two diverge.
- Output goes through `logger.info`, matching the banner style in `summary_runner.py` — there is no `click.echo` or `print` anywhere in `src/afft/cli`.

`encode_frame_dtypes` and `decode_frame_dtypes` are exported from `afft.deployment` so the action imports from the package rather than reaching into `bundle_common`.

## Verification

- `ruff check`, `ruff format`, and `mypy` clean across `src` and `tests`.
- 321 tests pass. No new tests: the command is a manifest read and a log loop, and the manifest it reads is covered by #241's tests.
- Exercised against a two-frame bundle, with and without `--dtypes`.

## Note

Stacked on #242 — this depends on the `dtypes` manifest column and the codec it adds, so it cannot build against `integration/deployment-bundle` alone. Based on `feature/hdf-manifest-dtypes`; GitHub retargets it to the integration branch once #242 merges.
