### PR TITLE
Add desktop batch scripts for the deployment bundle workflow

### DIFF
--- a/scripts/shell/bundle_batch_build_desktop.sh
+++ b/scripts/shell/bundle_batch_build_desktop.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/bash
+
+# Exit on the first failing command, on any unset variable, and on a failure
+# anywhere in a pipeline rather than only in its last command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DESCRIPTOR_FILE="${REPO_ROOT}/data/deployment_descriptors_v1_subset_enriched.toml"
+CONFIG_FILE="${REPO_ROOT}/config/default.toml"
+
+DEPLOYMENT_DATA_DIR="/data/exos_01/acfr_deployments_v1_subset_fixed"
+SEALEVEL_DATA_DIR="/data/exos_01/metocean_sea_level_hourly"
+OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+
+DEPLOYMENTS=(
+  "qdch0ftq_20100428_020202"
+  "qdch0ftq_20110415_020103"
+  "qdch0ftq_20120430_002423"
+  "qdch0ftq_20130406_023610"
+  "qdchdmy1_20110416_005411"
+  "qdchdmy1_20120501_071203"
+  "qdchdmy1_20130406_081713"
+  "qdchdmy1_20170525_234624"
+  "r23685bc_20100605_021022"
+  "r23685bc_20120530_233021"
+  "r23685bc_20140616_225022"
+  "r29mrd5h_20090612_225306"
+  "r29mrd5h_20110612_033752"
+  "r29mrd5h_20130611_002419"
+  "r7jjskxq_20101023_210332"
+  "r7jjskxq_20121013_060425"
+  "r7jjskxq_20131022_004934"
+)
+
+for deployment in "${DEPLOYMENTS[@]}"; do
+  uv run afft bundle build \
+    --descriptor-file "${DESCRIPTOR_FILE}" \
+    --data-dir "${DEPLOYMENT_DATA_DIR}/${deployment}_deployment_data" \
+    --config "${CONFIG_FILE}" \
+    --deployment-label "${deployment}" \
+    --output "${OUTPUT_DIR}/${deployment}_deployment_bundle.sqlite" \
+    --overwrite
+done

