### PR TITLE
Add an export bundle frame task and CLI command

### DIFF
--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -16,7 +16,9 @@ from afft.tasks.build_deployment_bundle import (
     run_build_deployment_bundle,
 )
 from afft.tasks.deployment_bundle_common import (
+    ExportBundleFrameCommand,
     IngestBundleFrameCommand,
+    run_export_bundle_frame,
     run_ingest_bundle_frame,
 )
 from afft.tasks.process_deployment_bundle import (
@@ -96,6 +98,22 @@ def dispatch_ingest_bundle_frame(
         overwrite=overwrite,
     )
     run_ingest_bundle_frame(command)
+
+
+def dispatch_export_bundle_frame(
+    bundle_file: str | Path,
+    key: str,
+    output_file: str | Path,
+    overwrite: bool = False,
+) -> None:
+    """Export a single frame from a deployment bundle to a file."""
+    command = ExportBundleFrameCommand(
+        bundle_file=Path(bundle_file),
+        key=key,
+        output_file=Path(output_file),
+        overwrite=overwrite,
+    )
+    run_export_bundle_frame(command)
 
 
 def dispatch_process_deployment_bundle(

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -4,6 +4,7 @@ import click
 
 from .actions import (
     dispatch_build_deployment_bundle,
+    dispatch_export_bundle_frame,
     dispatch_ingest_bundle_frame,
     dispatch_list_deployment_bundle,
     dispatch_process_deployment_bundle,
@@ -201,5 +202,46 @@ def ingest_frame(
         key,
         input_file,
         datetime_columns,
+        overwrite,
+    )
+
+
+@bundle_group.command("export-frame")
+@click.option(
+    "--bundle",
+    "bundle_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment bundle to export from, never written",
+)
+@click.option(
+    "--key",
+    required=True,
+    help="bundle key to read the frame from",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    required=True,
+    help="path to write the frame to; its suffix selects the format",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="overwrite the output file if it already exists",
+)
+def export_frame(
+    bundle_file: str,
+    key: str,
+    output_file: str,
+    overwrite: bool,
+) -> None:
+    """Export a single frame from a deployment bundle to a file."""
+    dispatch_export_bundle_frame(
+        bundle_file,
+        key,
+        output_file,
         overwrite,
     )

--- a/src/afft/tasks/deployment_bundle_common/__init__.py
+++ b/src/afft/tasks/deployment_bundle_common/__init__.py
@@ -3,12 +3,17 @@
 from .task_helpers import (
     read_frame_file as read_frame_file,
     validate_bundle_frame_key as validate_bundle_frame_key,
+    validate_export_bundle_frame_input as validate_export_bundle_frame_input,
     validate_ingest_bundle_frame_input as validate_ingest_bundle_frame_input,
+    write_frame_file as write_frame_file,
 )
 from .task_runners import (
+    run_export_bundle_frame as run_export_bundle_frame,
     run_ingest_bundle_frame as run_ingest_bundle_frame,
 )
 from .task_types import (
+    ExportBundleFrameCommand as ExportBundleFrameCommand,
+    ExportBundleFrameResult as ExportBundleFrameResult,
     IngestBundleFrameCommand as IngestBundleFrameCommand,
     IngestBundleFrameResult as IngestBundleFrameResult,
 )

--- a/src/afft/tasks/deployment_bundle_common/task_helpers.py
+++ b/src/afft/tasks/deployment_bundle_common/task_helpers.py
@@ -1,15 +1,17 @@
 """Supporting functions for the common deployment bundle tasks: key
-validation, frame reading, and input validation."""
+validation, frame reading and writing, and input validation."""
 
 import re
 
+from collections.abc import Callable
 from pathlib import Path
 
 import pandas as pd
 
-from .task_types import IngestBundleFrameCommand
+from .task_types import ExportBundleFrameCommand, IngestBundleFrameCommand
 
 type BundleFrameKey = str
+type FrameWriter = Callable[[pd.DataFrame, Path], None]
 
 _SEGMENT_PATTERN: re.Pattern[str] = re.compile(r"^[A-Za-z0-9._-]+$")
 
@@ -93,6 +95,76 @@ def read_frame_file(
     return frame
 
 
+def write_frame_file(frame: pd.DataFrame, output_file: Path) -> None:
+    """
+    Write a frame to a file, choosing the writer from the file's suffix.
+
+    The index is not written where the writer offers the choice. Bundle
+    frames carry a default ``RangeIndex``, so an index column would be a
+    row number that the reader would then take for data.
+
+    Arguments
+    ---------
+    frame: Frame to write.
+    output_file: Path to write to. Its suffix selects the writer.
+
+    Raises
+    ------
+    ValueError: If the suffix does not name a supported format.
+    """
+    writer: FrameWriter | None = _FRAME_WRITERS.get(output_file.suffix)
+    if writer is None:
+        raise ValueError(
+            f"unsupported output file suffix {output_file.suffix!r}: "
+            f"{output_file}; supported suffixes are "
+            f"{sorted(_FRAME_WRITERS)}"
+        )
+
+    writer(frame, output_file)
+
+
+def validate_export_bundle_frame_input(
+    command: ExportBundleFrameCommand,
+) -> None:
+    """
+    Validate the task's inputs before the bundle is opened.
+
+    Whether the key holds a frame is not checked here -- that needs the
+    bundle open, and the runner reports it against the keys the bundle
+    actually holds.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Raises
+    ------
+    FileNotFoundError: If the bundle does not exist.
+    FileExistsError: If the output file exists and ``overwrite`` is not set.
+    ValueError: If the frame key is not structurally valid, or if the
+        output file's suffix does not name a supported format.
+    """
+    validate_bundle_frame_key(command.key)
+
+    if command.output_file.suffix not in _FRAME_WRITERS:
+        raise ValueError(
+            f"unsupported output file suffix "
+            f"{command.output_file.suffix!r}: {command.output_file}; "
+            f"supported suffixes are {sorted(_FRAME_WRITERS)}"
+        )
+
+    if not command.bundle_file.is_file():
+        raise FileNotFoundError(
+            f"deployment bundle does not exist: {command.bundle_file}"
+        )
+
+    if command.output_file.exists() and not command.overwrite:
+        raise FileExistsError(
+            f"output file already exists: {command.output_file}: "
+            f"pass overwrite to replace it"
+        )
+
+
 def validate_ingest_bundle_frame_input(
     command: IngestBundleFrameCommand,
 ) -> None:
@@ -119,3 +191,38 @@ def validate_ingest_bundle_frame_input(
         raise FileNotFoundError(
             f"input file does not exist: {command.input_file}"
         )
+
+
+def _write_csv(frame: pd.DataFrame, output_file: Path) -> None:
+    """Write a frame as CSV, with timestamps as ISO8601 in UTC.
+
+    The default timestamp rendering is what ``read_frame_file`` parses back
+    with ``format="ISO8601"``, which is what keeps an exported CSV
+    ingestable.
+    """
+    frame.to_csv(output_file, index=False)
+
+
+def _write_parquet(frame: pd.DataFrame, output_file: Path) -> None:
+    frame.to_parquet(output_file, index=False)
+
+
+def _write_feather(frame: pd.DataFrame, output_file: Path) -> None:
+    frame.to_feather(output_file)
+
+
+def _write_json(frame: pd.DataFrame, output_file: Path) -> None:
+    """Write a frame as a JSON array of row objects.
+
+    ``orient="records"`` drops the index, and ``date_format="iso"`` keeps
+    timestamps readable rather than rendering them as epoch milliseconds.
+    """
+    frame.to_json(output_file, orient="records", date_format="iso")
+
+
+_FRAME_WRITERS: dict[str, FrameWriter] = {
+    ".csv": _write_csv,
+    ".feather": _write_feather,
+    ".json": _write_json,
+    ".parquet": _write_parquet,
+}

--- a/src/afft/tasks/deployment_bundle_common/task_runners.py
+++ b/src/afft/tasks/deployment_bundle_common/task_runners.py
@@ -4,11 +4,88 @@ from typing import Literal
 
 import pandas as pd
 
-from afft.deployment import DeploymentBundleIO, open_deployment_bundle
+from afft.deployment import (
+    DeploymentBundleIO,
+    DeploymentBundleReader,
+    open_deployment_bundle,
+    open_deployment_bundle_reader,
+)
 from afft.utils.log import logger
 
-from .task_helpers import read_frame_file, validate_ingest_bundle_frame_input
-from .task_types import IngestBundleFrameCommand, IngestBundleFrameResult
+from .task_helpers import (
+    read_frame_file,
+    validate_export_bundle_frame_input,
+    validate_ingest_bundle_frame_input,
+    write_frame_file,
+)
+from .task_types import (
+    ExportBundleFrameCommand,
+    ExportBundleFrameResult,
+    IngestBundleFrameCommand,
+    IngestBundleFrameResult,
+)
+
+
+def run_export_bundle_frame(
+    command: ExportBundleFrameCommand,
+) -> ExportBundleFrameResult:
+    """
+    Export a single frame from a deployment bundle to a file.
+
+    The bundle is opened through the reader interface and is never written,
+    so an export cannot damage the bundle it reads.
+
+    A key the bundle does not hold raises, and the message names the keys
+    it does. Getting the key wrong is the expected user error here -- they
+    are long, layered, and vary by deployment -- and a bare "no frame at
+    that key" turns a typo into a round trip through ``afft bundle list``.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The run's result, naming the file written and the frame's shape.
+
+    Raises
+    ------
+    FileNotFoundError: If the bundle does not exist.
+    FileExistsError: If the output file exists and ``overwrite`` is not set.
+    ValueError: If the frame key is not structurally valid, if the output
+        file's suffix does not name a supported format, or if the bundle
+        holds no frame at the key.
+    """
+    validate_export_bundle_frame_input(command)
+
+    reader: DeploymentBundleReader
+    with open_deployment_bundle_reader(command.bundle_file) as reader:
+        if not reader.has_frame(command.key):
+            raise ValueError(
+                f"bundle holds no frame at {command.key!r}: "
+                f"{command.bundle_file} holds {sorted(reader.list_frames())}"
+            )
+        frame: pd.DataFrame = reader.read_frame(command.key)
+
+    logger.info("-------------------------------------")
+    logger.info("Export Frame")
+    logger.info(f"  bundle file: {command.bundle_file}")
+    logger.info(f"  key:         {command.key}")
+    logger.info(f"  output file: {command.output_file}")
+    logger.info(f"  rows:        {len(frame)}")
+    logger.info("-------------------------------------")
+
+    command.output_file.parent.mkdir(parents=True, exist_ok=True)
+    write_frame_file(frame, command.output_file)
+
+    logger.info(f"wrote {command.key} to {command.output_file}")
+
+    return ExportBundleFrameResult(
+        output_file=command.output_file,
+        key=command.key,
+        rows=len(frame),
+        columns=tuple(frame.columns),
+    )
 
 
 def run_ingest_bundle_frame(

--- a/src/afft/tasks/deployment_bundle_common/task_types.py
+++ b/src/afft/tasks/deployment_bundle_common/task_types.py
@@ -27,6 +27,26 @@ class IngestBundleFrameCommand(BaseModel):
     overwrite: bool = False
 
 
+class ExportBundleFrameCommand(BaseModel):
+    """
+    Attributes
+    ----------
+    bundle_file: Path to the deployment bundle to export from. Read only;
+        never written.
+    key: Bundle key to read the frame from.
+    output_file: Path to write the frame to. Its suffix selects the output
+        format.
+    overwrite: Overwrite an existing output file.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    bundle_file: Path
+    key: str
+    output_file: Path
+    overwrite: bool = False
+
+
 class IngestBundleFrameResult(BaseModel):
     """
     Attributes
@@ -40,6 +60,24 @@ class IngestBundleFrameResult(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     bundle_file: Path
+    key: str
+    rows: int
+    columns: tuple[str, ...]
+
+
+class ExportBundleFrameResult(BaseModel):
+    """
+    Attributes
+    ----------
+    output_file: Path the frame was written to.
+    key: Bundle key the frame was read from.
+    rows: Number of rows written.
+    columns: Column names written, in frame order.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    output_file: Path
     key: str
     rows: int
     columns: tuple[str, ...]

--- a/tests/test_tasks_deployment_bundle_common.py
+++ b/tests/test_tasks_deployment_bundle_common.py
@@ -13,9 +13,12 @@ from afft.deployment import (
     open_deployment_bundle_reader,
 )
 from afft.tasks.deployment_bundle_common import (
+    ExportBundleFrameCommand,
+    ExportBundleFrameResult,
     IngestBundleFrameCommand,
     IngestBundleFrameResult,
     read_frame_file,
+    run_export_bundle_frame,
     run_ingest_bundle_frame,
     validate_bundle_frame_key,
 )
@@ -46,6 +49,20 @@ def bundle_file(tmp_path: Path) -> Path:
             "telemetry/raw/pressure/messages", pd.DataFrame({"value": [1.0]})
         )
     return path
+
+
+@pytest.fixture
+def populated_bundle_file(bundle_file: Path, source_file: Path) -> Path:
+    """A bundle holding the sea level frame, as ingest writes it."""
+    run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
+            bundle_file=bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=source_file,
+            datetime_columns=("datetime",),
+        )
+    )
+    return bundle_file
 
 
 def test_valid_frame_keys_are_accepted() -> None:
@@ -263,6 +280,224 @@ def test_cli_ingest_frame_exits_non_zero_on_a_missing_bundle(
             SEA_LEVEL_KEY,
             "--file",
             str(source_file),
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+@pytest.mark.parametrize(
+    "suffix, read",
+    [
+        (".csv", pd.read_csv),
+        (".parquet", pd.read_parquet),
+        (".feather", pd.read_feather),
+        (".json", pd.read_json),
+    ],
+)
+def test_an_exported_frame_reads_back_with_the_bundle_contents(
+    populated_bundle_file: Path,
+    tmp_path: Path,
+    suffix: str,
+    read: object,
+) -> None:
+    """Every supported suffix carries the rows and columns through."""
+    output_file: Path = tmp_path / f"exported{suffix}"
+
+    result: ExportBundleFrameResult = run_export_bundle_frame(
+        ExportBundleFrameCommand(
+            bundle_file=populated_bundle_file,
+            key=SEA_LEVEL_KEY,
+            output_file=output_file,
+        )
+    )
+
+    assert result.rows == 2
+    assert "sea_level" in result.columns
+
+    frame: pd.DataFrame = read(output_file)  # type: ignore[operator]
+    assert len(frame) == 2
+    assert frame["sea_level"].to_list() == [0.266, 0.311]
+
+
+@pytest.mark.parametrize(
+    "suffix, read",
+    [(".parquet", pd.read_parquet), (".feather", pd.read_feather)],
+)
+def test_the_binary_formats_preserve_the_timestamp_dtype(
+    populated_bundle_file: Path,
+    tmp_path: Path,
+    suffix: str,
+    read: object,
+) -> None:
+    """Parquet and Feather carry `datetime64[ns, UTC]` in the file, so a
+    round trip needs no timestamp handling at all."""
+    output_file: Path = tmp_path / f"exported{suffix}"
+    run_export_bundle_frame(
+        ExportBundleFrameCommand(
+            bundle_file=populated_bundle_file,
+            key=SEA_LEVEL_KEY,
+            output_file=output_file,
+        )
+    )
+
+    frame: pd.DataFrame = read(output_file)  # type: ignore[operator]
+
+    assert isinstance(frame["datetime"].dtype, pd.DatetimeTZDtype)
+
+
+def test_an_exported_csv_can_be_ingested_back(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    """The property that keeps export and ingest a pair rather than two
+    commands that happen to share a file format."""
+    output_file: Path = tmp_path / "exported.csv"
+    run_export_bundle_frame(
+        ExportBundleFrameCommand(
+            bundle_file=populated_bundle_file,
+            key=SEA_LEVEL_KEY,
+            output_file=output_file,
+        )
+    )
+
+    run_ingest_bundle_frame(
+        IngestBundleFrameCommand(
+            bundle_file=populated_bundle_file,
+            key=SEA_LEVEL_KEY,
+            input_file=output_file,
+            datetime_columns=("datetime",),
+            overwrite=True,
+        )
+    )
+
+    with open_deployment_bundle_reader(populated_bundle_file) as reader:
+        frame: pd.DataFrame = reader.read_frame(SEA_LEVEL_KEY)
+
+    assert isinstance(frame["datetime"].dtype, pd.DatetimeTZDtype)
+    assert frame["datetime"].to_list() == [
+        pd.Timestamp("2008-12-31 15:00:00+00:00"),
+        pd.Timestamp("2008-12-31 16:00:00.500000+00:00"),
+    ]
+    assert frame["sea_level"].to_list() == [0.266, 0.311]
+
+
+def test_an_unsupported_output_suffix_is_rejected(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="unsupported output file suffix"):
+        run_export_bundle_frame(
+            ExportBundleFrameCommand(
+                bundle_file=populated_bundle_file,
+                key=SEA_LEVEL_KEY,
+                output_file=tmp_path / "exported.xlsx",
+            )
+        )
+
+
+def test_a_missing_key_names_the_keys_the_bundle_holds(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    """A bare 'no frame at that key' would turn a typo into a round trip
+    through `afft bundle list`."""
+    with pytest.raises(ValueError, match="holds no frame") as error:
+        run_export_bundle_frame(
+            ExportBundleFrameCommand(
+                bundle_file=populated_bundle_file,
+                key="metocean/worldtides/sea_level",
+                output_file=tmp_path / "exported.csv",
+            )
+        )
+
+    assert SEA_LEVEL_KEY in str(error.value)
+
+
+def test_exporting_over_an_existing_file_is_refused(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "exported.csv"
+    output_file.write_text("existing\n")
+    command = ExportBundleFrameCommand(
+        bundle_file=populated_bundle_file,
+        key=SEA_LEVEL_KEY,
+        output_file=output_file,
+    )
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        run_export_bundle_frame(command)
+
+    run_export_bundle_frame(command.model_copy(update={"overwrite": True}))
+
+    assert "sea_level" in output_file.read_text()
+
+
+def test_an_invalid_export_key_is_rejected_before_the_bundle_is_opened(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="leading or trailing slash"):
+        run_export_bundle_frame(
+            ExportBundleFrameCommand(
+                bundle_file=populated_bundle_file,
+                key="/metocean/worldtides/sealevel",
+                output_file=tmp_path / "exported.csv",
+            )
+        )
+
+
+def test_exporting_leaves_the_bundle_unchanged(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    """The reader interface makes this structural, but the guarantee is
+    what callers rely on."""
+    before: bytes = populated_bundle_file.read_bytes()
+
+    run_export_bundle_frame(
+        ExportBundleFrameCommand(
+            bundle_file=populated_bundle_file,
+            key=SEA_LEVEL_KEY,
+            output_file=tmp_path / "exported.csv",
+        )
+    )
+
+    assert populated_bundle_file.read_bytes() == before
+
+
+def test_cli_export_frame_writes_the_file(
+    populated_bundle_file: Path, tmp_path: Path
+) -> None:
+    output_file: Path = tmp_path / "exports" / "exported.csv"
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "bundle",
+            "export-frame",
+            "--bundle",
+            str(populated_bundle_file),
+            "--key",
+            SEA_LEVEL_KEY,
+            "--output",
+            str(output_file),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert output_file.is_file()
+
+
+def test_cli_export_frame_exits_non_zero_on_a_missing_bundle(
+    tmp_path: Path,
+) -> None:
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "bundle",
+            "export-frame",
+            "--bundle",
+            str(tmp_path / "absent.sqlite"),
+            "--key",
+            SEA_LEVEL_KEY,
+            "--output",
+            str(tmp_path / "exported.csv"),
         ],
     )
 


### PR DESCRIPTION
## Summary

Adds `afft bundle export-frame`, the output counterpart to `ingest-frame`: it reads one frame from a deployment bundle and writes it to a file. Until now a bundle could only be read by opening it in Python, since `bundle list` names the frames but shows no rows.

The task lives in `afft.tasks.deployment_bundle_common` alongside ingest, following the same types/helpers/runners split.

- `ExportBundleFrameCommand` and `ExportBundleFrameResult` in `task_types.py`, the result naming the file written rather than the bundle read.
- `write_frame_file` and `validate_export_bundle_frame_input` in `task_helpers.py`.
- `run_export_bundle_frame` in `task_runners.py`.
- `dispatch_export_bundle_frame` and the `export-frame` command in the bundle CLI.

The output format comes from the file's suffix rather than a `--format` flag, so the extension cannot disagree with the contents. Supported: `.csv`, `.parquet`, `.feather`, `.json` -- the single-frame pandas writers that need nothing beyond the installed dependencies. An unsupported suffix raises before the bundle is opened.

The bundle is opened with `open_deployment_bundle_reader`, which makes the read-only guarantee structural rather than a matter of the runner being careful. A key the bundle does not hold raises with the keys it does hold named in the message; mistyped keys are the expected user error here, and a bare "no frame at that key" would cost a round trip through `afft bundle list`.

CSV timestamps are written as ISO8601 in UTC, which is what `read_frame_file` parses back, so an exported CSV can be ingested unchanged. That round trip is covered by a test, since it is the property that keeps the two commands a pair rather than two commands that happen to share a file format.

Two departures from the issue as written, both minor:

- `.xlsx` was in the issue's format list but is not implemented. It needs `openpyxl`, which the project does not depend on, and adding a dependency for a format nobody has asked for is the wrong trade. It is one table entry plus one dependency whenever it is wanted.
- The JSON writer passes `orient="records", date_format="iso"` rather than bare defaults, which would otherwise write a dict-of-dicts keyed by index position with epoch-millisecond timestamps.

13 tests added, covering each supported suffix, dtype preservation through the binary formats, the ingest round trip, the overwrite guard, the missing-key message, and that the bundle is byte-identical after an export.

Closes #254
