### PR TITLE
Fix inconsistent datetime formats when reading sqlite bundle frames

### DIFF
--- a/src/afft/deployment/bundle_sqlite_common.py
+++ b/src/afft/deployment/bundle_sqlite_common.py
@@ -169,11 +169,14 @@ def read_frame_table(
     for column, dtype in dtypes.items():
         if isinstance(dtype, pd.DatetimeTZDtype):
             # Stored as ISO text with an offset, so parse before casting.
-            frame[column] = pd.to_datetime(frame[column], utc=True).astype(
-                dtype
-            )
+            # `to_sql` drops the fractional-second part when it is zero, so
+            # a column can mix "...41.123456+00:00" and "...41+00:00" --
+            # ISO8601 parsing handles both without a fixed format string.
+            frame[column] = pd.to_datetime(
+                frame[column], utc=True, format="ISO8601"
+            ).astype(dtype)
         elif pd.api.types.is_datetime64_dtype(dtype):
-            frame[column] = pd.to_datetime(frame[column])
+            frame[column] = pd.to_datetime(frame[column], format="ISO8601")
         else:
             frame[column] = frame[column].astype(dtype)
     return frame


### PR DESCRIPTION
## Summary

- `read_frame_table` parsed datetime columns with `pd.to_datetime` and no explicit format, so pandas inferred a single strptime pattern from the first row and applied it to the whole column.
- `write_frame_table` round-trips timestamps through `to_sql`/`isoformat()`, which drops the fractional-second suffix whenever a timestamp's microseconds are exactly zero. A column can therefore mix `...41.123456+00:00` and `...41+00:00`, and parsing fails on the first row that doesn't match the inferred format.
- Pass `format="ISO8601"` to both `pd.to_datetime` calls, which handles ISO 8601 strings of varying precision without needing one fixed pattern.

Verified by running `scripts/shell/bundle_batch_process_desktop.sh` against all 17 bundles in the subset dataset; all now process without error.