### PR TITLE
Add a task and CLI command for ingesting frames into deployment bundles

### DIFF
--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -16,8 +16,8 @@ from afft.tasks.build_deployment_bundle import (
     run_build_deployment_bundle,
 )
 from afft.tasks.deployment_bundle_common import (
-    IngestFrameCommand,
-    run_ingest_frame,
+    IngestBundleFrameCommand,
+    run_ingest_bundle_frame,
 )
 from afft.tasks.process_deployment_bundle import (
     ProcessDeploymentBundleCommand,
@@ -80,7 +80,7 @@ def dispatch_list_deployment_bundle(
                 logger.info(f"  {column}: {dtype}")
 
 
-def dispatch_ingest_frame(
+def dispatch_ingest_bundle_frame(
     bundle_file: str | Path,
     key: str,
     input_file: str | Path,
@@ -88,14 +88,14 @@ def dispatch_ingest_frame(
     overwrite: bool = False,
 ) -> None:
     """Ingest a frame from a file into an existing deployment bundle."""
-    command = IngestFrameCommand(
+    command = IngestBundleFrameCommand(
         bundle_file=Path(bundle_file),
         key=key,
         input_file=Path(input_file),
         datetime_columns=datetime_columns,
         overwrite=overwrite,
     )
-    run_ingest_frame(command)
+    run_ingest_bundle_frame(command)
 
 
 def dispatch_process_deployment_bundle(

--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -15,6 +15,10 @@ from afft.tasks.build_deployment_bundle import (
     read_build_deployment_bundle_config,
     run_build_deployment_bundle,
 )
+from afft.tasks.deployment_bundle_common import (
+    IngestFrameCommand,
+    run_ingest_frame,
+)
 from afft.tasks.process_deployment_bundle import (
     ProcessDeploymentBundleCommand,
     run_process_deployment_bundle,
@@ -74,6 +78,24 @@ def dispatch_list_deployment_bundle(
         if dtypes:
             for column, dtype in decode_frame_dtypes(row.dtypes).items():
                 logger.info(f"  {column}: {dtype}")
+
+
+def dispatch_ingest_frame(
+    bundle_file: str | Path,
+    key: str,
+    input_file: str | Path,
+    datetime_columns: tuple[str, ...] = (),
+    overwrite: bool = False,
+) -> None:
+    """Ingest a frame from a file into an existing deployment bundle."""
+    command = IngestFrameCommand(
+        bundle_file=Path(bundle_file),
+        key=key,
+        input_file=Path(input_file),
+        datetime_columns=datetime_columns,
+        overwrite=overwrite,
+    )
+    run_ingest_frame(command)
 
 
 def dispatch_process_deployment_bundle(

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -4,7 +4,7 @@ import click
 
 from .actions import (
     dispatch_build_deployment_bundle,
-    dispatch_ingest_frame,
+    dispatch_ingest_bundle_frame,
     dispatch_list_deployment_bundle,
     dispatch_process_deployment_bundle,
 )
@@ -196,7 +196,7 @@ def ingest_frame(
     overwrite: bool,
 ) -> None:
     """Ingest a frame from a file into an existing deployment bundle."""
-    dispatch_ingest_frame(
+    dispatch_ingest_bundle_frame(
         bundle_file,
         key,
         input_file,

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -4,6 +4,7 @@ import click
 
 from .actions import (
     dispatch_build_deployment_bundle,
+    dispatch_ingest_frame,
     dispatch_list_deployment_bundle,
     dispatch_process_deployment_bundle,
 )
@@ -152,4 +153,53 @@ def process(
         output_file,
         overwrite,
         verbose,
+    )
+
+
+@bundle_group.command("ingest-frame")
+@click.option(
+    "--bundle",
+    "bundle_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment bundle to ingest into, written in place",
+)
+@click.option(
+    "--key",
+    required=True,
+    help="bundle key to write the frame to",
+)
+@click.option(
+    "--file",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the CSV file holding the frame",
+)
+@click.option(
+    "--datetime-column",
+    "datetime_columns",
+    multiple=True,
+    help="column to parse as a timezone-aware UTC timestamp; repeatable",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="overwrite an existing frame at the key",
+)
+def ingest_frame(
+    bundle_file: str,
+    key: str,
+    input_file: str,
+    datetime_columns: tuple[str, ...],
+    overwrite: bool,
+) -> None:
+    """Ingest a frame from a file into an existing deployment bundle."""
+    dispatch_ingest_frame(
+        bundle_file,
+        key,
+        input_file,
+        datetime_columns,
+        overwrite,
     )

--- a/src/afft/tasks/deployment_bundle_common/__init__.py
+++ b/src/afft/tasks/deployment_bundle_common/__init__.py
@@ -2,15 +2,15 @@
 
 from .task_helpers import (
     read_frame_file as read_frame_file,
-    validate_frame_key as validate_frame_key,
-    validate_ingest_frame_input as validate_ingest_frame_input,
+    validate_bundle_frame_key as validate_bundle_frame_key,
+    validate_ingest_bundle_frame_input as validate_ingest_bundle_frame_input,
 )
 from .task_runners import (
-    run_ingest_frame as run_ingest_frame,
+    run_ingest_bundle_frame as run_ingest_bundle_frame,
 )
 from .task_types import (
-    IngestFrameCommand as IngestFrameCommand,
-    IngestFrameResult as IngestFrameResult,
+    IngestBundleFrameCommand as IngestBundleFrameCommand,
+    IngestBundleFrameResult as IngestBundleFrameResult,
 )
 
 __all__ = []

--- a/src/afft/tasks/deployment_bundle_common/__init__.py
+++ b/src/afft/tasks/deployment_bundle_common/__init__.py
@@ -1,0 +1,16 @@
+"""Common tasks for working with existing deployment bundles."""
+
+from .task_helpers import (
+    read_frame_file as read_frame_file,
+    validate_frame_key as validate_frame_key,
+    validate_ingest_frame_input as validate_ingest_frame_input,
+)
+from .task_runners import (
+    run_ingest_frame as run_ingest_frame,
+)
+from .task_types import (
+    IngestFrameCommand as IngestFrameCommand,
+    IngestFrameResult as IngestFrameResult,
+)
+
+__all__ = []

--- a/src/afft/tasks/deployment_bundle_common/task_helpers.py
+++ b/src/afft/tasks/deployment_bundle_common/task_helpers.py
@@ -1,0 +1,119 @@
+"""Supporting functions for the common deployment bundle tasks: key
+validation, frame reading, and input validation."""
+
+import re
+
+from pathlib import Path
+
+import pandas as pd
+
+from .task_types import IngestFrameCommand
+
+type FrameKey = str
+
+_SEGMENT_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def validate_frame_key(key: FrameKey) -> None:
+    """
+    Validate a bundle key's structure.
+
+    The check is deliberately structural only -- the key is not matched
+    against the bundle layer layout. ``metocean/<provider>/<variable>`` is
+    open-ended by design, so providers and variables cannot be enumerated
+    in advance, and ingest stays free of schema knowledge.
+
+    Arguments
+    ---------
+    key: Bundle key to validate.
+
+    Raises
+    ------
+    ValueError: If the key is empty, is slash-delimited at either end,
+        holds an empty segment, or holds a segment with characters outside
+        letters, digits, underscore, dot, and hyphen.
+    """
+    if not key:
+        raise ValueError("frame key is empty")
+
+    if key.startswith("/") or key.endswith("/"):
+        raise ValueError(f"frame key has a leading or trailing slash: {key!r}")
+
+    for segment in key.split("/"):
+        if not segment:
+            raise ValueError(f"frame key has an empty segment: {key!r}")
+        if not _SEGMENT_PATTERN.match(segment):
+            raise ValueError(
+                f"frame key segment {segment!r} holds characters outside "
+                f"letters, digits, underscore, dot, and hyphen: {key!r}"
+            )
+
+
+def read_frame_file(
+    input_file: Path,
+    datetime_columns: tuple[str, ...] = (),
+) -> pd.DataFrame:
+    """
+    Read a CSV file into a frame, parsing the named columns as timezone-aware
+    UTC timestamps.
+
+    Columns outside `datetime_columns` keep the dtype ``read_csv`` inferred.
+    The datetime columns are parsed with the same call the bundle readers
+    use, so both paths agree on how ISO text becomes a timestamp.
+
+    Arguments
+    ---------
+    input_file: Path to the CSV file.
+    datetime_columns: Columns to parse as timestamps.
+
+    Returns
+    -------
+    The frame, with each named column cast to ``datetime64[ns, UTC]``.
+
+    Raises
+    ------
+    ValueError: If a named datetime column is not in the file.
+    """
+    frame: pd.DataFrame = pd.read_csv(input_file)
+
+    missing: list[str] = [
+        column for column in datetime_columns if column not in frame.columns
+    ]
+    if missing:
+        raise ValueError(
+            f"datetime columns {missing} are not in {input_file}: "
+            f"columns are {list(frame.columns)}"
+        )
+
+    for column in datetime_columns:
+        frame[column] = pd.to_datetime(
+            frame[column], utc=True, format="ISO8601"
+        )
+
+    return frame
+
+
+def validate_ingest_frame_input(command: IngestFrameCommand) -> None:
+    """
+    Validate the task's inputs before any expensive work runs.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Raises
+    ------
+    FileNotFoundError: If the bundle or the input file does not exist.
+    ValueError: If the frame key is not structurally valid.
+    """
+    validate_frame_key(command.key)
+
+    if not command.bundle_file.is_file():
+        raise FileNotFoundError(
+            f"deployment bundle does not exist: {command.bundle_file}"
+        )
+
+    if not command.input_file.is_file():
+        raise FileNotFoundError(
+            f"input file does not exist: {command.input_file}"
+        )

--- a/src/afft/tasks/deployment_bundle_common/task_helpers.py
+++ b/src/afft/tasks/deployment_bundle_common/task_helpers.py
@@ -7,14 +7,14 @@ from pathlib import Path
 
 import pandas as pd
 
-from .task_types import IngestFrameCommand
+from .task_types import IngestBundleFrameCommand
 
-type FrameKey = str
+type BundleFrameKey = str
 
 _SEGMENT_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
-def validate_frame_key(key: FrameKey) -> None:
+def validate_bundle_frame_key(key: BundleFrameKey) -> None:
     """
     Validate a bundle key's structure.
 
@@ -93,7 +93,9 @@ def read_frame_file(
     return frame
 
 
-def validate_ingest_frame_input(command: IngestFrameCommand) -> None:
+def validate_ingest_bundle_frame_input(
+    command: IngestBundleFrameCommand,
+) -> None:
     """
     Validate the task's inputs before any expensive work runs.
 
@@ -106,7 +108,7 @@ def validate_ingest_frame_input(command: IngestFrameCommand) -> None:
     FileNotFoundError: If the bundle or the input file does not exist.
     ValueError: If the frame key is not structurally valid.
     """
-    validate_frame_key(command.key)
+    validate_bundle_frame_key(command.key)
 
     if not command.bundle_file.is_file():
         raise FileNotFoundError(

--- a/src/afft/tasks/deployment_bundle_common/task_runners.py
+++ b/src/afft/tasks/deployment_bundle_common/task_runners.py
@@ -1,0 +1,76 @@
+"""Runners for the common deployment bundle tasks."""
+
+from typing import Literal
+
+import pandas as pd
+
+from afft.deployment import DeploymentBundleIO, open_deployment_bundle
+from afft.utils.log import logger
+
+from .task_helpers import read_frame_file, validate_ingest_frame_input
+from .task_types import IngestFrameCommand, IngestFrameResult
+
+
+def run_ingest_frame(command: IngestFrameCommand) -> IngestFrameResult:
+    """
+    Ingest a frame from a file into an existing deployment bundle.
+
+    The bundle is written in place. This is a deliberate exception to the
+    build-don't-mutate rule the processing pipeline follows: ingestion
+    deposits data that already exists rather than deriving anything, so
+    copying a whole bundle forward per ingested frame would buy nothing.
+
+    Only the frame and its ``bundle_contents`` entry are written. The file
+    inventory and provenance layers are left alone -- an ingested frame is
+    a frame, not a change to what the bundle claims about the deployment.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The run's result, naming the key written and the frame's shape.
+
+    Raises
+    ------
+    FileNotFoundError: If the bundle or the input file does not exist.
+    ValueError: If the frame key is not structurally valid, if a named
+        datetime column is not in the input file, or if the key already
+        holds a frame and ``overwrite`` is not set.
+    """
+    validate_ingest_frame_input(command)
+
+    frame: pd.DataFrame = read_frame_file(
+        command.input_file, command.datetime_columns
+    )
+
+    logger.info("-------------------------------------")
+    logger.info("Ingest Frame")
+    logger.info(f"  bundle file: {command.bundle_file}")
+    logger.info(f"  input file:  {command.input_file}")
+    logger.info(f"  key:         {command.key}")
+    logger.info(f"  rows:        {len(frame)}")
+    logger.info("-------------------------------------")
+
+    if_exists: Literal["fail", "replace"] = (
+        "replace" if command.overwrite else "fail"
+    )
+
+    bundle: DeploymentBundleIO
+    with open_deployment_bundle(command.bundle_file) as bundle:
+        if bundle.has_frame(command.key) and not command.overwrite:
+            raise ValueError(
+                f"bundle already holds a frame at {command.key!r}: "
+                f"pass overwrite to replace it"
+            )
+        bundle.write_frame(command.key, frame, if_exists=if_exists)
+
+    logger.info(f"wrote {command.key} to {command.bundle_file}")
+
+    return IngestFrameResult(
+        bundle_file=command.bundle_file,
+        key=command.key,
+        rows=len(frame),
+        columns=tuple(frame.columns),
+    )

--- a/src/afft/tasks/deployment_bundle_common/task_runners.py
+++ b/src/afft/tasks/deployment_bundle_common/task_runners.py
@@ -7,11 +7,13 @@ import pandas as pd
 from afft.deployment import DeploymentBundleIO, open_deployment_bundle
 from afft.utils.log import logger
 
-from .task_helpers import read_frame_file, validate_ingest_frame_input
-from .task_types import IngestFrameCommand, IngestFrameResult
+from .task_helpers import read_frame_file, validate_ingest_bundle_frame_input
+from .task_types import IngestBundleFrameCommand, IngestBundleFrameResult
 
 
-def run_ingest_frame(command: IngestFrameCommand) -> IngestFrameResult:
+def run_ingest_bundle_frame(
+    command: IngestBundleFrameCommand,
+) -> IngestBundleFrameResult:
     """
     Ingest a frame from a file into an existing deployment bundle.
 
@@ -39,7 +41,7 @@ def run_ingest_frame(command: IngestFrameCommand) -> IngestFrameResult:
         datetime column is not in the input file, or if the key already
         holds a frame and ``overwrite`` is not set.
     """
-    validate_ingest_frame_input(command)
+    validate_ingest_bundle_frame_input(command)
 
     frame: pd.DataFrame = read_frame_file(
         command.input_file, command.datetime_columns
@@ -68,7 +70,7 @@ def run_ingest_frame(command: IngestFrameCommand) -> IngestFrameResult:
 
     logger.info(f"wrote {command.key} to {command.bundle_file}")
 
-    return IngestFrameResult(
+    return IngestBundleFrameResult(
         bundle_file=command.bundle_file,
         key=command.key,
         rows=len(frame),

--- a/src/afft/tasks/deployment_bundle_common/task_types.py
+++ b/src/afft/tasks/deployment_bundle_common/task_types.py
@@ -1,0 +1,45 @@
+"""Data types for the common deployment bundle tasks."""
+
+from pathlib import Path
+
+from pydantic import BaseModel, ConfigDict
+
+
+class IngestFrameCommand(BaseModel):
+    """
+    Attributes
+    ----------
+    bundle_file: Path to the deployment bundle to ingest into. Written in
+        place; it must already exist.
+    key: Bundle key to write the frame to.
+    input_file: Path to the CSV file holding the frame.
+    datetime_columns: Columns to parse as timezone-aware UTC timestamps.
+        Every other column keeps the dtype ``read_csv`` inferred.
+    overwrite: Overwrite an existing frame at ``key``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    bundle_file: Path
+    key: str
+    input_file: Path
+    datetime_columns: tuple[str, ...] = ()
+    overwrite: bool = False
+
+
+class IngestFrameResult(BaseModel):
+    """
+    Attributes
+    ----------
+    bundle_file: Path to the bundle the frame was written to.
+    key: Bundle key the frame was written to.
+    rows: Number of rows written.
+    columns: Column names written, in frame order.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    bundle_file: Path
+    key: str
+    rows: int
+    columns: tuple[str, ...]

--- a/src/afft/tasks/deployment_bundle_common/task_types.py
+++ b/src/afft/tasks/deployment_bundle_common/task_types.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from pydantic import BaseModel, ConfigDict
 
 
-class IngestFrameCommand(BaseModel):
+class IngestBundleFrameCommand(BaseModel):
     """
     Attributes
     ----------
@@ -27,7 +27,7 @@ class IngestFrameCommand(BaseModel):
     overwrite: bool = False
 
 
-class IngestFrameResult(BaseModel):
+class IngestBundleFrameResult(BaseModel):
     """
     Attributes
     ----------

--- a/tests/test_tasks_deployment_bundle_common.py
+++ b/tests/test_tasks_deployment_bundle_common.py
@@ -1,0 +1,267 @@
+"""Tests for the common deployment bundle tasks."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from click.testing import CliRunner, Result
+
+from afft.cli.entrypoint import cli
+from afft.deployment import (
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
+from afft.tasks.deployment_bundle_common import (
+    IngestFrameCommand,
+    IngestFrameResult,
+    read_frame_file,
+    run_ingest_frame,
+    validate_frame_key,
+)
+
+SEA_LEVEL_CSV: str = (
+    "dt,sea_level,datetime,station,latitude,longitude,atlas\n"
+    "1230735600,0.266,2008-12-31 15:00:00+00:00,,-28.8333,114,FES2022\n"
+    "1230739200,0.311,2008-12-31 16:00:00.500000+00:00,,-28.8333,114,FES2022\n"
+)
+
+SEA_LEVEL_KEY: str = "metocean/worldtides/sealevel"
+
+
+@pytest.fixture
+def source_file(tmp_path: Path) -> Path:
+    """A CSV shaped as the stored WorldTides sea level series."""
+    path: Path = tmp_path / "sea_level.csv"
+    path.write_text(SEA_LEVEL_CSV)
+    return path
+
+
+@pytest.fixture
+def bundle_file(tmp_path: Path) -> Path:
+    """An existing bundle holding one unrelated frame."""
+    path: Path = tmp_path / "deployment_bundle.sqlite"
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame(
+            "telemetry/raw/pressure/messages", pd.DataFrame({"value": [1.0]})
+        )
+    return path
+
+
+def test_valid_frame_keys_are_accepted() -> None:
+    validate_frame_key(SEA_LEVEL_KEY)
+    validate_frame_key("bundle")
+    validate_frame_key("platform/sensors/usbl_linkquest_transceiver/extrinsics")
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "",
+        "/metocean/worldtides/sealevel",
+        "metocean/worldtides/sealevel/",
+        "metocean//sealevel",
+        "metocean/world tides/sealevel",
+        "metocean/worldtides/sea:level",
+    ],
+)
+def test_structurally_invalid_frame_keys_are_rejected(key: str) -> None:
+    with pytest.raises(ValueError):
+        validate_frame_key(key)
+
+
+def test_unknown_frame_keys_are_accepted() -> None:
+    """Validation is structural only, so an unrecognised key still passes."""
+    validate_frame_key("metocean/worldtide/sealevel")
+    validate_frame_key("not_a_bundle_section/whatever")
+
+
+def test_datetime_columns_are_parsed_as_utc(source_file: Path) -> None:
+    frame: pd.DataFrame = read_frame_file(source_file, ("datetime",))
+
+    assert isinstance(frame["datetime"].dtype, pd.DatetimeTZDtype)
+    assert str(frame["datetime"].dt.tz) == "UTC"
+
+
+def test_columns_outside_datetime_columns_keep_inferred_dtypes(
+    source_file: Path,
+) -> None:
+    frame: pd.DataFrame = read_frame_file(source_file, ("datetime",))
+
+    assert frame["dt"].dtype == "int64"
+    assert frame["sea_level"].dtype == "float64"
+    assert frame["atlas"].dtype == object
+
+
+def test_a_datetime_column_not_in_the_file_is_rejected(
+    source_file: Path,
+) -> None:
+    with pytest.raises(ValueError, match="absent"):
+        read_frame_file(source_file, ("absent",))
+
+
+def test_ingested_frame_is_readable_from_the_bundle(
+    bundle_file: Path, source_file: Path
+) -> None:
+    result: IngestFrameResult = run_ingest_frame(
+        IngestFrameCommand(
+            bundle_file=bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=source_file,
+            datetime_columns=("datetime",),
+        )
+    )
+
+    assert result.rows == 2
+    with open_deployment_bundle_reader(bundle_file) as reader:
+        frame: pd.DataFrame = reader.read_frame(SEA_LEVEL_KEY)
+
+    assert len(frame) == 2
+    assert isinstance(frame["datetime"].dtype, pd.DatetimeTZDtype)
+    assert frame["sea_level"].to_list() == [0.266, 0.311]
+
+
+def test_ingestion_leaves_existing_frames_alone(
+    bundle_file: Path, source_file: Path
+) -> None:
+    run_ingest_frame(
+        IngestFrameCommand(
+            bundle_file=bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=source_file,
+            datetime_columns=("datetime",),
+        )
+    )
+
+    with open_deployment_bundle_reader(bundle_file) as reader:
+        keys: list[str] = reader.list_frames()
+
+    assert "telemetry/raw/pressure/messages" in keys
+    assert SEA_LEVEL_KEY in keys
+
+
+def test_ingesting_over_an_existing_key_is_refused(
+    bundle_file: Path, source_file: Path
+) -> None:
+    command = IngestFrameCommand(
+        bundle_file=bundle_file,
+        key=SEA_LEVEL_KEY,
+        input_file=source_file,
+        datetime_columns=("datetime",),
+    )
+    run_ingest_frame(command)
+
+    with pytest.raises(ValueError, match="already holds a frame"):
+        run_ingest_frame(command)
+
+
+def test_overwrite_replaces_an_existing_frame(
+    bundle_file: Path, source_file: Path, tmp_path: Path
+) -> None:
+    run_ingest_frame(
+        IngestFrameCommand(
+            bundle_file=bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=source_file,
+            datetime_columns=("datetime",),
+        )
+    )
+
+    replacement: Path = tmp_path / "replacement.csv"
+    replacement.write_text("sea_level\n9.0\n")
+    run_ingest_frame(
+        IngestFrameCommand(
+            bundle_file=bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=replacement,
+            overwrite=True,
+        )
+    )
+
+    with open_deployment_bundle_reader(bundle_file) as reader:
+        frame: pd.DataFrame = reader.read_frame(SEA_LEVEL_KEY)
+
+    assert frame["sea_level"].to_list() == [9.0]
+
+
+def test_a_missing_bundle_is_rejected(
+    tmp_path: Path, source_file: Path
+) -> None:
+    with pytest.raises(FileNotFoundError, match="deployment bundle"):
+        run_ingest_frame(
+            IngestFrameCommand(
+                bundle_file=tmp_path / "absent.sqlite",
+                key=SEA_LEVEL_KEY,
+                input_file=source_file,
+            )
+        )
+
+
+def test_a_missing_input_file_is_rejected(
+    bundle_file: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(FileNotFoundError, match="input file"):
+        run_ingest_frame(
+            IngestFrameCommand(
+                bundle_file=bundle_file,
+                key=SEA_LEVEL_KEY,
+                input_file=tmp_path / "absent.csv",
+            )
+        )
+
+
+def test_an_invalid_key_is_rejected_before_the_bundle_is_opened(
+    bundle_file: Path, source_file: Path
+) -> None:
+    with pytest.raises(ValueError, match="leading or trailing slash"):
+        run_ingest_frame(
+            IngestFrameCommand(
+                bundle_file=bundle_file,
+                key="/metocean/worldtides/sealevel",
+                input_file=source_file,
+            )
+        )
+
+
+def test_cli_ingest_frame_writes_the_frame(
+    bundle_file: Path, source_file: Path
+) -> None:
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "bundle",
+            "ingest-frame",
+            "--bundle",
+            str(bundle_file),
+            "--key",
+            SEA_LEVEL_KEY,
+            "--file",
+            str(source_file),
+            "--datetime-column",
+            "datetime",
+        ],
+    )
+
+    assert result.exit_code == 0
+    with open_deployment_bundle_reader(bundle_file) as reader:
+        assert SEA_LEVEL_KEY in reader.list_frames()
+
+
+def test_cli_ingest_frame_exits_non_zero_on_a_missing_bundle(
+    tmp_path: Path, source_file: Path
+) -> None:
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "bundle",
+            "ingest-frame",
+            "--bundle",
+            str(tmp_path / "absent.sqlite"),
+            "--key",
+            SEA_LEVEL_KEY,
+            "--file",
+            str(source_file),
+        ],
+    )
+
+    assert result.exit_code != 0

--- a/tests/test_tasks_deployment_bundle_common.py
+++ b/tests/test_tasks_deployment_bundle_common.py
@@ -13,11 +13,11 @@ from afft.deployment import (
     open_deployment_bundle_reader,
 )
 from afft.tasks.deployment_bundle_common import (
-    IngestFrameCommand,
-    IngestFrameResult,
+    IngestBundleFrameCommand,
+    IngestBundleFrameResult,
     read_frame_file,
-    run_ingest_frame,
-    validate_frame_key,
+    run_ingest_bundle_frame,
+    validate_bundle_frame_key,
 )
 
 SEA_LEVEL_CSV: str = (
@@ -49,9 +49,11 @@ def bundle_file(tmp_path: Path) -> Path:
 
 
 def test_valid_frame_keys_are_accepted() -> None:
-    validate_frame_key(SEA_LEVEL_KEY)
-    validate_frame_key("bundle")
-    validate_frame_key("platform/sensors/usbl_linkquest_transceiver/extrinsics")
+    validate_bundle_frame_key(SEA_LEVEL_KEY)
+    validate_bundle_frame_key("bundle")
+    validate_bundle_frame_key(
+        "platform/sensors/usbl_linkquest_transceiver/extrinsics"
+    )
 
 
 @pytest.mark.parametrize(
@@ -67,13 +69,13 @@ def test_valid_frame_keys_are_accepted() -> None:
 )
 def test_structurally_invalid_frame_keys_are_rejected(key: str) -> None:
     with pytest.raises(ValueError):
-        validate_frame_key(key)
+        validate_bundle_frame_key(key)
 
 
 def test_unknown_frame_keys_are_accepted() -> None:
     """Validation is structural only, so an unrecognised key still passes."""
-    validate_frame_key("metocean/worldtide/sealevel")
-    validate_frame_key("not_a_bundle_section/whatever")
+    validate_bundle_frame_key("metocean/worldtide/sealevel")
+    validate_bundle_frame_key("not_a_bundle_section/whatever")
 
 
 def test_datetime_columns_are_parsed_as_utc(source_file: Path) -> None:
@@ -103,8 +105,8 @@ def test_a_datetime_column_not_in_the_file_is_rejected(
 def test_ingested_frame_is_readable_from_the_bundle(
     bundle_file: Path, source_file: Path
 ) -> None:
-    result: IngestFrameResult = run_ingest_frame(
-        IngestFrameCommand(
+    result: IngestBundleFrameResult = run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
             bundle_file=bundle_file,
             key=SEA_LEVEL_KEY,
             input_file=source_file,
@@ -124,8 +126,8 @@ def test_ingested_frame_is_readable_from_the_bundle(
 def test_ingestion_leaves_existing_frames_alone(
     bundle_file: Path, source_file: Path
 ) -> None:
-    run_ingest_frame(
-        IngestFrameCommand(
+    run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
             bundle_file=bundle_file,
             key=SEA_LEVEL_KEY,
             input_file=source_file,
@@ -143,23 +145,23 @@ def test_ingestion_leaves_existing_frames_alone(
 def test_ingesting_over_an_existing_key_is_refused(
     bundle_file: Path, source_file: Path
 ) -> None:
-    command = IngestFrameCommand(
+    command = IngestBundleFrameCommand(
         bundle_file=bundle_file,
         key=SEA_LEVEL_KEY,
         input_file=source_file,
         datetime_columns=("datetime",),
     )
-    run_ingest_frame(command)
+    run_ingest_bundle_frame(command)
 
     with pytest.raises(ValueError, match="already holds a frame"):
-        run_ingest_frame(command)
+        run_ingest_bundle_frame(command)
 
 
 def test_overwrite_replaces_an_existing_frame(
     bundle_file: Path, source_file: Path, tmp_path: Path
 ) -> None:
-    run_ingest_frame(
-        IngestFrameCommand(
+    run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
             bundle_file=bundle_file,
             key=SEA_LEVEL_KEY,
             input_file=source_file,
@@ -169,8 +171,8 @@ def test_overwrite_replaces_an_existing_frame(
 
     replacement: Path = tmp_path / "replacement.csv"
     replacement.write_text("sea_level\n9.0\n")
-    run_ingest_frame(
-        IngestFrameCommand(
+    run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
             bundle_file=bundle_file,
             key=SEA_LEVEL_KEY,
             input_file=replacement,
@@ -188,8 +190,8 @@ def test_a_missing_bundle_is_rejected(
     tmp_path: Path, source_file: Path
 ) -> None:
     with pytest.raises(FileNotFoundError, match="deployment bundle"):
-        run_ingest_frame(
-            IngestFrameCommand(
+        run_ingest_bundle_frame(
+            IngestBundleFrameCommand(
                 bundle_file=tmp_path / "absent.sqlite",
                 key=SEA_LEVEL_KEY,
                 input_file=source_file,
@@ -201,8 +203,8 @@ def test_a_missing_input_file_is_rejected(
     bundle_file: Path, tmp_path: Path
 ) -> None:
     with pytest.raises(FileNotFoundError, match="input file"):
-        run_ingest_frame(
-            IngestFrameCommand(
+        run_ingest_bundle_frame(
+            IngestBundleFrameCommand(
                 bundle_file=bundle_file,
                 key=SEA_LEVEL_KEY,
                 input_file=tmp_path / "absent.csv",
@@ -214,8 +216,8 @@ def test_an_invalid_key_is_rejected_before_the_bundle_is_opened(
     bundle_file: Path, source_file: Path
 ) -> None:
     with pytest.raises(ValueError, match="leading or trailing slash"):
-        run_ingest_frame(
-            IngestFrameCommand(
+        run_ingest_bundle_frame(
+            IngestBundleFrameCommand(
                 bundle_file=bundle_file,
                 key="/metocean/worldtides/sealevel",
                 input_file=source_file,


### PR DESCRIPTION
## Summary

Adds `afft.tasks.deployment_bundle_common` and a `bundle ingest-frame` CLI command, so a frame from a CSV file can be written into an existing deployment bundle at a given key.

```shell
uv run afft bundle ingest-frame \
  --bundle "/path/to/deployment_bundle.sqlite" \
  --key "metocean/worldtides/sealevel" \
  --file "/path/to/sea_level.csv" \
  --datetime-column "datetime"
```

- The bundle is written **in place**. This is a deliberate, narrow exception to D1 of #177 — ingestion deposits data that already exists rather than deriving it, so copying a multi-gigabyte bundle forward per ingested frame would buy nothing D1 was protecting. The pipeline's build-don't-mutate guarantee is unaffected.
- Only the frame and its `bundle_contents` entry are written. `deployment/files` and the provenance layers are left alone.
- An existing frame at the key is refused unless `--overwrite` is given.
- Column dtypes come from `read_csv`'s inference, except for columns named by the repeatable `--datetime-column`, parsed with `pd.to_datetime(..., utc=True, format="ISO8601")` — the same call the bundle readers use.
- Key validation is structural only (non-empty, no leading/trailing slash, no empty segments, legal characters), keeping ingest free of any knowledge of the layer layout.

The new package uses the `task_types.py` / `task_helpers.py` / `task_runners.py` split, resolving the inconsistency with `build_deployment_bundle`'s `types.py` in favour of the convention `process_deployment_bundle` already follows. An `init` task for creating empty bundles is planned for the same package.

## Verification

Ingested all 113,954 rows of `qdch0ftq_20090101_20211231_sea_level.csv` into a copy of a real bundle. Frame count went 35 → 36, and the dtypes round-tripped as expected: `datetime` as `datetime64[ns, UTC]`, `dt` `int64`, `sea_level` `float64`, `atlas` `object`, and `station` as an all-`NaN` `float64` (the empty column noted in the issue).

374 tests pass, 20 of them new. `mypy` and `ruff` are clean.

## Notes

`longitude` infers as `int64` rather than `float64`, since the stored value is a whole number with no decimal point. It is within the supported dtype set and harmless, but the same logical column could land as either type depending on a file's values. Consistent with the "inference is enough" decision, and flagged because the issue did not anticipate it.

Closes #246