### PR TITLE
Add USBL processors to the bundle processing pipeline

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -47,3 +47,21 @@ config.velocity_z_uncertainty = 0.003
 config.roll_uncertainty       = 0.50
 config.pitch_uncertainty      = 0.50
 config.heading_uncertainty    = 2.00
+
+# USBL steps are optional: no deployment carries both transceivers, and the
+# earlier ones carry neither. Omit inputs.extrinsics for a deployment whose
+# readings were already corrected for the transceiver mounting.
+[[afft.tasks.process_deployment_bundle.pipeline.steps]]
+processor         = "process_tracklink_usbl_from_messages"
+output            = "telemetry/processed/usbl_linkquest_transponder/LQMODEM/messages"
+inputs.usbl       = "telemetry/raw/usbl_linkquest_transponder/LQMODEM/messages"
+inputs.pressure   = "telemetry/raw/pressure_parosci/PAROSCI/messages"
+inputs.extrinsics = "vessel/sensors/usbl_linkquest_transceiver/extrinsics"
+optional          = true
+
+# [[afft.tasks.process_deployment_bundle.pipeline.steps]]
+# processor         = "process_evologics_usbl"
+# output            = "telemetry/processed/usbl_evologics_transponder/EVOLOGICS_FIX/messages"
+# inputs.usbl       = "telemetry/raw/usbl_evologics_transponder/EVOLOGICS_FIX/messages"
+# inputs.extrinsics = "vessel/sensors/usbl_evologics_transceiver/extrinsics"
+# optional          = true

--- a/src/afft/bundle_processing/pipeline_builders.py
+++ b/src/afft/bundle_processing/pipeline_builders.py
@@ -56,6 +56,7 @@ def build_pipeline(
                 config=step_config_model,
                 inputs=dict(step_config.inputs),
                 output=step_config.output,
+                optional=step_config.optional,
             )
         )
 

