### PR TITLE
Look up sea level files from an associative array

### DIFF
--- a/scripts/shell/bundle_batch_workflow_desktop.sh
+++ b/scripts/shell/bundle_batch_workflow_desktop.sh
@@ -17,42 +17,37 @@ OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
 SEALEVEL_KEY="metocean/worldtides/sealevel"
 SEALEVEL_DATETIME_COLUMN="datetime"
 
-# The sea level series were fetched once for a fixed span covering every
-# deployment, so the range is a constant of the data rather than something
-# derived per site.
-SEALEVEL_RANGE="20090101_20211231"
-
-DEPLOYMENTS=(
-  "qdch0ftq_20100428_020202"
-  "qdch0ftq_20110415_020103"
-  "qdch0ftq_20120430_002423"
-  "qdch0ftq_20130406_023610"
-  "qdchdmy1_20110416_005411"
-  "qdchdmy1_20120501_071203"
-  "qdchdmy1_20130406_081713"
-  "qdchdmy1_20170525_234624"
-  "r23685bc_20100605_021022"
-  "r23685bc_20120530_233021"
-  "r23685bc_20140616_225022"
-  "r29mrd5h_20090612_225306"
-  "r29mrd5h_20110612_033752"
-  "r29mrd5h_20130611_002419"
-  "r7jjskxq_20101023_210332"
-  "r7jjskxq_20121013_060425"
-  "r7jjskxq_20131022_004934"
+# Sea level file per deployment. The series are per site rather than per
+# deployment, so the deployments sharing a site share a file.
+declare -A SEALEVEL_FILES=(
+  ["qdch0ftq_20100428_020202"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20110415_020103"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20120430_002423"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20130406_023610"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20110416_005411"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20120501_071203"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20130406_081713"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20170525_234624"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["r23685bc_20100605_021022"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20120530_233021"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20140616_225022"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20090612_225306"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20110612_033752"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20130611_002419"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20101023_210332"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20121013_060425"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20131022_004934"]="r7jjskxq_20090101_20211231_sea_level.csv"
 )
 
 # Building overwrites the bundle, so the sea level ingestion has to follow the
 # build of the same deployment rather than run as a second pass over all of
 # them -- a rebuild would otherwise discard a frame ingested earlier.
-for deployment in "${DEPLOYMENTS[@]}"; do
+#
+# Associative arrays iterate in hash order, so sort the keys to keep runs
+# reproducible and their logs comparable.
+for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
   bundle_file="${OUTPUT_DIR}/${deployment}_deployment_bundle.sqlite"
-
-  # The sea level series are per site rather than per deployment, so the
-  # deployments sharing a site share a file. The site is the deployment
-  # label's first segment.
-  site="${deployment%%_*}"
-  sealevel_file="${SEALEVEL_DATA_DIR}/${site}_${SEALEVEL_RANGE}_sea_level.csv"
+  sealevel_file="${SEALEVEL_DATA_DIR}/${SEALEVEL_FILES[${deployment}]}"
 
   uv run afft bundle build \
     --descriptor-file "${DESCRIPTOR_FILE}" \

--- a/scripts/shell/bundle_batch_workflow_laptop.sh
+++ b/scripts/shell/bundle_batch_workflow_laptop.sh
@@ -17,42 +17,37 @@ OUTPUT_DIR="${HOME}/data/acfr_deployment_bundles_v1_subset"
 SEALEVEL_KEY="metocean/worldtides/sealevel"
 SEALEVEL_DATETIME_COLUMN="datetime"
 
-# The sea level series were fetched once for a fixed span covering every
-# deployment, so the range is a constant of the data rather than something
-# derived per site.
-SEALEVEL_RANGE="20090101_20211231"
-
-DEPLOYMENTS=(
-  "qdch0ftq_20100428_020202"
-  "qdch0ftq_20110415_020103"
-  "qdch0ftq_20120430_002423"
-  "qdch0ftq_20130406_023610"
-  "qdchdmy1_20110416_005411"
-  "qdchdmy1_20120501_071203"
-  "qdchdmy1_20130406_081713"
-  "qdchdmy1_20170525_234624"
-  "r23685bc_20100605_021022"
-  "r23685bc_20120530_233021"
-  "r23685bc_20140616_225022"
-  "r29mrd5h_20090612_225306"
-  "r29mrd5h_20110612_033752"
-  "r29mrd5h_20130611_002419"
-  "r7jjskxq_20101023_210332"
-  "r7jjskxq_20121013_060425"
-  "r7jjskxq_20131022_004934"
+# Sea level file per deployment. The series are per site rather than per
+# deployment, so the deployments sharing a site share a file.
+declare -A SEALEVEL_FILES=(
+  ["qdch0ftq_20100428_020202"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20110415_020103"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20120430_002423"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdch0ftq_20130406_023610"]="qdch0ftq_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20110416_005411"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20120501_071203"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20130406_081713"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["qdchdmy1_20170525_234624"]="qdchdmy1_20090101_20211231_sea_level.csv"
+  ["r23685bc_20100605_021022"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20120530_233021"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r23685bc_20140616_225022"]="r23685bc_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20090612_225306"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20110612_033752"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r29mrd5h_20130611_002419"]="r29mrd5h_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20101023_210332"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20121013_060425"]="r7jjskxq_20090101_20211231_sea_level.csv"
+  ["r7jjskxq_20131022_004934"]="r7jjskxq_20090101_20211231_sea_level.csv"
 )
 
 # Building overwrites the bundle, so the sea level ingestion has to follow the
 # build of the same deployment rather than run as a second pass over all of
 # them -- a rebuild would otherwise discard a frame ingested earlier.
-for deployment in "${DEPLOYMENTS[@]}"; do
+#
+# Associative arrays iterate in hash order, so sort the keys to keep runs
+# reproducible and their logs comparable.
+for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
   bundle_file="${OUTPUT_DIR}/${deployment}_deployment_bundle.sqlite"
-
-  # The sea level series are per site rather than per deployment, so the
-  # deployments sharing a site share a file. The site is the deployment
-  # label's first segment.
-  site="${deployment%%_*}"
-  sealevel_file="${SEALEVEL_DATA_DIR}/${site}_${SEALEVEL_RANGE}_sea_level.csv"
+  sealevel_file="${SEALEVEL_DATA_DIR}/${SEALEVEL_FILES[${deployment}]}"
 
   uv run afft bundle build \
     --descriptor-file "${DESCRIPTOR_FILE}" \


### PR DESCRIPTION
## Summary

Looks the sea level file up from an associative array keyed on the deployment label, in both bundle workflow scripts.

The file was previously derived from the deployment label's site segment. That derivation ties every deployment to the per-site naming rule, so a deployment whose sea level series does not follow it cannot be expressed. The map states each pairing outright:

```bash
declare -A SEALEVEL_FILES=(
  ["qdch0ftq_20100428_020202"]="qdch0ftq_20090101_20211231_sea_level.csv"
  ...
)
```

The map's keys are the deployment list, so the separate `DEPLOYMENTS` array is gone rather than kept alongside it, and the loop iterates the sorted keys. The labels were already in sorted order, so the execution order is unchanged. `SEALEVEL_RANGE` is gone as well, since the file names are now literal.

Adding a deployment means adding a map entry, which makes omitting its sea level file impossible.

### Verification

The array was sourced in `bash` and all 17 keys resolved: the two scripts' maps are identical to each other, and every pairing matches what the derivation produced. No behavioural change.