--- a/scripts/shell/bundle_batch_ingest_desktop.sh
+++ b/scripts/shell/bundle_batch_ingest_desktop.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/bash
+
+# Exit on the first failing command, on any unset variable, and on a failure
+# anywhere in a pipeline rather than only in its last command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+DEPLOYMENT_BUNDLE_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+SEALEVEL_DATA_DIR="/data/exos_01/metocean_sea_level_hourly"
+
+FRAME_KEY="metocean/worldtides/sealevel"
+DATETIME_COLUMN="datetime"
+
+# Bundle file to sea level file. The sea level series are per site rather
+# than per deployment, so the deployments sharing a site share a file.
+declare -A INGESTIONS=(
+  ["qdch0ftq_20100428_020202_deployment_bundle.sqlite"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20110415_020103_deployment_bundle.sqlite"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20120430_002423_deployment_bundle.sqlite"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20130406_023610_deployment_bundle.sqlite"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20110416_005411_deployment_bundle.sqlite"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20120501_071203_deployment_bundle.sqlite"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20130406_081713_deployment_bundle.sqlite"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20170525_234624_deployment_bundle.sqlite"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["r23685bc_20100605_021022_deployment_bundle.sqlite"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20120530_233021_deployment_bundle.sqlite"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20140616_225022_deployment_bundle.sqlite"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20090612_225306_deployment_bundle.sqlite"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20110612_033752_deployment_bundle.sqlite"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20130611_002419_deployment_bundle.sqlite"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20101023_210332_deployment_bundle.sqlite"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20121013_060425_deployment_bundle.sqlite"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20131022_004934_deployment_bundle.sqlite"]="r7jjskxq_20090101_20211231_sea_level.csv"
+)
+
+# Associative arrays iterate in hash order, so sort the keys to keep runs
+# reproducible and their logs comparable.
+for bundle_file in $(printf "%s\n" "${!INGESTIONS[@]}" | sort); do
+  # Retrieve sealevel file from associative array
+  sealevel_file="${INGESTIONS[${bundle_file}]}"
+
+  bundle_path="${DEPLOYMENT_BUNDLE_DIR}/${bundle_file}"
+  sealevel_path="${SEALEVEL_DATA_DIR}/${sealevel_file}"
+
+  uv run afft bundle ingest-frame \
+    --bundle "${bundle_path}" \
+    --key "${FRAME_KEY}" \
+    --file "${sealevel_path}" \
+    --datetime-column "${DATETIME_COLUMN}" \
+    --overwrite
+done

--- a/scripts/shell/bundle_batch_process_desktop.sh
+++ b/scripts/shell/bundle_batch_process_desktop.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+# Exit on the first failing command, on any unset variable, and on a failure
+# anywhere in a pipeline rather than only in its last command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CONFIG_FILE="${REPO_ROOT}/config/default.toml"
+
+INPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset_processed"
+
+BUNDLE_FILES=(
+  "qdch0ftq_20100428_020202_deployment_bundle.sqlite"
+  "qdch0ftq_20110415_020103_deployment_bundle.sqlite"
+  "qdch0ftq_20120430_002423_deployment_bundle.sqlite"
+  "qdch0ftq_20130406_023610_deployment_bundle.sqlite"
+  "qdchdmy1_20110416_005411_deployment_bundle.sqlite"
+  "qdchdmy1_20120501_071203_deployment_bundle.sqlite"
+  "qdchdmy1_20130406_081713_deployment_bundle.sqlite"
+  "qdchdmy1_20170525_234624_deployment_bundle.sqlite"
+  "r23685bc_20100605_021022_deployment_bundle.sqlite"
+  "r23685bc_20120530_233021_deployment_bundle.sqlite"
+  "r23685bc_20140616_225022_deployment_bundle.sqlite"
+  "r29mrd5h_20090612_225306_deployment_bundle.sqlite"
+  "r29mrd5h_20110612_033752_deployment_bundle.sqlite"
+  "r29mrd5h_20130611_002419_deployment_bundle.sqlite"
+  "r7jjskxq_20101023_210332_deployment_bundle.sqlite"
+  "r7jjskxq_20121013_060425_deployment_bundle.sqlite"
+  "r7jjskxq_20131022_004934_deployment_bundle.sqlite"
+)
+
+mkdir -p "${OUTPUT_DIR}"
+
+for bundle_file in "${BUNDLE_FILES[@]}"; do
+  uv run afft bundle process \
+    --input "${INPUT_DIR}/${bundle_file}" \
+    --output "${OUTPUT_DIR}/${bundle_file}" \
+    --config "${CONFIG_FILE}" \
+    --overwrite \
+    --verbose
+done


### PR DESCRIPTION
## Summary

Adds the three shell scripts driving the deployment bundle workflow against the subset dataset on the desktop workstation.

- `bundle_batch_build_desktop.sh` — builds the 17 subset bundles from the enriched descriptors and raw message logs.
- `bundle_batch_ingest_desktop.sh` — ingests the stored hourly WorldTides sea level series into each bundle at `metocean/worldtides/sealevel`, using the `bundle ingest-frame` command added in #249.
- `bundle_batch_process_desktop.sh` — runs the processing pipeline over the bundles.

The data paths are specific to this machine, so these sit alongside the portable `bundle_batch_build.sh` and `bundle_batch_process.sh` rather than replacing them.

The sea level series are per site rather than per deployment, so the four `qdch0ftq_*` deployments all draw from one file. The ingest script therefore maps bundle to sea level file through an associative array rather than deriving one name from the other, and iterates over sorted keys so runs stay reproducible and their logs comparable.

## Notes

Ingestion is an in-place mutation, so `bundle_batch_ingest_desktop.sh` writes directly into the bundles in `acfr_deployment_bundles_v1_subset`. Re-running is safe -- every invocation passes `--overwrite`.