--- a/src/afft/bundle_processing/pipeline_runners.py
+++ b/src/afft/bundle_processing/pipeline_runners.py
@@ -27,6 +27,10 @@ def run_pipeline(
         the source of every step's inputs.
     verbose: Log each step's output key as it is written.
 
+    A step marked optional is skipped when one of its input keys is absent,
+    on the reading that the deployment does not carry that sensor. The skip
+    is logged with the missing key, since a mistyped key looks the same.
+
     Raises
     ------
     PipelineStepError: If a step fails, naming the step and chaining the
@@ -36,6 +40,17 @@ def run_pipeline(
         target.write_frame(key, source.read_frame(key))
 
     for index, step in enumerate(pipeline):
+        missing: str | None = next(
+            (key for key in step.inputs.values() if not target.has_frame(key)),
+            None,
+        )
+        if step.optional and missing is not None:
+            logger.info(
+                f"pipeline step {index} ({step.processor_key}) skipped: "
+                f"{missing} is not in the bundle"
+            )
+            continue
+
         try:
             frames = {
                 name: target.read_frame(key)

--- a/src/afft/bundle_processing/pipeline_types.py
+++ b/src/afft/bundle_processing/pipeline_types.py
@@ -26,6 +26,8 @@ class PipelineStep:
     config: The processor's config, already constructed as its typed model.
     inputs: Maps each processor argument name to the bundle key supplying it.
     output: Bundle key the resulting frame is written to.
+    optional: Whether the step is skipped when an input key is absent, rather
+        than failing the run.
     """
 
     processor_key: str
@@ -33,6 +35,7 @@ class PipelineStep:
     config: BaseModel
     inputs: Mapping[str, str]
     output: str
+    optional: bool = False
 
 
 type Pipeline = tuple[PipelineStep, ...]
@@ -49,6 +52,9 @@ class PipelineStepConfig(BaseModel):
     inputs: Maps each processor argument name to the bundle key supplying it.
     config: Raw config table, constructed as the processor's config type by
         the builder.
+    optional: Whether the step is skipped when an input key is absent, rather
+        than failing the run. Set it for a step whose sensor is not on every
+        deployment.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -57,6 +63,7 @@ class PipelineStepConfig(BaseModel):
     output: str
     inputs: dict[str, str]
     config: dict[str, Any] = {}
+    optional: bool = False
 
 
 class PipelineConfig(BaseModel):

--- a/src/afft/bundle_processing/pipeline_validators.py
+++ b/src/afft/bundle_processing/pipeline_validators.py
@@ -15,13 +15,20 @@ def validate_pipeline(pipeline: Pipeline, available: Set[str]) -> None:
     pipeline: The resolved steps, in run order.
     available: Keys present before the first step -- the input bundle's.
 
+    An optional step is exempt: a missing input means the deployment does not
+    carry that sensor, which the runner skips rather than fails. Its output is
+    still counted as produced, since whether it runs is not known until then.
+
     Raises
     ------
-    ValueError: If a step names an input key that no earlier step produces
-        and the input bundle does not hold.
+    ValueError: If a required step names an input key that no earlier step
+        produces and the input bundle does not hold.
     """
     produced: set[str] = set(available)
     for index, step in enumerate(pipeline):
+        if step.optional:
+            produced.add(step.output)
+            continue
         for name, key in step.inputs.items():
             if key not in produced:
                 raise ValueError(

--- a/src/afft/bundle_processing/sensor_processors.py
+++ b/src/afft/bundle_processing/sensor_processors.py
@@ -144,7 +144,7 @@ def step_estimate_dvl_uncertainty(
     "process_tracklink_usbl_from_messages",
     config_type=TrackLinkProcessingFromMessagesConfig,
 )
-def step_process_tracklink_usbl_from_messages(
+def step_process_tracklink_usbl(
     frames: Mapping[str, pd.DataFrame],
     config: TrackLinkProcessingFromMessagesConfig,
 ) -> pd.DataFrame:

--- a/src/afft/bundle_processing/sensor_processors.py
+++ b/src/afft/bundle_processing/sensor_processors.py
@@ -3,8 +3,11 @@
 function's natural signature."""
 
 from collections.abc import Mapping
+from typing import TypeVar
 
 import pandas as pd
+
+from pydantic import BaseModel, ValidationError
 
 from afft.sensors.acfr_vision import (
     StereoPairingConfig,
@@ -19,8 +22,90 @@ from afft.sensors.pressure_parosci import (
     PressureUncertaintyConfig,
     estimate_pressure_uncertainty,
 )
+from afft.sensors.usbl_evologics import (
+    EvologicsProcessingConfig,
+    EvologicsTransceiverExtrinsics,
+    process_evologics_usbl,
+)
+from afft.sensors.usbl_linkquest import (
+    TrackLinkProcessingFromMessagesConfig,
+    TrackLinkTransceiverExtrinsics,
+    process_tracklink_usbl_from_messages,
+)
+from afft.utils.log import logger
 
 from .processor_registry import register_processor
+
+Extrinsics = TypeVar("Extrinsics", bound=BaseModel)
+
+
+def _decode_extrinsics(
+    frames: Mapping[str, pd.DataFrame],
+    extrinsics_type: type[Extrinsics],
+    processor_key: str,
+) -> Extrinsics | None:
+    """
+    Decode the one-row extrinsics frame into `extrinsics_type`.
+
+    Absence of the `extrinsics` input is the signal to run without an
+    extrinsics correction, for deployments whose readings were already
+    corrected upstream. Which of the two happened is logged, since a mistyped
+    input key is indistinguishable from a deliberate omission.
+
+    The decode is strict. A frame that is empty, holds more than one row, or
+    does not carry exactly the expected fields means the bundle was built
+    wrong, and taking the first row regardless would shift every resulting
+    position by a plausible-looking amount.
+
+    Arguments
+    ---------
+    frames: The step's inputs, keyed by processor argument name.
+    extrinsics_type: The sensor's extrinsics model.
+    processor_key: Registered processor name, for the log lines.
+
+    Returns
+    -------
+    The decoded extrinsics, or None when the input was not supplied.
+
+    Raises
+    ------
+    ValueError: If the frame does not hold exactly one row, or its columns do
+        not match `extrinsics_type`.
+    """
+    frame: pd.DataFrame | None = frames.get("extrinsics")
+    if frame is None:
+        logger.info(
+            f"{processor_key}: no extrinsics input; running without an "
+            f"extrinsics correction"
+        )
+        return None
+
+    if len(frame) != 1:
+        raise ValueError(
+            f"{processor_key}: extrinsics frame holds {len(frame)} rows, "
+            f"expected exactly 1"
+        )
+
+    # Every field carries a default, so a frame missing a column would
+    # otherwise decode to a silent zero for that axis.
+    expected: set[str] = set(extrinsics_type.model_fields)
+    if set(frame.columns) != expected:
+        raise ValueError(
+            f"{processor_key}: extrinsics frame does not match "
+            f"{extrinsics_type.__name__}: columns are "
+            f"{sorted(frame.columns)}, expected {sorted(expected)}"
+        )
+
+    try:
+        extrinsics: Extrinsics = extrinsics_type(**frame.iloc[0].to_dict())
+    except ValidationError as error:
+        raise ValueError(
+            f"{processor_key}: extrinsics frame does not match "
+            f"{extrinsics_type.__name__}: {error}"
+        ) from error
+
+    logger.info(f"{processor_key}: applying extrinsics from the bundle")
+    return extrinsics
 
 
 @register_processor("pair_stereo_images", config_type=StereoPairingConfig)
@@ -53,3 +138,38 @@ def step_estimate_dvl_uncertainty(
 ) -> pd.DataFrame:
     """Add per-axis velocity and attitude uncertainty columns to a DVL frame."""
     return estimate_dvl_uncertainty(frames["df"], config)
+
+
+@register_processor(
+    "process_tracklink_usbl_from_messages",
+    config_type=TrackLinkProcessingFromMessagesConfig,
+)
+def step_process_tracklink_usbl_from_messages(
+    frames: Mapping[str, pd.DataFrame],
+    config: TrackLinkProcessingFromMessagesConfig,
+) -> pd.DataFrame:
+    """Resolve TrackLink USBL positions, correcting for the transceiver
+    extrinsics the bundle carries."""
+    extrinsics: TrackLinkTransceiverExtrinsics | None = _decode_extrinsics(
+        frames,
+        TrackLinkTransceiverExtrinsics,
+        "process_tracklink_usbl_from_messages",
+    )
+    return process_tracklink_usbl_from_messages(
+        frames["usbl"], frames["pressure"], extrinsics, config
+    )
+
+
+@register_processor(
+    "process_evologics_usbl", config_type=EvologicsProcessingConfig
+)
+def step_process_evologics_usbl(
+    frames: Mapping[str, pd.DataFrame],
+    config: EvologicsProcessingConfig,
+) -> pd.DataFrame:
+    """Resolve Evologics USBL positions, correcting for the transceiver
+    extrinsics the bundle carries."""
+    extrinsics: EvologicsTransceiverExtrinsics | None = _decode_extrinsics(
+        frames, EvologicsTransceiverExtrinsics, "process_evologics_usbl"
+    )
+    return process_evologics_usbl(frames["usbl"], extrinsics, config)

--- a/src/afft/cli/sensors/actions.py
+++ b/src/afft/cli/sensors/actions.py
@@ -58,8 +58,9 @@ def dispatch_process_tracklink_usbl_from_messages(
         f"{deployment.date}, sensor_keys={list(deployment.sensor_keys)}"
     )
 
+    extrinsics: TrackLinkTransceiverExtrinsics | None
     if ignore_extrinsics:
-        extrinsics = TrackLinkTransceiverExtrinsics()
+        extrinsics = None
         logger.info("USBL transceiver extrinsics: ignored (zero extrinsics)")
     else:
         extrinsics = TrackLinkTransceiverExtrinsics(
@@ -77,9 +78,7 @@ def dispatch_process_tracklink_usbl_from_messages(
             f"rotz={extrinsics.rotz:.4f}) rad"
         )
     config = TrackLinkProcessingFromMessagesConfig(
-        resolve=TrackLinkResolvePositionFromMessagesConfig(
-            extrinsics=extrinsics
-        ),
+        resolve=TrackLinkResolvePositionFromMessagesConfig(),
         uncertainty=TrackLinkUncertaintyConfig(
             horizontal_position_std=deployment.usbl_uncertainty.horizontal_position_std,
             depth_position_std=deployment.usbl_uncertainty.slant_range_std,
@@ -90,7 +89,7 @@ def dispatch_process_tracklink_usbl_from_messages(
     pressure: pd.DataFrame = pd.read_csv(Path(pressure_file))
 
     result: pd.DataFrame = process_tracklink_usbl_from_messages(
-        usbl, pressure, config
+        usbl, pressure, extrinsics, config
     )
 
     output_path: Path = Path(output_file)
@@ -115,8 +114,9 @@ def dispatch_process_tracklink_usbl_from_logs(
         f"{deployment.date}, sensor_keys={list(deployment.sensor_keys)}"
     )
 
+    extrinsics: TrackLinkTransceiverExtrinsics | None
     if ignore_extrinsics:
-        extrinsics = TrackLinkTransceiverExtrinsics()
+        extrinsics = None
         logger.info("USBL transceiver extrinsics: ignored (zero extrinsics)")
     else:
         extrinsics = TrackLinkTransceiverExtrinsics(
@@ -134,7 +134,7 @@ def dispatch_process_tracklink_usbl_from_logs(
             f"rotz={extrinsics.rotz:.4f}) rad"
         )
     config = TrackLinkProcessingFromLogsConfig(
-        resolve=TrackLinkResolvePositionFromLogsConfig(extrinsics=extrinsics),
+        resolve=TrackLinkResolvePositionFromLogsConfig(),
         uncertainty=TrackLinkUncertaintyConfig(
             horizontal_position_std=deployment.usbl_uncertainty.horizontal_position_std,
             depth_position_std=deployment.usbl_uncertainty.slant_range_std,
@@ -144,7 +144,9 @@ def dispatch_process_tracklink_usbl_from_logs(
     usbl: pd.DataFrame = pd.read_csv(Path(usbl_file))
 
     try:
-        result: pd.DataFrame = process_tracklink_usbl_from_logs(usbl, config)
+        result: pd.DataFrame = process_tracklink_usbl_from_logs(
+            usbl, extrinsics, config
+        )
     except ValueError as error:
         logger.error(f"skipping {Path(usbl_file).name}: {error}")
         return
@@ -162,7 +164,7 @@ def dispatch_process_evologics_usbl(
     deployment_label: str,
     ignore_extrinsics: bool = False,
 ) -> None:
-    """Convert Evologics USBL data to the unified USBL output schema."""
+    """Convert Evologics USBL data to the USBL output schema."""
     deployment = load_deployment_config(
         Path(deployment_configs), deployment_label
     )
@@ -171,8 +173,9 @@ def dispatch_process_evologics_usbl(
         f"{deployment.date}, sensor_keys={list(deployment.sensor_keys)}"
     )
 
+    extrinsics: EvologicsTransceiverExtrinsics | None
     if ignore_extrinsics:
-        extrinsics = EvologicsTransceiverExtrinsics()
+        extrinsics = None
         logger.info("USBL transceiver extrinsics: ignored (zero extrinsics)")
     else:
         extrinsics = EvologicsTransceiverExtrinsics(
@@ -191,13 +194,12 @@ def dispatch_process_evologics_usbl(
         )
 
     config = EvologicsProcessingConfig(
-        extrinsics=extrinsics,
         horizontal_position_std=deployment.usbl_uncertainty.horizontal_position_std,
         depth_position_std=deployment.usbl_uncertainty.slant_range_std,
     )
 
     usbl: pd.DataFrame = pd.read_csv(Path(usbl_file))
-    result: pd.DataFrame = process_evologics_usbl(usbl, config)
+    result: pd.DataFrame = process_evologics_usbl(usbl, extrinsics, config)
 
     output_path: Path = Path(output_file)
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/afft/cli/sensors/commands.py
+++ b/src/afft/cli/sensors/commands.py
@@ -196,7 +196,7 @@ def process_evologics_usbl(
     deployment_label: str,
     ignore_extrinsics: bool,
 ) -> None:
-    """Convert Evologics USBL data to the unified USBL output schema."""
+    """Convert Evologics USBL data to the USBL output schema."""
     dispatch_process_evologics_usbl(
         usbl_file,
         output_file,

--- a/src/afft/sensors/usbl_evologics/processors.py
+++ b/src/afft/sensors/usbl_evologics/processors.py
@@ -21,9 +21,13 @@ _RFU_TO_FRD: NDArray[np.float64] = np.array(
 
 def process_evologics_usbl(
     usbl: pd.DataFrame,
+    extrinsics: EvologicsTransceiverExtrinsics | None = None,
     config: EvologicsProcessingConfig = EvologicsProcessingConfig(),
 ) -> pd.DataFrame:
-    """Convert Evologics USBL data to the unified USBL output schema.
+    """Convert Evologics USBL data to the USBL output schema.
+
+    The schema is a core shared with the other USBL sensors, plus the
+    sensor-specific `evologics_accuracy`.
 
     Applies the USBL-Frame → Vessel-Frame transformation to target_x/y/z,
     derives geometric quantities, assigns deployment-calibrated uncertainty
@@ -43,7 +47,8 @@ def process_evologics_usbl(
           target_horizontal_range, target_inclination_angle,
           horizontal_position_std, depth_position_std, evologics_accuracy,
           usbl_extrinsics_locx, usbl_extrinsics_locy, usbl_extrinsics_locz,
-          usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz.
+          usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz,
+          usbl_extrinsics_applied, usbl_extrinsics_rotation_units.
     Removes: accuracy (renamed to evologics_accuracy).
 
     target_depth, target_latitude, and target_longitude are the modem-reported
@@ -51,14 +56,22 @@ def process_evologics_usbl(
     derived from the ship position, ship attitude, and transceiver extrinsics
     via the NED → geodetic chain (pymap3d.ned2geodetic).
 
+    Extrinsics rotations are recorded in the output in degrees, so that every
+    angle in the resulting table shares one unit, with
+    `usbl_extrinsics_rotation_units` stating it explicitly.
+
     Arguments
     ---------
     usbl: Parsed Evologics USBL DataFrame with USBL-Frame target_x/y/z.
-    config: Processing configuration with optional extrinsics and uncertainty values.
+    extrinsics: Transceiver extrinsics in the ship body frame. When None, no
+        extrinsics correction is applied -- only the USBL-Frame flip -- and
+        `usbl_extrinsics_applied` is False. Omit it for deployments whose
+        readings were already corrected upstream.
+    config: Processing configuration with uncertainty values.
 
     Returns
     -------
-    DataFrame conforming to the unified USBL output schema.
+    DataFrame conforming to the USBL output schema.
     """
     result: pd.DataFrame = usbl.copy()
 
@@ -78,11 +91,9 @@ def process_evologics_usbl(
         np.arcsin(np.clip(depth_rel / slant_range, -1.0, 1.0))
     )
 
-    extrinsics: EvologicsTransceiverExtrinsics = (
-        config.extrinsics
-        if config.extrinsics is not None
-        else EvologicsTransceiverExtrinsics()
-    )
+    extrinsics_applied: bool = extrinsics is not None
+    if extrinsics is None:
+        extrinsics = EvologicsTransceiverExtrinsics()
 
     # Apply frame flip (USBL-Frame → intermediate aligned with vessel axes).
     target_flipped: NDArray[np.float64] = (_RFU_TO_FRD @ target_xyz_usbl.T).T
@@ -155,9 +166,11 @@ def process_evologics_usbl(
     result["usbl_extrinsics_locx"] = extrinsics.locx
     result["usbl_extrinsics_locy"] = extrinsics.locy
     result["usbl_extrinsics_locz"] = extrinsics.locz
-    result["usbl_extrinsics_rotx"] = extrinsics.rotx
-    result["usbl_extrinsics_roty"] = extrinsics.roty
-    result["usbl_extrinsics_rotz"] = extrinsics.rotz
+    result["usbl_extrinsics_rotx"] = np.degrees(extrinsics.rotx)
+    result["usbl_extrinsics_roty"] = np.degrees(extrinsics.roty)
+    result["usbl_extrinsics_rotz"] = np.degrees(extrinsics.rotz)
+    result["usbl_extrinsics_applied"] = extrinsics_applied
+    result["usbl_extrinsics_rotation_units"] = "degrees"
     result = result.rename(columns={"accuracy": "evologics_accuracy"})
 
     return result

--- a/src/afft/sensors/usbl_evologics/types.py
+++ b/src/afft/sensors/usbl_evologics/types.py
@@ -61,14 +61,11 @@ class EvologicsProcessingConfig(BaseModel):
 
     Attributes
     ----------
-    extrinsics: Transceiver extrinsics in the ship body frame. When None,
-        only the USBL-Frame flip is applied (no rotation or translation).
     horizontal_position_std: 1σ horizontal position uncertainty in metres.
     depth_position_std: 1σ depth uncertainty in metres.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    extrinsics: EvologicsTransceiverExtrinsics | None = None
     horizontal_position_std: float = 15.8
     depth_position_std: float = 5.0

--- a/src/afft/sensors/usbl_linkquest/processors.py
+++ b/src/afft/sensors/usbl_linkquest/processors.py
@@ -24,6 +24,7 @@ _NS_PER_S: float = 1e9
 def resolve_target_position_from_messages(
     usbl: pd.DataFrame,
     pressure: pd.DataFrame,
+    extrinsics: TrackLinkTransceiverExtrinsics | None = None,
     config: TrackLinkResolvePositionFromMessagesConfig = TrackLinkResolvePositionFromMessagesConfig(),
 ) -> pd.DataFrame:
     """Resolve AUV lat/lon from TrackLink USBL bearing, slant range, and depth.
@@ -32,9 +33,13 @@ def resolve_target_position_from_messages(
     The raw bearing is treated as an azimuth in the transceiver body frame
     (0 = transceiver forward, clockwise). The ZYX attitude chain is applied:
     transceiver → ship body (via extrinsics rotation) → NED (via ship attitude).
-    When config.extrinsics is None a zero-offset, zero-rotation transceiver is
+    When `extrinsics` is None a zero-offset, zero-rotation transceiver is
     used, so bearing is relative to the ship bow and heading is applied via the
-    rotation chain.
+    rotation chain, and `usbl_extrinsics_applied` is False.
+
+    Extrinsics rotations are recorded in the output in degrees, so that every
+    angle in the resulting table shares one unit, with
+    `usbl_extrinsics_rotation_units` stating it explicitly.
 
     The transceiver geodetic position is computed by rotating the body-frame
     translation through the ship attitude and calling pymap3d.ned2geodetic.
@@ -46,18 +51,17 @@ def resolve_target_position_from_messages(
                   target_horizontal_range, target_inclination_angle,
                   target_latitude, target_longitude, target_height,
                   usbl_extrinsics_locx, usbl_extrinsics_locy, usbl_extrinsics_locz,
-                  usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz.
+                  usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz,
+                  usbl_extrinsics_applied, usbl_extrinsics_rotation_units.
     """
     _validate_time_alignment(usbl, pressure, config)
 
     result: pd.DataFrame = usbl.copy()
     result["target_depth"] = _interpolate_depth(usbl, pressure, config)
 
-    extrinsics: TrackLinkTransceiverExtrinsics = (
-        config.extrinsics
-        if config.extrinsics is not None
-        else TrackLinkTransceiverExtrinsics()
-    )
+    extrinsics_applied: bool = extrinsics is not None
+    if extrinsics is None:
+        extrinsics = TrackLinkTransceiverExtrinsics()
 
     ship_attitudes_ypr: NDArray[np.float64] = np.column_stack(
         [
@@ -154,9 +158,11 @@ def resolve_target_position_from_messages(
     result["usbl_extrinsics_locx"] = extrinsics.locx
     result["usbl_extrinsics_locy"] = extrinsics.locy
     result["usbl_extrinsics_locz"] = extrinsics.locz
-    result["usbl_extrinsics_rotx"] = extrinsics.rotx
-    result["usbl_extrinsics_roty"] = extrinsics.roty
-    result["usbl_extrinsics_rotz"] = extrinsics.rotz
+    result["usbl_extrinsics_rotx"] = np.degrees(extrinsics.rotx)
+    result["usbl_extrinsics_roty"] = np.degrees(extrinsics.roty)
+    result["usbl_extrinsics_rotz"] = np.degrees(extrinsics.rotz)
+    result["usbl_extrinsics_applied"] = extrinsics_applied
+    result["usbl_extrinsics_rotation_units"] = "degrees"
 
     return result
 
@@ -188,6 +194,7 @@ def estimate_usbl_uncertainty(
 def process_tracklink_usbl_from_messages(
     usbl: pd.DataFrame,
     pressure: pd.DataFrame,
+    extrinsics: TrackLinkTransceiverExtrinsics | None = None,
     config: TrackLinkProcessingFromMessagesConfig = TrackLinkProcessingFromMessagesConfig(),
 ) -> pd.DataFrame:
     """Resolve positions and estimate uncertainty from TrackLink AUV messages.
@@ -196,6 +203,9 @@ def process_tracklink_usbl_from_messages(
     ---------
     usbl: TrackLink USBL observations with bearing, range, and ship position.
     pressure: Pressure sensor depth readings to interpolate at USBL timestamps.
+    extrinsics: Transceiver extrinsics in the ship body frame. When None, no
+        extrinsics correction is applied. Omit it for deployments whose
+        readings were already corrected upstream.
     config: Combined configuration for position resolution and uncertainty estimation.
 
     Returns
@@ -203,7 +213,7 @@ def process_tracklink_usbl_from_messages(
     DataFrame with resolved target positions and uncertainty columns.
     """
     result: pd.DataFrame = resolve_target_position_from_messages(
-        usbl, pressure, config.resolve
+        usbl, pressure, extrinsics, config.resolve
     )
     result = estimate_usbl_uncertainty(result, config.uncertainty)
     return result
@@ -211,14 +221,20 @@ def process_tracklink_usbl_from_messages(
 
 def resolve_target_position_from_logs(
     usbl: pd.DataFrame,
+    extrinsics: TrackLinkTransceiverExtrinsics | None = None,
     config: TrackLinkResolvePositionFromLogsConfig = TrackLinkResolvePositionFromLogsConfig(),
 ) -> pd.DataFrame:
     """Resolve AUV lat/lon from TrackLink USBL log entries with target XYZ.
 
     Target XYZ in the sensor frame is taken directly from the log DataFrame.
     The ZYX attitude chain is applied: transceiver → ship body (via extrinsics
-    rotation) → NED (via ship attitude). When config.extrinsics is None a
-    zero-offset, zero-rotation transceiver is assumed.
+    rotation) → NED (via ship attitude). When `extrinsics` is None a
+    zero-offset, zero-rotation transceiver is assumed, and
+    `usbl_extrinsics_applied` is False.
+
+    Extrinsics rotations are recorded in the output in degrees, so that every
+    angle in the resulting table shares one unit, with
+    `usbl_extrinsics_rotation_units` stating it explicitly.
 
     The transceiver geodetic position is computed by rotating the body-frame
     translation through the ship attitude and calling pymap3d.ned2geodetic.
@@ -230,17 +246,16 @@ def resolve_target_position_from_logs(
                   target_horizontal_range, target_inclination_angle,
                   target_latitude, target_longitude, target_height,
                   usbl_extrinsics_locx, usbl_extrinsics_locy, usbl_extrinsics_locz,
-                  usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz.
+                  usbl_extrinsics_rotx, usbl_extrinsics_roty, usbl_extrinsics_rotz,
+                  usbl_extrinsics_applied, usbl_extrinsics_rotation_units.
     """
     _validate_logs_contain_target_xyz(usbl, config)
 
     result: pd.DataFrame = usbl.copy()
 
-    extrinsics: TrackLinkTransceiverExtrinsics = (
-        config.extrinsics
-        if config.extrinsics is not None
-        else TrackLinkTransceiverExtrinsics()
-    )
+    extrinsics_applied: bool = extrinsics is not None
+    if extrinsics is None:
+        extrinsics = TrackLinkTransceiverExtrinsics()
 
     ship_attitudes_ypr: NDArray[np.float64] = np.column_stack(
         [
@@ -334,15 +349,18 @@ def resolve_target_position_from_logs(
     result["usbl_extrinsics_locx"] = extrinsics.locx
     result["usbl_extrinsics_locy"] = extrinsics.locy
     result["usbl_extrinsics_locz"] = extrinsics.locz
-    result["usbl_extrinsics_rotx"] = extrinsics.rotx
-    result["usbl_extrinsics_roty"] = extrinsics.roty
-    result["usbl_extrinsics_rotz"] = extrinsics.rotz
+    result["usbl_extrinsics_rotx"] = np.degrees(extrinsics.rotx)
+    result["usbl_extrinsics_roty"] = np.degrees(extrinsics.roty)
+    result["usbl_extrinsics_rotz"] = np.degrees(extrinsics.rotz)
+    result["usbl_extrinsics_applied"] = extrinsics_applied
+    result["usbl_extrinsics_rotation_units"] = "degrees"
 
     return result
 
 
 def process_tracklink_usbl_from_logs(
     usbl: pd.DataFrame,
+    extrinsics: TrackLinkTransceiverExtrinsics | None = None,
     config: TrackLinkProcessingFromLogsConfig = TrackLinkProcessingFromLogsConfig(),
 ) -> pd.DataFrame:
     """Resolve positions and estimate uncertainty from TrackLink USBL log entries.
@@ -351,6 +369,9 @@ def process_tracklink_usbl_from_logs(
     ---------
     usbl: Merged TrackLink log DataFrame with ship position, ship attitude,
         and target XYZ in sensor frame.
+    extrinsics: Transceiver extrinsics in the ship body frame. When None, no
+        extrinsics correction is applied. Omit it for deployments whose
+        readings were already corrected upstream.
     config: Combined configuration for position resolution and uncertainty estimation.
 
     Returns
@@ -358,7 +379,7 @@ def process_tracklink_usbl_from_logs(
     DataFrame with resolved target positions and uncertainty columns.
     """
     result: pd.DataFrame = resolve_target_position_from_logs(
-        usbl, config.resolve
+        usbl, extrinsics, config.resolve
     )
     result = estimate_usbl_uncertainty(result, config.uncertainty)
     return result

--- a/src/afft/sensors/usbl_linkquest/types.py
+++ b/src/afft/sensors/usbl_linkquest/types.py
@@ -119,10 +119,9 @@ class TrackLinkResolvePositionFromMessagesConfig(BaseModel):
 
     The raw bearing is always treated as an azimuth in the transceiver body
     frame (0 = transceiver forward, clockwise). The full ZYX attitude chain
-    (transceiver → ship body → NED) is applied on every call. When no
-    extrinsics are provided a zero-offset, zero-rotation transceiver is
-    assumed (bearing is then relative to the ship bow, and ship heading is
-    applied via the rotation chain).
+    (transceiver → ship body → NED) is applied on every call. Extrinsics are
+    passed to the processor rather than configured here, since they are a
+    property of the deployment.
 
     Attributes
     ----------
@@ -136,8 +135,6 @@ class TrackLinkResolvePositionFromMessagesConfig(BaseModel):
     ship_pitch_col: Name of the ship pitch column (degrees).
     depth_col: Name of the depth column in the pressure DataFrame.
     max_time_gap_seconds: Maximum allowed gap between USBL and pressure windows.
-    extrinsics: Transceiver extrinsics relative to the ship body frame. Defaults
-        to zero offset and zero rotation when not provided.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -152,7 +149,6 @@ class TrackLinkResolvePositionFromMessagesConfig(BaseModel):
     ship_pitch_col: str = "ship_pitch"
     depth_col: str = "depth"
     max_time_gap_seconds: float = 60.0
-    extrinsics: TrackLinkTransceiverExtrinsics | None = None
 
 
 class TrackLinkResolvePositionFromLogsConfig(BaseModel):
@@ -161,8 +157,8 @@ class TrackLinkResolvePositionFromLogsConfig(BaseModel):
 
     Target XYZ in the sensor frame is taken directly from the log entries.
     The full ZYX attitude chain (transceiver → ship body → NED) is applied
-    on every call. When no extrinsics are provided a zero-offset,
-    zero-rotation transceiver is assumed.
+    on every call. Extrinsics are passed to the processor rather than
+    configured here, since they are a property of the deployment.
 
     Attributes
     ----------
@@ -177,8 +173,6 @@ class TrackLinkResolvePositionFromLogsConfig(BaseModel):
     ship_heading_col: Name of the ship heading column (degrees, clockwise from N).
     ship_roll_col: Name of the ship roll column (degrees).
     ship_pitch_col: Name of the ship pitch column (degrees).
-    extrinsics: Transceiver extrinsics relative to the ship body frame. Defaults
-        to zero offset and zero rotation when not provided.
     """
 
     model_config = ConfigDict(frozen=True, extra="forbid")
@@ -194,7 +188,6 @@ class TrackLinkResolvePositionFromLogsConfig(BaseModel):
     ship_heading_col: str = "ship_heading"
     ship_roll_col: str = "ship_roll"
     ship_pitch_col: str = "ship_pitch"
-    extrinsics: TrackLinkTransceiverExtrinsics | None = None
 
 
 class TrackLinkUncertaintyConfig(BaseModel):

--- a/tests/telemetry_processing/test_usbl_evologics.py
+++ b/tests/telemetry_processing/test_usbl_evologics.py
@@ -2,6 +2,7 @@
 
 import math
 
+import numpy as np
 import pandas as pd
 
 from afft.sensors.usbl_evologics import (
@@ -147,7 +148,7 @@ def test_uncertainty_values() -> None:
         horizontal_position_std=12.5,
         depth_position_std=3.0,
     )
-    result = process_evologics_usbl(_make_df(), config)
+    result = process_evologics_usbl(_make_df(), config=config)
     assert (result["horizontal_position_std"] == 12.5).all()
     assert (result["depth_position_std"] == 3.0).all()
 
@@ -156,14 +157,16 @@ def test_extrinsics_columns_written() -> None:
     extrinsics = EvologicsTransceiverExtrinsics(
         locx=1.0, locy=2.0, locz=3.0, rotx=0.1, roty=0.2, rotz=0.3
     )
-    config = EvologicsProcessingConfig(extrinsics=extrinsics)
-    result = process_evologics_usbl(_make_df(), config)
+    result = process_evologics_usbl(_make_df(), extrinsics)
     assert (result["usbl_extrinsics_locx"] == 1.0).all()
     assert (result["usbl_extrinsics_locy"] == 2.0).all()
     assert (result["usbl_extrinsics_locz"] == 3.0).all()
-    assert (result["usbl_extrinsics_rotx"] == 0.1).all()
-    assert (result["usbl_extrinsics_roty"] == 0.2).all()
-    assert (result["usbl_extrinsics_rotz"] == 0.3).all()
+    # Rotations are recorded in degrees, whatever unit they were supplied in.
+    assert np.allclose(result["usbl_extrinsics_rotx"], math.degrees(0.1))
+    assert np.allclose(result["usbl_extrinsics_roty"], math.degrees(0.2))
+    assert np.allclose(result["usbl_extrinsics_rotz"], math.degrees(0.3))
+    assert (result["usbl_extrinsics_rotation_units"] == "degrees").all()
+    assert result["usbl_extrinsics_applied"].all()
 
 
 def test_extrinsics_columns_zero_when_none() -> None:
@@ -177,6 +180,20 @@ def test_extrinsics_columns_zero_when_none() -> None:
         "usbl_extrinsics_rotz",
     ]:
         assert (result[col] == 0.0).all()
+
+
+def test_extrinsics_applied_false_when_none() -> None:
+    # The zero columns above are ambiguous on their own -- a transceiver
+    # genuinely mounted at the origin writes the same six values.
+    result = process_evologics_usbl(_make_df())
+    assert not result["usbl_extrinsics_applied"].any()
+
+
+def test_extrinsics_applied_true_for_zero_extrinsics() -> None:
+    result = process_evologics_usbl(
+        _make_df(), EvologicsTransceiverExtrinsics()
+    )
+    assert result["usbl_extrinsics_applied"].all()
 
 
 def test_sensor_frame_preserves_usbl_frame_input() -> None:
@@ -195,12 +212,11 @@ def test_extrinsics_translation_applied() -> None:
     # With only translation (no rotation), vessel-frame target = flipped + translation.
     # USBL (x=0, y=1, z=0) → flip → (x=1, y=0, z=0) → + (2, 3, 4) → (3, 3, 4)
     extrinsics = EvologicsTransceiverExtrinsics(locx=2.0, locy=3.0, locz=4.0)
-    config = EvologicsProcessingConfig(extrinsics=extrinsics)
     df = _make_df(rows=1)
     df["target_x"] = 0.0
     df["target_y"] = 1.0
     df["target_z"] = 0.0
-    result = process_evologics_usbl(df, config)
+    result = process_evologics_usbl(df, extrinsics)
     assert math.isclose(result["target_x_vessel"].iloc[0], 3.0, rel_tol=1e-9)
     assert math.isclose(result["target_y_vessel"].iloc[0], 3.0, rel_tol=1e-9)
     assert math.isclose(result["target_z_vessel"].iloc[0], 4.0, rel_tol=1e-9)

--- a/tests/telemetry_processing/test_usbl_linkquest_position.py
+++ b/tests/telemetry_processing/test_usbl_linkquest_position.py
@@ -2,6 +2,7 @@
 
 import math
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -208,7 +209,7 @@ def test_usbl_before_pressure_window_raises() -> None:
         max_time_gap_seconds=60.0
     )
     with pytest.raises(ValueError, match="precedes first pressure reading"):
-        resolve_target_position_from_messages(usbl, pressure, config)
+        resolve_target_position_from_messages(usbl, pressure, config=config)
 
 
 def test_usbl_after_pressure_window_raises() -> None:
@@ -222,7 +223,7 @@ def test_usbl_after_pressure_window_raises() -> None:
         max_time_gap_seconds=60.0
     )
     with pytest.raises(ValueError, match="follows last pressure reading"):
-        resolve_target_position_from_messages(usbl, pressure, config)
+        resolve_target_position_from_messages(usbl, pressure, config=config)
 
 
 def test_usbl_within_time_margin_does_not_raise() -> None:
@@ -235,7 +236,7 @@ def test_usbl_within_time_margin_does_not_raise() -> None:
     config = TrackLinkResolvePositionFromMessagesConfig(
         max_time_gap_seconds=60.0
     )
-    resolve_target_position_from_messages(usbl, pressure, config)
+    resolve_target_position_from_messages(usbl, pressure, config=config)
 
 
 # ---------------------------------------------------------------------------
@@ -250,18 +251,38 @@ def test_extrinsics_columns_written() -> None:
     pressure = _pressure_df(
         ["2010-04-21 02:22:29", "2010-04-21 02:22:31"], [5.0, 5.0]
     )
-    config = TrackLinkResolvePositionFromMessagesConfig(
-        extrinsics=TrackLinkTransceiverExtrinsics(
-            locx=1.0, locy=2.0, locz=3.0, rotx=0.1, roty=0.2, rotz=0.3
-        )
+    extrinsics = TrackLinkTransceiverExtrinsics(
+        locx=1.0, locy=2.0, locz=3.0, rotx=0.1, roty=0.2, rotz=0.3
     )
-    result = resolve_target_position_from_messages(usbl, pressure, config)
+    result = resolve_target_position_from_messages(usbl, pressure, extrinsics)
     assert (result["usbl_extrinsics_locx"] == 1.0).all()
     assert (result["usbl_extrinsics_locy"] == 2.0).all()
     assert (result["usbl_extrinsics_locz"] == 3.0).all()
-    assert (result["usbl_extrinsics_rotx"] == 0.1).all()
-    assert (result["usbl_extrinsics_roty"] == 0.2).all()
-    assert (result["usbl_extrinsics_rotz"] == 0.3).all()
+    # Rotations are recorded in degrees, whatever unit they were supplied in.
+    assert np.allclose(result["usbl_extrinsics_rotx"], math.degrees(0.1))
+    assert np.allclose(result["usbl_extrinsics_roty"], math.degrees(0.2))
+    assert np.allclose(result["usbl_extrinsics_rotz"], math.degrees(0.3))
+    assert (result["usbl_extrinsics_rotation_units"] == "degrees").all()
+    assert result["usbl_extrinsics_applied"].all()
+
+
+def test_extrinsics_applied_distinguishes_none_from_zero() -> None:
+    # Both write six zero columns, so the boolean is the only thing telling
+    # a disabled run apart from a transceiver mounted at the origin.
+    usbl = _usbl_df(
+        [_usbl_row("2010-04-21 02:22:30", 0.0, 0.0, 0.0, 90.0, 100.0)]
+    )
+    pressure = _pressure_df(
+        ["2010-04-21 02:22:29", "2010-04-21 02:22:31"], [5.0, 5.0]
+    )
+    without = resolve_target_position_from_messages(usbl, pressure)
+    with_zero = resolve_target_position_from_messages(
+        usbl, pressure, TrackLinkTransceiverExtrinsics()
+    )
+    assert not without["usbl_extrinsics_applied"].any()
+    assert with_zero["usbl_extrinsics_applied"].all()
+    assert (without["usbl_extrinsics_locx"] == 0.0).all()
+    assert (with_zero["usbl_extrinsics_locx"] == 0.0).all()
 
 
 def test_sensor_frame_columns_present_and_unrotated() -> None:
@@ -299,10 +320,8 @@ def test_extrinsics_yaw_rotates_bearing() -> None:
     result_ext = resolve_target_position_from_messages(
         usbl_ext,
         pressure,
-        TrackLinkResolvePositionFromMessagesConfig(
-            extrinsics=TrackLinkTransceiverExtrinsics(
-                locx=0.0, locy=0.0, locz=0.0, rotz=math.radians(90.0)
-            )
+        TrackLinkTransceiverExtrinsics(
+            locx=0.0, locy=0.0, locz=0.0, rotz=math.radians(90.0)
         ),
     )
 
@@ -334,11 +353,7 @@ def test_extrinsics_translation_shifts_origin() -> None:
     result_ext = resolve_target_position_from_messages(
         usbl,
         pressure,
-        TrackLinkResolvePositionFromMessagesConfig(
-            extrinsics=TrackLinkTransceiverExtrinsics(
-                locx=0.0, locy=100.0, locz=0.0
-            )
-        ),
+        TrackLinkTransceiverExtrinsics(locx=0.0, locy=100.0, locz=0.0),
     )
 
     # Target longitude should be ~100 m East of the reference result.
@@ -377,11 +392,9 @@ def test_extrinsics_roll_sensor_z_corrected() -> None:
     pressure = _pressure_df(
         ["2010-04-21 02:22:29", "2010-04-21 02:22:31"], [depth_m, depth_m]
     )
-    config = TrackLinkResolvePositionFromMessagesConfig(
-        extrinsics=TrackLinkTransceiverExtrinsics(rotx=roll_rad)
+    result = resolve_target_position_from_messages(
+        usbl, pressure, TrackLinkTransceiverExtrinsics(rotx=roll_rad)
     )
-
-    result = resolve_target_position_from_messages(usbl, pressure, config)
 
     expected_sensor_z: float = depth_m / math.cos(roll_rad)
     assert math.isclose(
@@ -401,11 +414,7 @@ def test_extrinsics_ship_heading_applied() -> None:
     result = resolve_target_position_from_messages(
         usbl,
         pressure,
-        TrackLinkResolvePositionFromMessagesConfig(
-            extrinsics=TrackLinkTransceiverExtrinsics(
-                locx=0.0, locy=0.0, locz=0.0
-            )
-        ),
+        TrackLinkTransceiverExtrinsics(locx=0.0, locy=0.0, locz=0.0),
     )
 
     # Target 1000 m ahead of an East-heading ship → 1000 m East of GPS.

--- a/tests/test_bundle_processing_pipeline_runners.py
+++ b/tests/test_bundle_processing_pipeline_runners.py
@@ -219,3 +219,59 @@ def test_a_run_stops_at_the_first_failure(tmp_path: Path) -> None:
 
     with open_deployment_bundle_reader(target) as reader:
         assert not reader.has_frame("telemetry/processed/second")
+
+
+def test_an_optional_step_is_skipped_when_an_input_is_absent(
+    tmp_path: Path,
+) -> None:
+    """A step whose sensor is not on the deployment is skipped, not fatal."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    step = PipelineStep(
+        processor_key="scale",
+        processor=_scale,
+        config=_ScaleConfig(),
+        inputs={"df": "telemetry/raw/usbl"},
+        output="telemetry/processed/usbl",
+        optional=True,
+    )
+
+    _run(source, target, (step,))
+
+    with open_deployment_bundle_reader(target) as reader:
+        assert not reader.has_frame("telemetry/processed/usbl")
+
+
+def test_a_required_step_still_fails_when_an_input_is_absent(
+    tmp_path: Path,
+) -> None:
+    """Optionality is opt-in: a missing input is otherwise fatal."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    with pytest.raises(PipelineStepError):
+        _run(source, target, (_step("out", source_key="telemetry/raw/usbl"),))
+
+
+def test_an_optional_step_runs_when_its_inputs_are_present(
+    tmp_path: Path,
+) -> None:
+    """Optional does not mean skipped -- present inputs run normally."""
+    source, target = tmp_path / "in.h5", tmp_path / "out.h5"
+    _source_bundle(source)
+
+    step = PipelineStep(
+        processor_key="scale",
+        processor=_scale,
+        config=_ScaleConfig(factor=3.0),
+        inputs={"df": "telemetry/raw/pressure"},
+        output="telemetry/processed/pressure",
+        optional=True,
+    )
+
+    _run(source, target, (step,))
+
+    with open_deployment_bundle_reader(target) as reader:
+        frame = reader.read_frame("telemetry/processed/pressure")
+        assert frame["value"].tolist() == [3.0, 6.0]

--- a/tests/test_bundle_processing_processor_registry.py
+++ b/tests/test_bundle_processing_processor_registry.py
@@ -86,6 +86,8 @@ def test_default_registry_holds_every_shipped_processor() -> None:
         "estimate_dvl_uncertainty",
         "estimate_pressure_uncertainty",
         "pair_stereo_images",
+        "process_evologics_usbl",
+        "process_tracklink_usbl_from_messages",
         "rename_columns",
         "select_columns",
     ]

--- a/tests/test_bundle_processing_sensor_processors.py
+++ b/tests/test_bundle_processing_sensor_processors.py
@@ -1,0 +1,144 @@
+"""Tests for the pipeline wrappers around the sensor processing functions,
+covering what the wrappers add rather than the processors they call."""
+
+import pandas as pd
+import pytest
+
+from afft.bundle_processing.sensor_processors import (
+    step_process_evologics_usbl,
+    step_process_tracklink_usbl_from_messages,
+)
+from afft.sensors.usbl_evologics import EvologicsProcessingConfig
+from afft.sensors.usbl_linkquest import TrackLinkProcessingFromMessagesConfig
+
+
+def _extrinsics_frame(rows: int = 1) -> pd.DataFrame:
+    """A frame shaped as the bundle builder writes `SensorExtrinsics`."""
+    return pd.DataFrame(
+        {
+            "locx": [1.0] * rows,
+            "locy": [2.0] * rows,
+            "locz": [3.0] * rows,
+            "rotx": [0.0] * rows,
+            "roty": [0.0] * rows,
+            "rotz": [0.0] * rows,
+        }
+    )
+
+
+def _evologics_frame() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": ["2017-05-23 04:08:16+00:00"],
+            "target_latitude": [-32.035152],
+            "target_longitude": [115.459240],
+            "target_depth": [12.0],
+            "target_x": [1.0],
+            "target_y": [2.0],
+            "target_z": [-3.0],
+            "ship_latitude": [-32.03],
+            "ship_longitude": [115.46],
+            "ship_heading": [10.0],
+            "ship_roll": [0.0],
+            "ship_pitch": [0.0],
+            "accuracy": [1.5],
+        }
+    )
+
+
+def _tracklink_frames() -> dict[str, pd.DataFrame]:
+    usbl = pd.DataFrame(
+        {
+            "timestamp": ["2010-04-21 02:22:30"],
+            "ship_latitude": [0.0],
+            "ship_longitude": [0.0],
+            "ship_heading": [0.0],
+            "ship_roll": [0.0],
+            "ship_pitch": [0.0],
+            "target_bearing_angle": [90.0],
+            "target_slant_range": [100.0],
+        }
+    )
+    pressure = pd.DataFrame(
+        {
+            "timestamp": ["2010-04-21 02:22:29", "2010-04-21 02:22:31"],
+            "depth": [5.0, 5.0],
+        }
+    )
+    return {"usbl": usbl, "pressure": pressure}
+
+
+def test_extrinsics_frame_is_applied_to_the_evologics_step() -> None:
+    """The bundle's extrinsics frame reaches the processor."""
+    frames = {
+        "usbl": _evologics_frame(),
+        "extrinsics": _extrinsics_frame(),
+    }
+
+    result = step_process_evologics_usbl(frames, EvologicsProcessingConfig())
+
+    assert (result["usbl_extrinsics_locx"] == 1.0).all()
+    assert (result["usbl_extrinsics_locy"] == 2.0).all()
+    assert (result["usbl_extrinsics_locz"] == 3.0).all()
+    assert result["usbl_extrinsics_applied"].all()
+
+
+def test_omitting_the_extrinsics_input_disables_the_correction() -> None:
+    """Absence of the input is the disable signal -- there is no flag."""
+    frames = {"usbl": _evologics_frame()}
+
+    result = step_process_evologics_usbl(frames, EvologicsProcessingConfig())
+
+    assert not result["usbl_extrinsics_applied"].any()
+    assert (result["usbl_extrinsics_locx"] == 0.0).all()
+
+
+def test_extrinsics_frame_is_applied_to_the_tracklink_step() -> None:
+    frames = _tracklink_frames() | {"extrinsics": _extrinsics_frame()}
+
+    result = step_process_tracklink_usbl_from_messages(
+        frames, TrackLinkProcessingFromMessagesConfig()
+    )
+
+    assert (result["usbl_extrinsics_locy"] == 2.0).all()
+    assert result["usbl_extrinsics_applied"].all()
+
+
+def test_a_multi_row_extrinsics_frame_is_rejected() -> None:
+    """Taking the first row would shift every position by a plausible amount."""
+    frames = {
+        "usbl": _evologics_frame(),
+        "extrinsics": _extrinsics_frame(rows=2),
+    }
+
+    with pytest.raises(ValueError, match="holds 2 rows"):
+        step_process_evologics_usbl(frames, EvologicsProcessingConfig())
+
+
+def test_an_empty_extrinsics_frame_is_rejected() -> None:
+    frames = {
+        "usbl": _evologics_frame(),
+        "extrinsics": _extrinsics_frame(rows=0),
+    }
+
+    with pytest.raises(ValueError, match="holds 0 rows"):
+        step_process_evologics_usbl(frames, EvologicsProcessingConfig())
+
+
+def test_an_extrinsics_frame_with_unexpected_columns_is_rejected() -> None:
+    """`extra="forbid"` is what catches a bundle written against a changed
+    `SensorExtrinsics`, so the decode must not drop unknown columns."""
+    frame = _extrinsics_frame()
+    frame["unexpected"] = [0.0]
+    frames = {"usbl": _evologics_frame(), "extrinsics": frame}
+
+    with pytest.raises(ValueError, match="does not match"):
+        step_process_evologics_usbl(frames, EvologicsProcessingConfig())
+
+
+def test_an_extrinsics_frame_missing_a_field_is_rejected() -> None:
+    frame = _extrinsics_frame().drop(columns=["rotz"])
+    frames = {"usbl": _evologics_frame(), "extrinsics": frame}
+
+    with pytest.raises(ValueError, match="does not match"):
+        step_process_evologics_usbl(frames, EvologicsProcessingConfig())

--- a/tests/test_bundle_processing_sensor_processors.py
+++ b/tests/test_bundle_processing_sensor_processors.py
@@ -6,7 +6,7 @@ import pytest
 
 from afft.bundle_processing.sensor_processors import (
     step_process_evologics_usbl,
-    step_process_tracklink_usbl_from_messages,
+    step_process_tracklink_usbl,
 )
 from afft.sensors.usbl_evologics import EvologicsProcessingConfig
 from afft.sensors.usbl_linkquest import TrackLinkProcessingFromMessagesConfig
@@ -96,7 +96,7 @@ def test_omitting_the_extrinsics_input_disables_the_correction() -> None:
 def test_extrinsics_frame_is_applied_to_the_tracklink_step() -> None:
     frames = _tracklink_frames() | {"extrinsics": _extrinsics_frame()}
 
-    result = step_process_tracklink_usbl_from_messages(
+    result = step_process_tracklink_usbl(
         frames, TrackLinkProcessingFromMessagesConfig()
     )
 


### PR DESCRIPTION
## Summary

Registers `process_evologics_usbl` and `process_tracklink_usbl_from_messages` as pipeline steps, and moves the vessel USBL transceiver extrinsics out of the sensor processor configs.

- Extrinsics become an explicit argument on all five USBL functions and are removed from `EvologicsProcessingConfig`, `TrackLinkResolvePositionFromMessagesConfig`, and `TrackLinkResolvePositionFromLogsConfig`. The logs path changes too: it is not a pipeline step, but shares the package and would otherwise disagree with its neighbours about where extrinsics come from.
- Omitting the `extrinsics` input disables the correction, for deployments whose readings were already corrected upstream. The step logs which mode it ran in.
- The frame decode is strict: exactly one row, and a column set equal to the model's fields.
- Output gains `usbl_extrinsics_applied` and `usbl_extrinsics_rotation_units`; extrinsics rotations are recorded in degrees, matching `target_inclination_angle`.
- Pipeline steps gain an `optional` flag. USBL is the first step whose sensor is not on every deployment, so the runner skips such a step, logging the missing key, rather than aborting the run.
- `config/default.toml` gains the LinkQuest step (active, optional) and the Evologics step (commented out).

Two deviations from the issue as written:

- The issue specifies an identity default, `extrinsics: X = X()`. That is unimplementable alongside `usbl_extrinsics_applied` — the processor could not tell an omitted argument from a deliberate identity. The argument is `X | None = None` instead; the pipeline still disables by not providing it.
- Strictness needed an explicit column-set check. Every extrinsics field carries a default, so `extra="forbid"` alone would let a frame missing a column decode to a silent zero for that axis.

Units were verified end to end and are correct as they stand: catalog to processor is radians throughout, with no conversion. Only the output representation changes.

Closes #229