### PR TITLE
Rename the CLI action functions from dispatch_ to invoke_

### DIFF
--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -27,7 +27,7 @@ from afft.tasks.process_deployment_bundle import (
 )
 
 
-def dispatch_build_deployment_bundle(
+def invoke_build_deployment_bundle(
     descriptor_file: str | Path,
     deployment_label: str,
     data_dir: str | Path,
@@ -50,7 +50,7 @@ def dispatch_build_deployment_bundle(
     run_build_deployment_bundle(command, config)
 
 
-def dispatch_list_deployment_bundle(
+def invoke_list_deployment_bundle(
     input_file: str | Path,
     dtypes: bool = False,
 ) -> None:
@@ -82,7 +82,7 @@ def dispatch_list_deployment_bundle(
                 logger.info(f"  {column}: {dtype}")
 
 
-def dispatch_ingest_bundle_frame(
+def invoke_ingest_bundle_frame(
     bundle_file: str | Path,
     key: str,
     input_file: str | Path,
@@ -100,7 +100,7 @@ def dispatch_ingest_bundle_frame(
     run_ingest_bundle_frame(command)
 
 
-def dispatch_export_bundle_frame(
+def invoke_export_bundle_frame(
     bundle_file: str | Path,
     key: str,
     output_file: str | Path,
@@ -116,7 +116,7 @@ def dispatch_export_bundle_frame(
     run_export_bundle_frame(command)
 
 
-def dispatch_process_deployment_bundle(
+def invoke_process_deployment_bundle(
     input_file: str | Path,
     config_file: str | Path,
     output_file: str | Path,

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -3,11 +3,11 @@
 import click
 
 from .actions import (
-    dispatch_build_deployment_bundle,
-    dispatch_export_bundle_frame,
-    dispatch_ingest_bundle_frame,
-    dispatch_list_deployment_bundle,
-    dispatch_process_deployment_bundle,
+    invoke_build_deployment_bundle,
+    invoke_export_bundle_frame,
+    invoke_ingest_bundle_frame,
+    invoke_list_deployment_bundle,
+    invoke_process_deployment_bundle,
 )
 
 
@@ -76,7 +76,7 @@ def build(
     verbose: bool,
 ) -> None:
     """Build a deployment bundle from a descriptor and its raw message logs."""
-    dispatch_build_deployment_bundle(
+    invoke_build_deployment_bundle(
         descriptor_file,
         deployment_label,
         data_dir,
@@ -103,7 +103,7 @@ def build(
 )
 def list_contents(input_file: str, dtypes: bool) -> None:
     """List the frames a deployment bundle holds."""
-    dispatch_list_deployment_bundle(input_file, dtypes)
+    invoke_list_deployment_bundle(input_file, dtypes)
 
 
 @bundle_group.command()
@@ -148,7 +148,7 @@ def process(
     verbose: bool,
 ) -> None:
     """Run the configured processing pipeline over a deployment bundle."""
-    dispatch_process_deployment_bundle(
+    invoke_process_deployment_bundle(
         input_file,
         config_file,
         output_file,
@@ -197,7 +197,7 @@ def ingest_frame(
     overwrite: bool,
 ) -> None:
     """Ingest a frame from a file into an existing deployment bundle."""
-    dispatch_ingest_bundle_frame(
+    invoke_ingest_bundle_frame(
         bundle_file,
         key,
         input_file,
@@ -239,7 +239,7 @@ def export_frame(
     overwrite: bool,
 ) -> None:
     """Export a single frame from a deployment bundle to a file."""
-    dispatch_export_bundle_frame(
+    invoke_export_bundle_frame(
         bundle_file,
         key,
         output_file,

--- a/src/afft/cli/database/actions.py
+++ b/src/afft/cli/database/actions.py
@@ -17,7 +17,7 @@ from afft.tasks.ingest_tables import IngestTablesCommand, run_ingest_tables
 from afft.utils.log import logger
 
 
-def dispatch_table_join(
+def invoke_table_join(
     database: str,
     host: str,
     port: int,
@@ -60,7 +60,7 @@ def dispatch_table_join(
         logger.info(f"Label: {label}, dataframe: {len(dataframe)}")
 
 
-def dispatch_table_export(
+def invoke_table_export(
     database: str,
     host: str,
     port: int,
@@ -110,7 +110,7 @@ def dispatch_table_export(
     progress.stop()
 
 
-def dispatch_table_ingest(
+def invoke_table_ingest(
     source_dir: str | Path,
     database: str,
     host: str,
@@ -135,7 +135,7 @@ def dispatch_table_ingest(
     run_ingest_tables(command, credentials)
 
 
-def dispatch_table_write(
+def invoke_table_write(
     source: str | Path,
     database: str,
     host: str,

--- a/src/afft/cli/database/commands.py
+++ b/src/afft/cli/database/commands.py
@@ -5,10 +5,10 @@ CLI commands for working with databases.
 import click
 
 from .actions import (
-    dispatch_table_export,
-    dispatch_table_ingest,
-    dispatch_table_join,
-    dispatch_table_write,
+    invoke_table_export,
+    invoke_table_ingest,
+    invoke_table_join,
+    invoke_table_write,
 )
 
 
@@ -26,7 +26,7 @@ def database_group(context: click.Context) -> None:
 @click.argument("config_path", type=click.Path(exists=True))
 def table_join(database: str, host: str, port: int, config_path: str) -> None:
     """Join tables in the database."""
-    dispatch_table_join(database, host, port, config_path)
+    invoke_table_join(database, host, port, config_path)
 
 
 @database_group.command()
@@ -49,7 +49,7 @@ def table_export(
     tables: tuple[str, ...],
 ) -> None:
     """Export database tables to CSV files in OUTPUT_DIR."""
-    dispatch_table_export(database, host, port, output_dir, tables)
+    invoke_table_export(database, host, port, output_dir, tables)
 
 
 @database_group.command()
@@ -96,7 +96,7 @@ def table_ingest(
     timestamp_columns: tuple[str, ...],
 ) -> None:
     """Ingest files from SOURCE_DIR as database tables."""
-    dispatch_table_ingest(
+    invoke_table_ingest(
         source_dir,
         database,
         host,
@@ -131,4 +131,4 @@ def table_write(
     overwrite: bool,
 ) -> None:
     """Write a table to a database."""
-    dispatch_table_write(source, database, host, port, name, overwrite)
+    invoke_table_write(source, database, host, port, name, overwrite)

--- a/src/afft/cli/deployment/actions.py
+++ b/src/afft/cli/deployment/actions.py
@@ -22,7 +22,7 @@ from afft.tasks.deployment_enrichment import (
 )
 
 
-def dispatch_describe_deployment(
+def invoke_describe_deployment(
     root_dir: str | Path,
     output_file: str | Path,
     deployment_suffix: str = "_deployment_data",
@@ -45,7 +45,7 @@ def dispatch_describe_deployment(
         raise SystemExit(1)
 
 
-def dispatch_scaffold_catalog(
+def invoke_scaffold_catalog(
     input_file: str | Path,
     output_file: str | Path,
     verbose: bool = False,
@@ -61,7 +61,7 @@ def dispatch_scaffold_catalog(
     run_scaffold_catalog(command)
 
 
-def dispatch_enrich_descriptor(
+def invoke_enrich_descriptor(
     input_file: str | Path,
     catalog_file: str | Path,
     output_file: str | Path,
@@ -84,7 +84,7 @@ def dispatch_enrich_descriptor(
     run_enrich_descriptor(command)
 
 
-def dispatch_summarize_descriptor(
+def invoke_summarize_descriptor(
     input_file: str | Path,
     output_file: str | Path | None = None,
     verbose: bool = False,
@@ -103,7 +103,7 @@ def dispatch_summarize_descriptor(
     run_summarize_descriptor(command)
 
 
-def dispatch_summarize_catalog(
+def invoke_summarize_catalog(
     input_file: str | Path,
     verbose: bool = False,
 ) -> None:

--- a/src/afft/cli/deployment/commands.py
+++ b/src/afft/cli/deployment/commands.py
@@ -5,11 +5,11 @@ import click
 from afft.deployment import EnrichmentSection
 
 from .actions import (
-    dispatch_describe_deployment,
-    dispatch_enrich_descriptor,
-    dispatch_scaffold_catalog,
-    dispatch_summarize_catalog,
-    dispatch_summarize_descriptor,
+    invoke_describe_deployment,
+    invoke_enrich_descriptor,
+    invoke_scaffold_catalog,
+    invoke_summarize_catalog,
+    invoke_summarize_descriptor,
 )
 
 
@@ -56,7 +56,7 @@ def describe(
     verbose: bool,
 ) -> None:
     """Describe the deployments in an ACFR deployment data directory tree."""
-    dispatch_describe_deployment(
+    invoke_describe_deployment(
         root_dir, output_file, deployment_suffix, verbose
     )
 
@@ -93,7 +93,7 @@ def scaffold_catalog(
     vessel names, sensor vendors and products, and every mounting pose — are
     left empty to be filled in by hand.
     """
-    dispatch_scaffold_catalog(input_file, output_file, verbose)
+    invoke_scaffold_catalog(input_file, output_file, verbose)
 
 
 @deployment_group.command()
@@ -144,7 +144,7 @@ def enrich(
     and vessel identities, sensor identities, and mounting poses. Passing the
     input path as the output enriches the descriptors in place.
     """
-    dispatch_enrich_descriptor(
+    invoke_enrich_descriptor(
         input_file, catalog_file, output_file, section, verbose
     )
 
@@ -180,7 +180,7 @@ def summarize(
     Without an output path, prints per-file aggregates to the terminal. With
     one, writes a detailed per-deployment report as Markdown.
     """
-    dispatch_summarize_descriptor(input_file, output_file, verbose)
+    invoke_summarize_descriptor(input_file, output_file, verbose)
 
 
 @deployment_group.command()
@@ -207,4 +207,4 @@ def summarize_catalog(
     assignment coverage, records nothing references, and the curated fields
     still left empty.
     """
-    dispatch_summarize_catalog(input_file, verbose)
+    invoke_summarize_catalog(input_file, verbose)

--- a/src/afft/cli/messages/actions.py
+++ b/src/afft/cli/messages/actions.py
@@ -6,7 +6,7 @@ from afft.environment import EnvironmentDatabase, load_environment
 from afft.tasks.parse_messages import ParseMessageCommand, run_parse_messages
 
 
-def dispatch_parse_messages(
+def invoke_parse_messages(
     source: str | Path,
     config: str | Path,
     database: str | None = None,

--- a/src/afft/cli/messages/commands.py
+++ b/src/afft/cli/messages/commands.py
@@ -4,7 +4,7 @@ CLI commands for processing AUV messages, including parsing from the native AUV 
 
 import click
 
-from .actions import dispatch_parse_messages
+from .actions import invoke_parse_messages
 
 
 @click.group()
@@ -39,6 +39,6 @@ def parse_messages(
     output_dir: str | None = None,
 ) -> None:
     """CLI action for ingesting messages into a destination."""
-    dispatch_parse_messages(
+    invoke_parse_messages(
         source, config, database, host, port, prefix, output_dir
     )

--- a/src/afft/cli/renav/actions.py
+++ b/src/afft/cli/renav/actions.py
@@ -35,7 +35,7 @@ from afft.tasks.transform_camera_poses import (
 CAMERA_SENSOR_TYPE: str = "stereo_camera"
 
 
-def dispatch_process_renav(
+def invoke_process_renav(
     input_file: str | Path,
     output_file: str | Path,
 ) -> None:
@@ -47,7 +47,7 @@ def dispatch_process_renav(
     run_process_renav_poses(command)
 
 
-def dispatch_batch_process_renav(
+def invoke_batch_process_renav(
     input_dir: str | Path,
     output_dir: str | Path,
     pattern: str = "*.txt",
@@ -61,7 +61,7 @@ def dispatch_batch_process_renav(
     run_process_renav_poses_batch(command)
 
 
-def dispatch_collect_renav_stereo_poses(
+def invoke_collect_renav_stereo_poses(
     root_dir: str | Path,
     output_dir: str | Path,
     deployment_suffix: str = "_deployment_data",
@@ -79,7 +79,7 @@ def dispatch_collect_renav_stereo_poses(
     run_collect_renav_stereo_poses(command)
 
 
-def dispatch_correct_renav_poses(
+def invoke_correct_renav_poses(
     target_file: str | Path,
     source_file: str | Path,
     output_file: str | Path,
@@ -93,7 +93,7 @@ def dispatch_correct_renav_poses(
     run_correct_renav_camera_poses(command)
 
 
-def dispatch_batch_correct_renav_poses(
+def invoke_batch_correct_renav_poses(
     target_dir: str | Path,
     source_dir: str | Path,
     output_dir: str | Path,
@@ -111,7 +111,7 @@ def dispatch_batch_correct_renav_poses(
     run_correct_renav_camera_poses_batch(command)
 
 
-def dispatch_transform_camera_poses(
+def invoke_transform_camera_poses(
     input_file: str | Path,
     output_file: str | Path,
     descriptor_file: str | Path,
@@ -128,7 +128,7 @@ def dispatch_transform_camera_poses(
     run_transform_camera_poses(command, extrinsics)
 
 
-def dispatch_transform_camera_poses_batch(
+def invoke_transform_camera_poses_batch(
     input_dir: str | Path,
     output_dir: str | Path,
     descriptor_file: str | Path,

--- a/src/afft/cli/renav/commands.py
+++ b/src/afft/cli/renav/commands.py
@@ -3,13 +3,13 @@
 import click
 
 from .actions import (
-    dispatch_batch_correct_renav_poses,
-    dispatch_batch_process_renav,
-    dispatch_collect_renav_stereo_poses,
-    dispatch_correct_renav_poses,
-    dispatch_process_renav,
-    dispatch_transform_camera_poses,
-    dispatch_transform_camera_poses_batch,
+    invoke_batch_correct_renav_poses,
+    invoke_batch_process_renav,
+    invoke_collect_renav_stereo_poses,
+    invoke_correct_renav_poses,
+    invoke_process_renav,
+    invoke_transform_camera_poses,
+    invoke_transform_camera_poses_batch,
 )
 
 
@@ -37,7 +37,7 @@ def renav_group(context: click.Context) -> None:
 )
 def process_poses(input_file: str, output_file: str) -> None:
     """Process a Renav stereo pose estimate file and write to CSV."""
-    dispatch_process_renav(input_file, output_file)
+    invoke_process_renav(input_file, output_file)
 
 
 @renav_group.command()
@@ -64,7 +64,7 @@ def process_poses(input_file: str, output_file: str) -> None:
 )
 def batch_process_poses(input_dir: str, output_dir: str, pattern: str) -> None:
     """Batch process Renav stereo pose estimate files in a directory."""
-    dispatch_batch_process_renav(input_dir, output_dir, pattern)
+    invoke_batch_process_renav(input_dir, output_dir, pattern)
 
 
 @renav_group.command()
@@ -113,7 +113,7 @@ def collect_stereo_poses(
     tiebreak_margin: float,
 ) -> None:
     """Collect and relabel Renav stereo pose estimate files by deployment."""
-    dispatch_collect_renav_stereo_poses(
+    invoke_collect_renav_stereo_poses(
         root_dir,
         output_dir,
         deployment_suffix,
@@ -150,7 +150,7 @@ def correct_poses(
     output_file: str,
 ) -> None:
     """Correct Renav camera poses with source camera pose latitude/longitude."""
-    dispatch_correct_renav_poses(target_file, source_file, output_file)
+    invoke_correct_renav_poses(target_file, source_file, output_file)
 
 
 @renav_group.command()
@@ -189,7 +189,7 @@ def transform_poses(
     deployment_label: str,
 ) -> None:
     """Transform camera poses to vehicle reference-point poses using stereo extrinsics."""
-    dispatch_transform_camera_poses(
+    invoke_transform_camera_poses(
         input_file, output_file, descriptor_file, deployment_label
     )
 
@@ -240,7 +240,7 @@ def batch_transform_poses(
     output_suffix: str,
 ) -> None:
     """Batch-transform camera poses to vehicle reference-point poses."""
-    dispatch_transform_camera_poses_batch(
+    invoke_transform_camera_poses_batch(
         input_dir, output_dir, descriptor_file, input_suffix, output_suffix
     )
 
@@ -291,7 +291,7 @@ def batch_correct_poses(
     source_suffix: str,
 ) -> None:
     """Batch-correct Renav camera poses with source camera pose latitude/longitude."""
-    dispatch_batch_correct_renav_poses(
+    invoke_batch_correct_renav_poses(
         target_dir,
         source_dir,
         output_dir,

--- a/src/afft/cli/sensors/actions.py
+++ b/src/afft/cli/sensors/actions.py
@@ -26,7 +26,7 @@ from afft.sensors.usbl_linkquest.types import (
 from afft.utils.log import logger
 
 
-def dispatch_parse_tracklink_log(
+def invoke_parse_tracklink_log(
     source_file: str | Path,
     output_file: str | Path,
 ) -> None:
@@ -41,7 +41,7 @@ def dispatch_parse_tracklink_log(
     logger.info(f"wrote {len(result)} rows → {output_path}")
 
 
-def dispatch_process_tracklink_usbl_from_messages(
+def invoke_process_tracklink_usbl_from_messages(
     usbl_file: str | Path,
     pressure_file: str | Path,
     output_file: str | Path,
@@ -98,7 +98,7 @@ def dispatch_process_tracklink_usbl_from_messages(
     logger.info(f"wrote {len(result)} rows → {output_path}")
 
 
-def dispatch_process_tracklink_usbl_from_logs(
+def invoke_process_tracklink_usbl_from_logs(
     usbl_file: str | Path,
     output_file: str | Path,
     deployment_configs: str | Path,
@@ -157,7 +157,7 @@ def dispatch_process_tracklink_usbl_from_logs(
     logger.info(f"wrote {len(result)} rows → {output_path}")
 
 
-def dispatch_process_evologics_usbl(
+def invoke_process_evologics_usbl(
     usbl_file: str | Path,
     output_file: str | Path,
     deployment_configs: str | Path,

--- a/src/afft/cli/sensors/commands.py
+++ b/src/afft/cli/sensors/commands.py
@@ -2,10 +2,10 @@
 
 import click
 
-from .actions import dispatch_parse_tracklink_log
-from .actions import dispatch_process_evologics_usbl
-from .actions import dispatch_process_tracklink_usbl_from_logs
-from .actions import dispatch_process_tracklink_usbl_from_messages
+from .actions import invoke_parse_tracklink_log
+from .actions import invoke_process_evologics_usbl
+from .actions import invoke_process_tracklink_usbl_from_logs
+from .actions import invoke_process_tracklink_usbl_from_messages
 
 
 @click.group()
@@ -35,7 +35,7 @@ def parse_tracklink_log(
     output_file: str,
 ) -> None:
     """Parse a merged TrackLink USBL log file into a CSV of fixes."""
-    dispatch_parse_tracklink_log(source_file, output_file)
+    invoke_parse_tracklink_log(source_file, output_file)
 
 
 @sensors_group.command()
@@ -90,7 +90,7 @@ def process_tracklink_usbl_from_messages(
     ignore_extrinsics: bool,
 ) -> None:
     """Resolve positions and estimate uncertainty from TrackLink AUV messages."""
-    dispatch_process_tracklink_usbl_from_messages(
+    invoke_process_tracklink_usbl_from_messages(
         usbl_file,
         pressure_file,
         output_file,
@@ -144,7 +144,7 @@ def process_tracklink_usbl_from_logs(
     ignore_extrinsics: bool,
 ) -> None:
     """Resolve positions and estimate uncertainty from TrackLink USBL log entries."""
-    dispatch_process_tracklink_usbl_from_logs(
+    invoke_process_tracklink_usbl_from_logs(
         usbl_file,
         output_file,
         deployment_configs,
@@ -197,7 +197,7 @@ def process_evologics_usbl(
     ignore_extrinsics: bool,
 ) -> None:
     """Convert Evologics USBL data to the USBL output schema."""
-    dispatch_process_evologics_usbl(
+    invoke_process_evologics_usbl(
         usbl_file,
         output_file,
         deployment_configs,

--- a/src/afft/cli/squidle/actions.py
+++ b/src/afft/cli/squidle/actions.py
@@ -28,7 +28,7 @@ def _create_client() -> SquidleClient:
     return create_client(token.get_secret_value())
 
 
-def dispatch_list_platforms(name: str | None = None) -> None:
+def invoke_list_platforms(name: str | None = None) -> None:
     """Fetch and print platforms, optionally filtered by name."""
     filters: list[dict[str, Any]] = []
     if name:
@@ -54,7 +54,7 @@ def dispatch_list_platforms(name: str | None = None) -> None:
     logger.info("\n" + dataframe.to_string(index=False))
 
 
-def dispatch_collect_deployment(
+def invoke_collect_deployment(
     deployment_id: int,
     output_file: Path,
 ) -> None:
@@ -70,7 +70,7 @@ def dispatch_collect_deployment(
     )
 
 
-def dispatch_collect_deployments(
+def invoke_collect_deployments(
     deployment_ids: list[int],
     output_dir: Path,
 ) -> None:
@@ -91,7 +91,7 @@ def dispatch_collect_deployments(
         )
 
 
-def dispatch_collect_campaign(
+def invoke_collect_campaign(
     campaign_id: int,
     output_dir: Path,
 ) -> None:
@@ -115,7 +115,7 @@ def dispatch_collect_campaign(
         )
 
 
-def dispatch_list_campaigns(name: str | None = None) -> None:
+def invoke_list_campaigns(name: str | None = None) -> None:
     """Fetch and print campaigns, optionally filtered by name."""
     filters: list[dict[str, Any]] = []
     if name:
@@ -143,7 +143,7 @@ def dispatch_list_campaigns(name: str | None = None) -> None:
     logger.info("\n" + dataframe.to_string(index=False))
 
 
-def dispatch_list_deployments(
+def invoke_list_deployments(
     campaign_id: int | None = None,
     name: str | None = None,
 ) -> None:

--- a/src/afft/cli/squidle/commands.py
+++ b/src/afft/cli/squidle/commands.py
@@ -5,12 +5,12 @@ import click
 from pathlib import Path
 
 from .actions import (
-    dispatch_collect_campaign,
-    dispatch_collect_deployment,
-    dispatch_collect_deployments,
-    dispatch_list_campaigns,
-    dispatch_list_deployments,
-    dispatch_list_platforms,
+    invoke_collect_campaign,
+    invoke_collect_deployment,
+    invoke_collect_deployments,
+    invoke_list_campaigns,
+    invoke_list_deployments,
+    invoke_list_platforms,
 )
 
 
@@ -30,7 +30,7 @@ def squidle_group(context: click.Context) -> None:
 )
 def list_platforms(name: str | None) -> None:
     """List Squidle+ platforms."""
-    dispatch_list_platforms(name)
+    invoke_list_platforms(name)
 
 
 @squidle_group.command()
@@ -42,7 +42,7 @@ def list_platforms(name: str | None) -> None:
 )
 def list_campaigns(name: str | None) -> None:
     """List Squidle+ campaigns."""
-    dispatch_list_campaigns(name)
+    invoke_list_campaigns(name)
 
 
 @squidle_group.command()
@@ -61,7 +61,7 @@ def list_campaigns(name: str | None) -> None:
 )
 def list_deployments(campaign_id: int | None, name: str | None) -> None:
     """List Squidle+ deployments."""
-    dispatch_list_deployments(campaign_id, name)
+    invoke_list_deployments(campaign_id, name)
 
 
 @squidle_group.command()
@@ -81,7 +81,7 @@ def list_deployments(campaign_id: int | None, name: str | None) -> None:
 )
 def collect_deployment(deployment_id: int, output_file: str) -> None:
     """Fetch media for a single Squidle+ deployment and write to CSV."""
-    dispatch_collect_deployment(deployment_id, Path(output_file))
+    invoke_collect_deployment(deployment_id, Path(output_file))
 
 
 @squidle_group.command()
@@ -102,7 +102,7 @@ def collect_deployment(deployment_id: int, output_file: str) -> None:
 def collect_deployments(deployment_ids: str, output_dir: str) -> None:
     """Fetch media for multiple Squidle+ deployments and write one CSV each."""
     ids: list[int] = [int(i.strip()) for i in deployment_ids.split(",")]
-    dispatch_collect_deployments(ids, Path(output_dir))
+    invoke_collect_deployments(ids, Path(output_dir))
 
 
 @squidle_group.command()
@@ -122,4 +122,4 @@ def collect_deployments(deployment_ids: str, output_dir: str) -> None:
 )
 def collect_campaign(campaign_id: int, output_dir: str) -> None:
     """Fetch media for all deployments in a Squidle+ campaign."""
-    dispatch_collect_campaign(campaign_id, Path(output_dir))
+    invoke_collect_campaign(campaign_id, Path(output_dir))

--- a/src/afft/cli/tasks/actions.py
+++ b/src/afft/cli/tasks/actions.py
@@ -13,7 +13,7 @@ from afft.tasks.collect_squidle_media import (
 )
 
 
-def dispatch_clip_tables(
+def invoke_clip_tables(
     source_dir: str | Path,
     output_dir: str | Path,
     start: datetime,
@@ -35,7 +35,7 @@ def dispatch_clip_tables(
     run_clip_tables(command)
 
 
-def dispatch_collect_squidle_media(
+def invoke_collect_squidle_media(
     deployments_file: str | Path,
     output_dir: str | Path,
     match_policy: DeploymentMatchPolicy = DeploymentMatchPolicy.BY_NAME,
@@ -44,7 +44,7 @@ def dispatch_collect_squidle_media(
     download_images: bool = False,
     verbose: bool = False,
 ) -> None:
-    """Dispatch the collect Squidle+ media task."""
+    """Invoke the collect Squidle+ media task."""
     token = load_environment().tokens.squidle
     if token is None:
         raise ValueError(

--- a/src/afft/cli/tasks/commands.py
+++ b/src/afft/cli/tasks/commands.py
@@ -9,8 +9,8 @@ import click
 from afft.tasks.collect_squidle_media import DeploymentMatchPolicy
 
 from .actions import (
-    dispatch_clip_tables,
-    dispatch_collect_squidle_media,
+    invoke_clip_tables,
+    invoke_collect_squidle_media,
 )
 
 _TIMESTAMP_FORMAT = "%Y%m%d_%H%M%S"
@@ -88,7 +88,7 @@ def clip_tables(
     timestamp_format: str,
 ) -> None:
     """Clip CSV files in SOURCE_DIR to [START, END] and write to OUTPUT_DIR."""
-    dispatch_clip_tables(
+    invoke_clip_tables(
         source_dir,
         output_dir,
         start,
@@ -162,7 +162,7 @@ def collect_squidle_media(
     verbose: bool,
 ) -> None:
     """Fetch Squidle+ media for all deployments in the ACFR deployments file."""
-    dispatch_collect_squidle_media(
+    invoke_collect_squidle_media(
         deployments_file,
         output_dir,
         DeploymentMatchPolicy(match_policy),


### PR DESCRIPTION
## Summary

Renames the CLI action functions from `dispatch_*` to `invoke_*`. These functions translate command line arguments into a task command and hand it to a runner, and `invoke` is the vocabulary Click itself uses for calling a command.

34 functions across the 8 CLI groups, renamed at their definitions in each `actions.py` and at their imports and call sites in the `commands.py` beside it. Nothing outside `src/afft/cli/` referred to them -- no task, test, script, or config -- so the change is a pure rename with no behaviour attached.

One prose change came with it: `invoke_collect_squidle_media`'s docstring read "Dispatch the collect Squidle+ media task", which would otherwise have contradicted the name.

`request_data_and_dispatch` in `afft.tasks.database_tasks` keeps its name. It is not a CLI action, and the word carries a different meaning there.

Verified with ruff, ruff format, mypy over 216 files, and the 399 tests, plus `--help` on the root command and all 8 groups. The help check matters here more than the rest: Click wires these functions in at import time, so a missed rename would surface only when a command was actually run, not at type-check.
