### PR TITLE
Name the sensor steps' inputs after what they carry

### DIFF
--- a/config/default.toml
+++ b/config/default.toml
@@ -25,7 +25,7 @@ GPS_RMC = "GpsRmcMessageV1"
 [[afft.tasks.process_deployment_bundle.pipeline.steps]]
 processor            = "pair_stereo_images"
 output               = "telemetry/processed/camera_avt_prosilica/VIS/stereo_image_pairs"
-inputs.df            = "telemetry/raw/camera_avt_prosilica/VIS/messages"
+inputs.images        = "telemetry/raw/camera_avt_prosilica/VIS/messages"
 config.left_suffix   = "LC16"
 config.right_suffix  = "RM16"
 config.max_offset_ms = 300.0
@@ -33,7 +33,7 @@ config.max_offset_ms = 300.0
 [[afft.tasks.process_deployment_bundle.pipeline.steps]]
 processor               = "estimate_pressure_uncertainty"
 output                  = "telemetry/intermediate/pressure_parosci/depth_with_uncertainty"
-inputs.df               = "telemetry/raw/pressure_parosci/PAROSCI/messages"
+inputs.pressure         = "telemetry/raw/pressure_parosci/PAROSCI/messages"
 config.base_uncertainty = 0.1
 config.depth_scale      = 0.0
 
@@ -51,7 +51,7 @@ optional               = true
 [[afft.tasks.process_deployment_bundle.pipeline.steps]]
 processor                     = "estimate_dvl_uncertainty"
 output                        = "telemetry/processed/dvl_teledyne_navigator/RDI/messages"
-inputs.df                     = "telemetry/raw/dvl_teledyne_navigator/RDI/messages"
+inputs.dvl                    = "telemetry/raw/dvl_teledyne_navigator/RDI/messages"
 config.velocity_x_uncertainty = 0.003
 config.velocity_y_uncertainty = 0.003
 config.velocity_z_uncertainty = 0.003

--- a/src/afft/bundle_processing/sensor_processors.py
+++ b/src/afft/bundle_processing/sensor_processors.py
@@ -116,7 +116,7 @@ def step_pair_stereo_images(
     config: StereoPairingConfig,
 ) -> pd.DataFrame:
     """Pair left/right stereo captures into one frame per trigger."""
-    result: StereoPairingResult = pair_stereo_images(frames["df"], config)
+    result: StereoPairingResult = pair_stereo_images(frames["images"], config)
     return result.frame
 
 
@@ -128,7 +128,7 @@ def step_estimate_pressure_uncertainty(
     config: PressureUncertaintyConfig,
 ) -> pd.DataFrame:
     """Add a `depth_uncertainty` column to a pressure frame."""
-    return estimate_pressure_uncertainty(frames["df"], config)
+    return estimate_pressure_uncertainty(frames["pressure"], config)
 
 
 @register_processor(
@@ -153,7 +153,7 @@ def step_estimate_dvl_uncertainty(
     config: DvlUncertaintyConfig,
 ) -> pd.DataFrame:
     """Add per-axis velocity and attitude uncertainty columns to a DVL frame."""
-    return estimate_dvl_uncertainty(frames["df"], config)
+    return estimate_dvl_uncertainty(frames["dvl"], config)
 
 
 @register_processor(


### PR DESCRIPTION
## Summary

Renames the single-input sensor steps' frame inputs from `df` to names that say what the step expects:

| Step | Was | Now |
|---|---|---|
| `pair_stereo_images` | `inputs.df` | `inputs.images` |
| `estimate_pressure_uncertainty` | `inputs.df` | `inputs.pressure` |
| `estimate_dvl_uncertainty` | `inputs.df` | `inputs.dvl` |

`df` carried no information and read as the odd one out next to the USBL steps, whose inputs are already named `usbl`, `pressure`, and `extrinsics`. Applied to both the wrappers in `afft.bundle_processing.sensor_processors` and `config/default.toml`.

The generic processors in `common_processors` -- `rename_columns`, `select_columns`, `drop_columns` -- keep `df`. They operate on any frame and have nothing to name it after, so the name is honest there.

Verified by resolving `config/default.toml` through `build_pipeline` and checking each step's resolved inputs, since the test suite builds its pipelines from inline fixtures rather than from the shipped config.

## Note for reviewers

Input names are part of the config contract, so any pipeline config outside this repository that drives these three steps needs the same rename.

This touches `config/default.toml` lines adjacent to those changed in #252, so whichever of the two merges second will need a small manual conflict resolution in that file.
