### PR TITLE
Add deployment temporal range fields

### DIFF
--- a/data/deployment_descriptors_v1.toml
+++ b/data/deployment_descriptors_v1.toml
@@ -1,6 +1,6 @@
 [[deployments]]
 deployment_label = "qd61g27j_20100421_022145"
-deployment_datetime = 2010-04-21 02:21:45+00:00
+deployment_start_datetime = 2010-04-21 02:21:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_03_25m_s_out"
@@ -104,7 +104,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20110410_011202"
-deployment_datetime = 2011-04-10 01:12:02+00:00
+deployment_start_datetime = 2011-04-10 01:12:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out"
@@ -198,7 +198,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20120422_043114"
-deployment_datetime = 2012-04-22 04:31:14+00:00
+deployment_start_datetime = 2012-04-22 04:31:14+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
@@ -300,7 +300,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20130414_013620"
-deployment_datetime = 2013-04-14 01:36:20+00:00
+deployment_start_datetime = 2013-04-14 01:36:20+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_22_25m_s_out"
@@ -396,7 +396,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20170523_040815"
-deployment_datetime = 2017-05-23 04:08:15+00:00
+deployment_start_datetime = 2017-05-23 04:08:15+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS05_rottnest_25m_s_out"
@@ -498,7 +498,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20100430_024508"
-deployment_datetime = 2010-04-30 02:45:08+00:00
+deployment_start_datetime = 2010-04-30 02:45:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_23_40m"
@@ -591,7 +591,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20120501_033336"
-deployment_datetime = 2012-05-01 03:33:36+00:00
+deployment_start_datetime = 2012-05-01 03:33:36+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_39_40m_out"
@@ -691,7 +691,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20130405_103429"
-deployment_datetime = 2013-04-05 10:34:29+00:00
+deployment_start_datetime = 2013-04-05 10:34:29+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_02_40m_out"
@@ -787,7 +787,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20210315_230947"
-deployment_datetime = 2021-03-15 23:09:47+00:00
+deployment_start_datetime = 2021-03-15 23:09:47+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS13_coralpatches_40m_out"
@@ -886,7 +886,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
-deployment_datetime = 2010-04-28 02:02:02+00:00
+deployment_start_datetime = 2010-04-28 02:02:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_16_15m_out"
@@ -983,7 +983,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20110415_020103"
-deployment_datetime = 2011-04-15 02:01:03+00:00
+deployment_start_datetime = 2011-04-15 02:01:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_24_15m_out"
@@ -1081,7 +1081,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20120430_002423"
-deployment_datetime = 2012-04-30 00:24:23+00:00
+deployment_start_datetime = 2012-04-30 00:24:23+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_34_15m_out"
@@ -1183,7 +1183,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20130406_023610"
-deployment_datetime = 2013-04-06 02:36:10+00:00
+deployment_start_datetime = 2013-04-06 02:36:10+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_03_15m_out"
@@ -1281,7 +1281,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20140327_071251"
-deployment_datetime = 2014-03-27 07:12:51+00:00
+deployment_start_datetime = 2014-03-27 07:12:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_02_15m_out"
@@ -1389,7 +1389,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20170526_025746"
-deployment_datetime = 2017-05-26 02:57:46+00:00
+deployment_start_datetime = 2017-05-26 02:57:46+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_geebank_15m_out"
@@ -1492,7 +1492,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20210315_034028"
-deployment_datetime = 2021-03-15 03:40:28+00:00
+deployment_start_datetime = 2021-03-15 03:40:28+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS10_geebank_15m_out"
@@ -1593,7 +1593,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
-deployment_datetime = 2011-04-16 00:54:11+00:00
+deployment_start_datetime = 2011-04-16 00:54:11+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_27"
@@ -1686,7 +1686,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20120501_071203"
-deployment_datetime = 2012-05-01 07:12:03+00:00
+deployment_start_datetime = 2012-05-01 07:12:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_37"
@@ -1783,7 +1783,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20130406_081713"
-deployment_datetime = 2013-04-06 08:17:13+00:00
+deployment_start_datetime = 2013-04-06 08:17:13+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -1879,7 +1879,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20140328_063358"
-deployment_datetime = 2014-03-28 06:33:58+00:00
+deployment_start_datetime = 2014-03-28 06:33:58+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -1984,7 +1984,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
-deployment_datetime = 2017-05-25 23:46:24+00:00
+deployment_start_datetime = 2017-05-25 23:46:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS11_snapperbank"
@@ -2085,7 +2085,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20210315_081519"
-deployment_datetime = 2021-03-15 08:15:19+00:00
+deployment_start_datetime = 2021-03-15 08:15:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_snapperbank"
@@ -2197,7 +2197,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20110815_102540"
-deployment_datetime = 2011-08-15 10:25:40+00:00
+deployment_start_datetime = 2011-08-15 10:25:40+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "19_scott_grids_deep_auv4"
@@ -2296,7 +2296,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150327_015552"
-deployment_datetime = 2015-03-27 01:55:52+00:00
+deployment_start_datetime = 2015-03-27 01:55:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "02_scott_grids_deep_auv4"
@@ -2410,7 +2410,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_000850"
-deployment_datetime = 2015-03-28 00:08:50+00:00
+deployment_start_datetime = 2015-03-28 00:08:50+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
@@ -2516,7 +2516,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_042551"
-deployment_datetime = 2015-03-28 04:25:51+00:00
+deployment_start_datetime = 2015-03-28 04:25:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
@@ -2620,7 +2620,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20100604_230524"
-deployment_datetime = 2010-06-04 23:05:24+00:00
+deployment_start_datetime = 2010-06-04 23:05:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_14_shallow"
@@ -2716,7 +2716,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20120530_064545"
-deployment_datetime = 2012-05-30 06:45:45+00:00
+deployment_start_datetime = 2012-05-30 06:45:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_08_shallow"
@@ -2819,7 +2819,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20140616_205232"
-deployment_datetime = 2014-06-16 20:52:32+00:00
+deployment_start_datetime = 2014-06-16 20:52:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_12_lanterns_shallow"
@@ -2917,7 +2917,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20100605_021022"
-deployment_datetime = 2010-06-05 02:10:22+00:00
+deployment_start_datetime = 2010-06-05 02:10:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_15_deep"
@@ -3012,7 +3012,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20120530_233021"
-deployment_datetime = 2012-05-30 23:30:21+00:00
+deployment_start_datetime = 2012-05-30 23:30:21+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_10_deep"
@@ -3112,7 +3112,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20140616_225022"
-deployment_datetime = 2014-06-16 22:50:22+00:00
+deployment_start_datetime = 2014-06-16 22:50:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_13_lanterns_deep"
@@ -3211,7 +3211,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20100606_001908"
-deployment_datetime = 2010-06-06 00:19:08+00:00
+deployment_start_datetime = 2010-06-06 00:19:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_19_shallow_shift"
@@ -3304,7 +3304,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20120601_070118"
-deployment_datetime = 2012-06-01 07:01:18+00:00
+deployment_start_datetime = 2012-06-01 07:01:18+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
@@ -3403,7 +3403,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20140616_044549"
-deployment_datetime = 2014-06-16 04:45:49+00:00
+deployment_start_datetime = 2014-06-16 04:45:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
@@ -3504,7 +3504,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_010853"
-deployment_datetime = 2009-06-13 01:08:53+00:00
+deployment_start_datetime = 2009-06-13 01:08:53+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
@@ -3594,7 +3594,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_104954"
-deployment_datetime = 2009-06-13 10:49:54+00:00
+deployment_start_datetime = 2009-06-13 10:49:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
@@ -3684,7 +3684,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20110612_045149"
-deployment_datetime = 2011-06-12 04:51:49+00:00
+deployment_start_datetime = 2011-06-12 04:51:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
@@ -3776,7 +3776,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20130611_015335"
-deployment_datetime = 2013-06-11 01:53:35+00:00
+deployment_start_datetime = 2013-06-11 01:53:35+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
@@ -3875,7 +3875,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
-deployment_datetime = 2009-06-12 22:53:06+00:00
+deployment_start_datetime = 2009-06-12 22:53:06+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_07_elephant_rock_deep"
@@ -3967,7 +3967,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090613_100254"
-deployment_datetime = 2009-06-13 10:02:54+00:00
+deployment_start_datetime = 2009-06-13 10:02:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
@@ -4057,7 +4057,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20110612_033752"
-deployment_datetime = 2011-06-12 03:37:52+00:00
+deployment_start_datetime = 2011-06-12 03:37:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
@@ -4148,7 +4148,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20130611_002419"
-deployment_datetime = 2013-06-11 00:24:19+00:00
+deployment_start_datetime = 2013-06-11 00:24:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
@@ -4250,7 +4250,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4343,7 +4343,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -4440,7 +4440,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -4533,7 +4533,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4626,7 +4626,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -4723,7 +4723,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -4816,7 +4816,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4909,7 +4909,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -5006,7 +5006,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"

--- a/data/deployment_descriptors_v1_all.toml
+++ b/data/deployment_descriptors_v1_all.toml
@@ -1,6 +1,6 @@
 [[deployments]]
 deployment_label = "qd61g27j_20100421_022145"
-deployment_datetime = 2010-04-21 02:21:45+00:00
+deployment_start_datetime = 2010-04-21 02:21:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_03_25m_s_out"
@@ -104,7 +104,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20110410_011202"
-deployment_datetime = 2011-04-10 01:12:02+00:00
+deployment_start_datetime = 2011-04-10 01:12:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out"
@@ -198,7 +198,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20120422_043114"
-deployment_datetime = 2012-04-22 04:31:14+00:00
+deployment_start_datetime = 2012-04-22 04:31:14+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
@@ -300,7 +300,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20130414_013620"
-deployment_datetime = 2013-04-14 01:36:20+00:00
+deployment_start_datetime = 2013-04-14 01:36:20+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_22_25m_s_out"
@@ -396,7 +396,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qd61g27j_20170523_040815"
-deployment_datetime = 2017-05-23 04:08:15+00:00
+deployment_start_datetime = 2017-05-23 04:08:15+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS05_rottnest_25m_s_out"
@@ -498,7 +498,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20100430_024508"
-deployment_datetime = 2010-04-30 02:45:08+00:00
+deployment_start_datetime = 2010-04-30 02:45:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_23_40m"
@@ -591,7 +591,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20120501_033336"
-deployment_datetime = 2012-05-01 03:33:36+00:00
+deployment_start_datetime = 2012-05-01 03:33:36+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_39_40m_out"
@@ -691,7 +691,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20130405_103429"
-deployment_datetime = 2013-04-05 10:34:29+00:00
+deployment_start_datetime = 2013-04-05 10:34:29+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_02_40m_out"
@@ -787,7 +787,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20210315_230947"
-deployment_datetime = 2021-03-15 23:09:47+00:00
+deployment_start_datetime = 2021-03-15 23:09:47+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS13_coralpatches_40m_out"
@@ -886,7 +886,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
-deployment_datetime = 2010-04-28 02:02:02+00:00
+deployment_start_datetime = 2010-04-28 02:02:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_16_15m_out"
@@ -983,7 +983,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20110415_020103"
-deployment_datetime = 2011-04-15 02:01:03+00:00
+deployment_start_datetime = 2011-04-15 02:01:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_24_15m_out"
@@ -1081,7 +1081,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20120430_002423"
-deployment_datetime = 2012-04-30 00:24:23+00:00
+deployment_start_datetime = 2012-04-30 00:24:23+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_34_15m_out"
@@ -1183,7 +1183,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20130406_023610"
-deployment_datetime = 2013-04-06 02:36:10+00:00
+deployment_start_datetime = 2013-04-06 02:36:10+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_03_15m_out"
@@ -1281,7 +1281,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20140327_071251"
-deployment_datetime = 2014-03-27 07:12:51+00:00
+deployment_start_datetime = 2014-03-27 07:12:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_02_15m_out"
@@ -1389,7 +1389,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20170526_025746"
-deployment_datetime = 2017-05-26 02:57:46+00:00
+deployment_start_datetime = 2017-05-26 02:57:46+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_geebank_15m_out"
@@ -1492,7 +1492,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20210315_034028"
-deployment_datetime = 2021-03-15 03:40:28+00:00
+deployment_start_datetime = 2021-03-15 03:40:28+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS10_geebank_15m_out"
@@ -1593,7 +1593,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
-deployment_datetime = 2011-04-16 00:54:11+00:00
+deployment_start_datetime = 2011-04-16 00:54:11+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_27"
@@ -1686,7 +1686,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20120501_071203"
-deployment_datetime = 2012-05-01 07:12:03+00:00
+deployment_start_datetime = 2012-05-01 07:12:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_37"
@@ -1783,7 +1783,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20130406_081713"
-deployment_datetime = 2013-04-06 08:17:13+00:00
+deployment_start_datetime = 2013-04-06 08:17:13+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -1879,7 +1879,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20140328_063358"
-deployment_datetime = 2014-03-28 06:33:58+00:00
+deployment_start_datetime = 2014-03-28 06:33:58+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -1984,7 +1984,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
-deployment_datetime = 2017-05-25 23:46:24+00:00
+deployment_start_datetime = 2017-05-25 23:46:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS11_snapperbank"
@@ -2085,7 +2085,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20210315_081519"
-deployment_datetime = 2021-03-15 08:15:19+00:00
+deployment_start_datetime = 2021-03-15 08:15:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_snapperbank"
@@ -2197,7 +2197,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20110815_102540"
-deployment_datetime = 2011-08-15 10:25:40+00:00
+deployment_start_datetime = 2011-08-15 10:25:40+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "19_scott_grids_deep_auv4"
@@ -2296,7 +2296,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150327_015552"
-deployment_datetime = 2015-03-27 01:55:52+00:00
+deployment_start_datetime = 2015-03-27 01:55:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "02_scott_grids_deep_auv4"
@@ -2410,7 +2410,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_000850"
-deployment_datetime = 2015-03-28 00:08:50+00:00
+deployment_start_datetime = 2015-03-28 00:08:50+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
@@ -2516,7 +2516,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_042551"
-deployment_datetime = 2015-03-28 04:25:51+00:00
+deployment_start_datetime = 2015-03-28 04:25:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
@@ -2620,7 +2620,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20100604_230524"
-deployment_datetime = 2010-06-04 23:05:24+00:00
+deployment_start_datetime = 2010-06-04 23:05:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_14_shallow"
@@ -2716,7 +2716,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20120530_064545"
-deployment_datetime = 2012-05-30 06:45:45+00:00
+deployment_start_datetime = 2012-05-30 06:45:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_08_shallow"
@@ -2819,7 +2819,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r234xgje_20140616_205232"
-deployment_datetime = 2014-06-16 20:52:32+00:00
+deployment_start_datetime = 2014-06-16 20:52:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_12_lanterns_shallow"
@@ -2917,7 +2917,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20100605_021022"
-deployment_datetime = 2010-06-05 02:10:22+00:00
+deployment_start_datetime = 2010-06-05 02:10:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_15_deep"
@@ -3012,7 +3012,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20120530_233021"
-deployment_datetime = 2012-05-30 23:30:21+00:00
+deployment_start_datetime = 2012-05-30 23:30:21+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_10_deep"
@@ -3112,7 +3112,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20140616_225022"
-deployment_datetime = 2014-06-16 22:50:22+00:00
+deployment_start_datetime = 2014-06-16 22:50:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_13_lanterns_deep"
@@ -3211,7 +3211,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20100606_001908"
-deployment_datetime = 2010-06-06 00:19:08+00:00
+deployment_start_datetime = 2010-06-06 00:19:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_19_shallow_shift"
@@ -3304,7 +3304,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20120601_070118"
-deployment_datetime = 2012-06-01 07:01:18+00:00
+deployment_start_datetime = 2012-06-01 07:01:18+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
@@ -3403,7 +3403,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23m7ms0_20140616_044549"
-deployment_datetime = 2014-06-16 04:45:49+00:00
+deployment_start_datetime = 2014-06-16 04:45:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
@@ -3504,7 +3504,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_010853"
-deployment_datetime = 2009-06-13 01:08:53+00:00
+deployment_start_datetime = 2009-06-13 01:08:53+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
@@ -3594,7 +3594,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_104954"
-deployment_datetime = 2009-06-13 10:49:54+00:00
+deployment_start_datetime = 2009-06-13 10:49:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
@@ -3684,7 +3684,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20110612_045149"
-deployment_datetime = 2011-06-12 04:51:49+00:00
+deployment_start_datetime = 2011-06-12 04:51:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
@@ -3776,7 +3776,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd12_20130611_015335"
-deployment_datetime = 2013-06-11 01:53:35+00:00
+deployment_start_datetime = 2013-06-11 01:53:35+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
@@ -3875,7 +3875,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
-deployment_datetime = 2009-06-12 22:53:06+00:00
+deployment_start_datetime = 2009-06-12 22:53:06+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_07_elephant_rock_deep"
@@ -3967,7 +3967,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090613_100254"
-deployment_datetime = 2009-06-13 10:02:54+00:00
+deployment_start_datetime = 2009-06-13 10:02:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
@@ -4057,7 +4057,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20110612_033752"
-deployment_datetime = 2011-06-12 03:37:52+00:00
+deployment_start_datetime = 2011-06-12 03:37:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
@@ -4148,7 +4148,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20130611_002419"
-deployment_datetime = 2013-06-11 00:24:19+00:00
+deployment_start_datetime = 2013-06-11 00:24:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
@@ -4250,7 +4250,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4343,7 +4343,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -4440,7 +4440,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -4533,7 +4533,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4626,7 +4626,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -4723,7 +4723,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjss8n_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -4816,7 +4816,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -4909,7 +4909,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -5006,7 +5006,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjssbh_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"

--- a/data/deployment_descriptors_v1_all_enriched.toml
+++ b/data/deployment_descriptors_v1_all_enriched.toml
@@ -1,6 +1,6 @@
 [[deployments]]
 deployment_label = "qd61g27j_20100421_022145"
-deployment_datetime = 2010-04-21 02:21:45+00:00
+deployment_start_datetime = 2010-04-21 02:21:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_03_25m_s_out"
@@ -227,7 +227,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qd61g27j_20110410_011202"
-deployment_datetime = 2011-04-10 01:12:02+00:00
+deployment_start_datetime = 2011-04-10 01:12:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out"
@@ -444,7 +444,7 @@ extrinsics.rotz = -0.0106
 
 [[deployments]]
 deployment_label = "qd61g27j_20120422_043114"
-deployment_datetime = 2012-04-22 04:31:14+00:00
+deployment_start_datetime = 2012-04-22 04:31:14+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_07_25m_s_out_grid23"
@@ -675,7 +675,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qd61g27j_20130414_013620"
-deployment_datetime = 2013-04-14 01:36:20+00:00
+deployment_start_datetime = 2013-04-14 01:36:20+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "rottnest_22_25m_s_out"
@@ -900,7 +900,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qd61g27j_20170523_040815"
-deployment_datetime = 2017-05-23 04:08:15+00:00
+deployment_start_datetime = 2017-05-23 04:08:15+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS05_rottnest_25m_s_out"
@@ -1131,7 +1131,7 @@ extrinsics.rotz = 0.4713
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20100430_024508"
-deployment_datetime = 2010-04-30 02:45:08+00:00
+deployment_start_datetime = 2010-04-30 02:45:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_23_40m"
@@ -1347,7 +1347,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20120501_033336"
-deployment_datetime = 2012-05-01 03:33:36+00:00
+deployment_start_datetime = 2012-05-01 03:33:36+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_39_40m_out"
@@ -1576,7 +1576,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20130405_103429"
-deployment_datetime = 2013-04-05 10:34:29+00:00
+deployment_start_datetime = 2013-04-05 10:34:29+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "coralpatches_02_40m_out"
@@ -1801,7 +1801,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdc5ghs3_20210315_230947"
-deployment_datetime = 2021-03-15 23:09:47+00:00
+deployment_start_datetime = 2021-03-15 23:09:47+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS13_coralpatches_40m_out"
@@ -2029,7 +2029,7 @@ extrinsics.rotz = -0.21
 
 [[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
-deployment_datetime = 2010-04-28 02:02:02+00:00
+deployment_start_datetime = 2010-04-28 02:02:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_16_15m_out"
@@ -2249,7 +2249,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdch0ftq_20110415_020103"
-deployment_datetime = 2011-04-15 02:01:03+00:00
+deployment_start_datetime = 2011-04-15 02:01:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_24_15m_out"
@@ -2470,7 +2470,7 @@ extrinsics.rotz = 0.0375
 
 [[deployments]]
 deployment_label = "qdch0ftq_20120430_002423"
-deployment_datetime = 2012-04-30 00:24:23+00:00
+deployment_start_datetime = 2012-04-30 00:24:23+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_34_15m_out"
@@ -2701,7 +2701,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qdch0ftq_20130406_023610"
-deployment_datetime = 2013-04-06 02:36:10+00:00
+deployment_start_datetime = 2013-04-06 02:36:10+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_03_15m_out"
@@ -2928,7 +2928,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdch0ftq_20140327_071251"
-deployment_datetime = 2014-03-27 07:12:51+00:00
+deployment_start_datetime = 2014-03-27 07:12:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_02_15m_out"
@@ -3165,7 +3165,7 @@ extrinsics.rotz = -0.0685
 
 [[deployments]]
 deployment_label = "qdch0ftq_20170526_025746"
-deployment_datetime = 2017-05-26 02:57:46+00:00
+deployment_start_datetime = 2017-05-26 02:57:46+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_geebank_15m_out"
@@ -3397,7 +3397,7 @@ extrinsics.rotz = 0.4713
 
 [[deployments]]
 deployment_label = "qdch0ftq_20210315_034028"
-deployment_datetime = 2021-03-15 03:40:28+00:00
+deployment_start_datetime = 2021-03-15 03:40:28+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS10_geebank_15m_out"
@@ -3627,7 +3627,7 @@ extrinsics.rotz = -0.21
 
 [[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
-deployment_datetime = 2011-04-16 00:54:11+00:00
+deployment_start_datetime = 2011-04-16 00:54:11+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_27"
@@ -3843,7 +3843,7 @@ extrinsics.rotz = 0.0375
 
 [[deployments]]
 deployment_label = "qdchdmy1_20120501_071203"
-deployment_datetime = 2012-05-01 07:12:03+00:00
+deployment_start_datetime = 2012-05-01 07:12:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_37"
@@ -4069,7 +4069,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qdchdmy1_20130406_081713"
-deployment_datetime = 2013-04-06 08:17:13+00:00
+deployment_start_datetime = 2013-04-06 08:17:13+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -4294,7 +4294,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdchdmy1_20140328_063358"
-deployment_datetime = 2014-03-28 06:33:58+00:00
+deployment_start_datetime = 2014-03-28 06:33:58+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -4528,7 +4528,7 @@ extrinsics.rotz = -0.0685
 
 [[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
-deployment_datetime = 2017-05-25 23:46:24+00:00
+deployment_start_datetime = 2017-05-25 23:46:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS11_snapperbank"
@@ -4758,7 +4758,7 @@ extrinsics.rotz = 0.4713
 
 [[deployments]]
 deployment_label = "qdchdmy1_20210315_081519"
-deployment_datetime = 2021-03-15 08:15:19+00:00
+deployment_start_datetime = 2021-03-15 08:15:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS12_snapperbank"
@@ -4999,7 +4999,7 @@ extrinsics.rotz = -0.21
 
 [[deployments]]
 deployment_label = "qtqxshxs_20110815_102540"
-deployment_datetime = 2011-08-15 10:25:40+00:00
+deployment_start_datetime = 2011-08-15 10:25:40+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "19_scott_grids_deep_auv4"
@@ -5221,7 +5221,7 @@ extrinsics.rotz = -0.0609
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150327_015552"
-deployment_datetime = 2015-03-27 01:55:52+00:00
+deployment_start_datetime = 2015-03-27 01:55:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "02_scott_grids_deep_auv4"
@@ -5464,7 +5464,7 @@ extrinsics.rotz = -0.0464
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_000850"
-deployment_datetime = 2015-03-28 00:08:50+00:00
+deployment_start_datetime = 2015-03-28 00:08:50+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "03_scott_grids_deep_auv4_shifted"
@@ -5699,7 +5699,7 @@ extrinsics.rotz = -0.0464
 
 [[deployments]]
 deployment_label = "qtqxshxs_20150328_042551"
-deployment_datetime = 2015-03-28 04:25:51+00:00
+deployment_start_datetime = 2015-03-28 04:25:51+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "04_scott_dense_grid_deep_auv4"
@@ -5932,7 +5932,7 @@ extrinsics.rotz = -0.0464
 
 [[deployments]]
 deployment_label = "r234xgje_20100604_230524"
-deployment_datetime = 2010-06-04 23:05:24+00:00
+deployment_start_datetime = 2010-06-04 23:05:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_14_shallow"
@@ -6151,7 +6151,7 @@ extrinsics.rotz = 0.3138
 
 [[deployments]]
 deployment_label = "r234xgje_20120530_064545"
-deployment_datetime = 2012-05-30 06:45:45+00:00
+deployment_start_datetime = 2012-05-30 06:45:45+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_08_shallow"
@@ -6383,7 +6383,7 @@ extrinsics.rotz = 0.1861
 
 [[deployments]]
 deployment_label = "r234xgje_20140616_205232"
-deployment_datetime = 2014-06-16 20:52:32+00:00
+deployment_start_datetime = 2014-06-16 20:52:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_12_lanterns_shallow"
@@ -6610,7 +6610,7 @@ extrinsics.rotz = -0.0327
 
 [[deployments]]
 deployment_label = "r23685bc_20100605_021022"
-deployment_datetime = 2010-06-05 02:10:22+00:00
+deployment_start_datetime = 2010-06-05 02:10:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_15_deep"
@@ -6828,7 +6828,7 @@ extrinsics.rotz = 0.3138
 
 [[deployments]]
 deployment_label = "r23685bc_20120530_233021"
-deployment_datetime = 2012-05-30 23:30:21+00:00
+deployment_start_datetime = 2012-05-30 23:30:21+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_10_deep"
@@ -7057,7 +7057,7 @@ extrinsics.rotz = 0.1861
 
 [[deployments]]
 deployment_label = "r23685bc_20140616_225022"
-deployment_datetime = 2014-06-16 22:50:22+00:00
+deployment_start_datetime = 2014-06-16 22:50:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_13_lanterns_deep"
@@ -7285,7 +7285,7 @@ extrinsics.rotz = -0.0327
 
 [[deployments]]
 deployment_label = "r23m7ms0_20100606_001908"
-deployment_datetime = 2010-06-06 00:19:08+00:00
+deployment_start_datetime = 2010-06-06 00:19:08+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_19_shallow_shift"
@@ -7501,7 +7501,7 @@ extrinsics.rotz = 0.3138
 
 [[deployments]]
 deployment_label = "r23m7ms0_20120601_070118"
-deployment_datetime = 2012-06-01 07:01:18+00:00
+deployment_start_datetime = 2012-06-01 07:01:18+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "mistakencape_14_shallow_shift_grid2"
@@ -7729,7 +7729,7 @@ extrinsics.rotz = 0.1861
 
 [[deployments]]
 deployment_label = "r23m7ms0_20140616_044549"
-deployment_datetime = 2014-06-16 04:45:49+00:00
+deployment_start_datetime = 2014-06-16 04:45:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_11_mistakencape_shallow_shift"
@@ -7959,7 +7959,7 @@ extrinsics.rotz = -0.0327
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_010853"
-deployment_datetime = 2009-06-13 01:08:53+00:00
+deployment_start_datetime = 2009-06-13 01:08:53+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_09_elephant_rock_shallow"
@@ -8172,7 +8172,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "r29mrd12_20090613_104954"
-deployment_datetime = 2009-06-13 10:49:54+00:00
+deployment_start_datetime = 2009-06-13 10:49:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_12_elephant_rock_shallow_night"
@@ -8385,7 +8385,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "r29mrd12_20110612_045149"
-deployment_datetime = 2011-06-12 04:51:49+00:00
+deployment_start_datetime = 2011-06-12 04:51:49+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_03_elephant_rock_shallow_repeat"
@@ -8600,7 +8600,7 @@ extrinsics.rotz = -0.24
 
 [[deployments]]
 deployment_label = "r29mrd12_20130611_015335"
-deployment_datetime = 2013-06-11 01:53:35+00:00
+deployment_start_datetime = 2013-06-11 01:53:35+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_15_elephant_rock_shallow_repeat"
@@ -8828,7 +8828,7 @@ extrinsics.rotz = -0.2815
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
-deployment_datetime = 2009-06-12 22:53:06+00:00
+deployment_start_datetime = 2009-06-12 22:53:06+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_07_elephant_rock_deep"
@@ -9043,7 +9043,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090613_100254"
-deployment_datetime = 2009-06-13 10:02:54+00:00
+deployment_start_datetime = 2009-06-13 10:02:54+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_11_elephant_rock_deep_night"
@@ -9256,7 +9256,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "r29mrd5h_20110612_033752"
-deployment_datetime = 2011-06-12 03:37:52+00:00
+deployment_start_datetime = 2011-06-12 03:37:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
@@ -9470,7 +9470,7 @@ extrinsics.rotz = -0.24
 
 [[deployments]]
 deployment_label = "r29mrd5h_20130611_002419"
-deployment_datetime = 2013-06-11 00:24:19+00:00
+deployment_start_datetime = 2013-06-11 00:24:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
@@ -9701,7 +9701,7 @@ extrinsics.rotz = -0.2815
 
 [[deployments]]
 deployment_label = "r7jjskxq_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -9917,7 +9917,7 @@ extrinsics.rotz = -0.0509
 
 [[deployments]]
 deployment_label = "r7jjskxq_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -10143,7 +10143,7 @@ extrinsics.rotz = -0.0511
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -10365,7 +10365,7 @@ extrinsics.rotz = 0.2499
 
 [[deployments]]
 deployment_label = "r7jjss8n_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -10581,7 +10581,7 @@ extrinsics.rotz = -0.0509
 
 [[deployments]]
 deployment_label = "r7jjss8n_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -10807,7 +10807,7 @@ extrinsics.rotz = -0.0511
 
 [[deployments]]
 deployment_label = "r7jjss8n_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"
@@ -11029,7 +11029,7 @@ extrinsics.rotz = 0.2499
 
 [[deployments]]
 deployment_label = "r7jjssbh_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -11245,7 +11245,7 @@ extrinsics.rotz = -0.0509
 
 [[deployments]]
 deployment_label = "r7jjssbh_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -11471,7 +11471,7 @@ extrinsics.rotz = -0.0511
 
 [[deployments]]
 deployment_label = "r7jjssbh_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"

--- a/data/deployment_descriptors_v1_subset.toml
+++ b/data/deployment_descriptors_v1_subset.toml
@@ -1,6 +1,6 @@
 [[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
-deployment_datetime = 2010-04-28 02:02:02+00:00
+deployment_start_datetime = 2010-04-28 02:02:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_16_15m_out"
@@ -97,7 +97,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20110415_020103"
-deployment_datetime = 2011-04-15 02:01:03+00:00
+deployment_start_datetime = 2011-04-15 02:01:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_24_15m_out"
@@ -195,7 +195,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20120430_002423"
-deployment_datetime = 2012-04-30 00:24:23+00:00
+deployment_start_datetime = 2012-04-30 00:24:23+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_34_15m_out"
@@ -297,7 +297,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdch0ftq_20130406_023610"
-deployment_datetime = 2013-04-06 02:36:10+00:00
+deployment_start_datetime = 2013-04-06 02:36:10+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_03_15m_out"
@@ -395,7 +395,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
-deployment_datetime = 2011-04-16 00:54:11+00:00
+deployment_start_datetime = 2011-04-16 00:54:11+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_27"
@@ -488,7 +488,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20120501_071203"
-deployment_datetime = 2012-05-01 07:12:03+00:00
+deployment_start_datetime = 2012-05-01 07:12:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_37"
@@ -585,7 +585,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20130406_081713"
-deployment_datetime = 2013-04-06 08:17:13+00:00
+deployment_start_datetime = 2013-04-06 08:17:13+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -681,7 +681,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
-deployment_datetime = 2017-05-25 23:46:24+00:00
+deployment_start_datetime = 2017-05-25 23:46:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS11_snapperbank"
@@ -782,7 +782,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20100605_021022"
-deployment_datetime = 2010-06-05 02:10:22+00:00
+deployment_start_datetime = 2010-06-05 02:10:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_15_deep"
@@ -877,7 +877,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20120530_233021"
-deployment_datetime = 2012-05-30 23:30:21+00:00
+deployment_start_datetime = 2012-05-30 23:30:21+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_10_deep"
@@ -977,7 +977,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r23685bc_20140616_225022"
-deployment_datetime = 2014-06-16 22:50:22+00:00
+deployment_start_datetime = 2014-06-16 22:50:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_13_lanterns_deep"
@@ -1076,7 +1076,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
-deployment_datetime = 2009-06-12 22:53:06+00:00
+deployment_start_datetime = 2009-06-12 22:53:06+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_07_elephant_rock_deep"
@@ -1168,7 +1168,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20110612_033752"
-deployment_datetime = 2011-06-12 03:37:52+00:00
+deployment_start_datetime = 2011-06-12 03:37:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
@@ -1259,7 +1259,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r29mrd5h_20130611_002419"
-deployment_datetime = 2013-06-11 00:24:19+00:00
+deployment_start_datetime = 2013-06-11 00:24:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
@@ -1361,7 +1361,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -1454,7 +1454,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -1551,7 +1551,7 @@ sensors = []
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"

--- a/data/deployment_descriptors_v1_subset_enriched.toml
+++ b/data/deployment_descriptors_v1_subset_enriched.toml
@@ -1,6 +1,6 @@
 [[deployments]]
 deployment_label = "qdch0ftq_20100428_020202"
-deployment_datetime = 2010-04-28 02:02:02+00:00
+deployment_start_datetime = 2010-04-28 02:02:02+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_16_15m_out"
@@ -220,7 +220,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdch0ftq_20110415_020103"
-deployment_datetime = 2011-04-15 02:01:03+00:00
+deployment_start_datetime = 2011-04-15 02:01:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_24_15m_out"
@@ -441,7 +441,7 @@ extrinsics.rotz = 0.0375
 
 [[deployments]]
 deployment_label = "qdch0ftq_20120430_002423"
-deployment_datetime = 2012-04-30 00:24:23+00:00
+deployment_start_datetime = 2012-04-30 00:24:23+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_34_15m_out"
@@ -672,7 +672,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qdch0ftq_20130406_023610"
-deployment_datetime = 2013-04-06 02:36:10+00:00
+deployment_start_datetime = 2013-04-06 02:36:10+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "geebank_03_15m_out"
@@ -899,7 +899,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdchdmy1_20110416_005411"
-deployment_datetime = 2011-04-16 00:54:11+00:00
+deployment_start_datetime = 2011-04-16 00:54:11+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_27"
@@ -1115,7 +1115,7 @@ extrinsics.rotz = 0.0375
 
 [[deployments]]
 deployment_label = "qdchdmy1_20120501_071203"
-deployment_datetime = 2012-05-01 07:12:03+00:00
+deployment_start_datetime = 2012-05-01 07:12:03+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_37"
@@ -1341,7 +1341,7 @@ extrinsics.rotz = 0.2548
 
 [[deployments]]
 deployment_label = "qdchdmy1_20130406_081713"
-deployment_datetime = 2013-04-06 08:17:13+00:00
+deployment_start_datetime = 2013-04-06 08:17:13+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "snapperbank_05"
@@ -1566,7 +1566,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "qdchdmy1_20170525_234624"
-deployment_datetime = 2017-05-25 23:46:24+00:00
+deployment_start_datetime = 2017-05-25 23:46:24+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "SS11_snapperbank"
@@ -1796,7 +1796,7 @@ extrinsics.rotz = 0.4713
 
 [[deployments]]
 deployment_label = "r23685bc_20100605_021022"
-deployment_datetime = 2010-06-05 02:10:22+00:00
+deployment_start_datetime = 2010-06-05 02:10:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_15_deep"
@@ -2014,7 +2014,7 @@ extrinsics.rotz = 0.3138
 
 [[deployments]]
 deployment_label = "r23685bc_20120530_233021"
-deployment_datetime = 2012-05-30 23:30:21+00:00
+deployment_start_datetime = 2012-05-30 23:30:21+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "lanterns_10_deep"
@@ -2243,7 +2243,7 @@ extrinsics.rotz = 0.1861
 
 [[deployments]]
 deployment_label = "r23685bc_20140616_225022"
-deployment_datetime = 2014-06-16 22:50:22+00:00
+deployment_start_datetime = 2014-06-16 22:50:22+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "tas_13_lanterns_deep"
@@ -2471,7 +2471,7 @@ extrinsics.rotz = -0.0327
 
 [[deployments]]
 deployment_label = "r29mrd5h_20090612_225306"
-deployment_datetime = 2009-06-12 22:53:06+00:00
+deployment_start_datetime = 2009-06-12 22:53:06+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_07_elephant_rock_deep"
@@ -2686,7 +2686,7 @@ extrinsics.rotz = 0.0
 
 [[deployments]]
 deployment_label = "r29mrd5h_20110612_033752"
-deployment_datetime = 2011-06-12 03:37:52+00:00
+deployment_start_datetime = 2011-06-12 03:37:52+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_01_elephant_rock_deep_repeat"
@@ -2900,7 +2900,7 @@ extrinsics.rotz = -0.24
 
 [[deployments]]
 deployment_label = "r29mrd5h_20130611_002419"
-deployment_datetime = 2013-06-11 00:24:19+00:00
+deployment_start_datetime = 2013-06-11 00:24:19+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "st_helens_13_elephant_rock_deep_repeat"
@@ -3131,7 +3131,7 @@ extrinsics.rotz = -0.2815
 
 [[deployments]]
 deployment_label = "r7jjskxq_20101023_210332"
-deployment_datetime = 2010-10-23 21:03:32+00:00
+deployment_start_datetime = 2010-10-23 21:03:32+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_10_shallow_grids"
@@ -3347,7 +3347,7 @@ extrinsics.rotz = -0.0509
 
 [[deployments]]
 deployment_label = "r7jjskxq_20121013_060425"
-deployment_datetime = 2012-10-13 06:04:25+00:00
+deployment_start_datetime = 2012-10-13 06:04:25+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_07_shallow_grids"
@@ -3573,7 +3573,7 @@ extrinsics.rotz = -0.0511
 
 [[deployments]]
 deployment_label = "r7jjskxq_20131022_004934"
-deployment_datetime = 2013-10-22 00:49:34+00:00
+deployment_start_datetime = 2013-10-22 00:49:34+00:00
 
 [deployments.metadata]
 acfr_deployment_label = "hendersonSth_03_shallow_grids"

--- a/src/afft/deployment/bundle_types.py
+++ b/src/afft/deployment/bundle_types.py
@@ -1,8 +1,11 @@
 """Data types describing a deployment bundle, as distinct from the deployment itself."""
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from .common_types import validate_temporal_range
 
 
 class DeploymentIdentity(BaseModel):
@@ -13,13 +16,23 @@ class DeploymentIdentity(BaseModel):
     Attributes
     ----------
     deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
-    deployment_datetime: Deployment datetime.
+    deployment_start_datetime: Start datetime of the deployment.
+    deployment_end_datetime: End datetime of the deployment; ``None`` when the
+        deployment covers its own full temporal range and no end was recorded.
     """
 
     model_config = ConfigDict(frozen=True)
 
     deployment_label: str
-    deployment_datetime: datetime
+    deployment_start_datetime: datetime
+    deployment_end_datetime: datetime | None = None
+
+    @model_validator(mode="after")
+    def _check_temporal_range(self) -> Self:
+        validate_temporal_range(
+            self.deployment_start_datetime, self.deployment_end_datetime
+        )
+        return self
 
 
 class DeploymentBundleHeader(BaseModel):

--- a/src/afft/deployment/common_types.py
+++ b/src/afft/deployment/common_types.py
@@ -1,6 +1,35 @@
 """Data types shared across deployment descriptor and deployment bundle representations."""
 
+from datetime import datetime
+
 from pydantic import BaseModel, ConfigDict, Field
+
+
+def validate_temporal_range(
+    start: datetime,
+    end: datetime | None,
+) -> None:
+    """
+    Validate a deployment's temporal range.
+
+    An absent end is valid: it means the deployment covers its own full
+    temporal range and no end was recorded. A present end must be strictly
+    after the start, since a deployment spanning no time is not a deployment.
+
+    Arguments
+    ---------
+    start: Start datetime of the deployment.
+    end: End datetime of the deployment, or ``None``.
+
+    Raises
+    ------
+    ValueError: If `end` is given and is not strictly after `start`.
+    """
+    if end is not None and end <= start:
+        raise ValueError(
+            f"deployment end datetime must be after its start: "
+            f"{end.isoformat()} <= {start.isoformat()}"
+        )
 
 
 class DeploymentMetadata(BaseModel):

--- a/src/afft/deployment/descriptor_exporters.py
+++ b/src/afft/deployment/descriptor_exporters.py
@@ -1,10 +1,16 @@
 """Markdown export for deployment descriptor summaries."""
 
+from datetime import datetime
 from pathlib import Path
 
 from .descriptor_summary import DescriptorSummary
 
 type MarkdownLines = list[str]
+
+
+def _format_end(end: datetime | None) -> str:
+    """Render a deployment's end datetime, or note that none was recorded."""
+    return end.isoformat() if end is not None else "not recorded"
 
 
 def format_table(headers: list[str], rows: list[list[str]]) -> MarkdownLines:
@@ -143,7 +149,8 @@ def format_deployments(summary: DescriptorSummary) -> MarkdownLines:
             [
                 f"### {deployment.deployment_label}",
                 "",
-                f"- Datetime: {deployment.deployment_datetime.isoformat()}",
+                f"- Start: {deployment.deployment_start_datetime.isoformat()}",
+                f"- End: {_format_end(deployment.deployment_end_datetime)}",
                 f"- Campaign: {deployment.campaign_label}",
                 f"- Files: {files if files else 'none'}",
                 f"- Topics: {', '.join(deployment.topics) or 'none'}",

--- a/src/afft/deployment/descriptor_summary.py
+++ b/src/afft/deployment/descriptor_summary.py
@@ -63,7 +63,9 @@ class DeploymentSummary(BaseModel):
     Attributes
     ----------
     deployment_label: Label of the summarized deployment.
-    deployment_datetime: Deployment datetime.
+    deployment_start_datetime: Start datetime of the deployment.
+    deployment_end_datetime: End datetime of the deployment; ``None`` when the
+        deployment covers its own full temporal range and no end was recorded.
     campaign_label: ACFR campaign the deployment belongs to.
     file_counts: File count per file section name.
     topics: Telemetry topics observed for the deployment.
@@ -75,7 +77,8 @@ class DeploymentSummary(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     deployment_label: str
-    deployment_datetime: datetime
+    deployment_start_datetime: datetime
+    deployment_end_datetime: datetime | None
     campaign_label: str
     file_counts: dict[SectionName, int]
     topics: list[TopicName]
@@ -218,7 +221,8 @@ def _summarize_deployment(
     """Build the per-deployment detail for one descriptor."""
     return DeploymentSummary(
         deployment_label=descriptor.deployment_label,
-        deployment_datetime=descriptor.deployment_datetime,
+        deployment_start_datetime=descriptor.deployment_start_datetime,
+        deployment_end_datetime=descriptor.deployment_end_datetime,
         campaign_label=descriptor.metadata.acfr_campaign_label,
         file_counts={
             section: len(getattr(descriptor.files, section))
@@ -292,10 +296,10 @@ def summarize_descriptors(
         deployment_count=len(descriptors),
         campaign_counts=_sort_counts(campaign_counts),
         earliest_datetime=min(
-            deployment.deployment_datetime for deployment in deployments
+            deployment.deployment_start_datetime for deployment in deployments
         ),
         latest_datetime=max(
-            deployment.deployment_datetime for deployment in deployments
+            deployment.deployment_start_datetime for deployment in deployments
         ),
         extent=GeographicExtent(
             min_latitude=min(latitudes),

--- a/src/afft/deployment/descriptor_types.py
+++ b/src/afft/deployment/descriptor_types.py
@@ -1,8 +1,9 @@
 """Data types describing a single ACFR deployment."""
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .common_types import (
     DeploymentMetadata,
@@ -10,6 +11,7 @@ from .common_types import (
     PlatformSensor,
     VesselIdentity,
     VesselSensor,
+    validate_temporal_range,
 )
 
 
@@ -137,7 +139,9 @@ class DeploymentDescriptor(BaseModel):
     Attributes
     ----------
     deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
-    deployment_datetime: Deployment datetime.
+    deployment_start_datetime: Start datetime of the deployment.
+    deployment_end_datetime: End datetime of the deployment; ``None`` when the
+        deployment covers its own full temporal range and no end was recorded.
     metadata: Collected deployment metadata.
     files: Inventory of the deployment's files, keyed by role.
     telemetry: Message topics observed in the RAW AUV logs.
@@ -152,7 +156,8 @@ class DeploymentDescriptor(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     deployment_label: str
-    deployment_datetime: datetime
+    deployment_start_datetime: datetime
+    deployment_end_datetime: datetime | None = None
 
     metadata: DeploymentMetadata
     files: FileDescriptorSection
@@ -163,3 +168,10 @@ class DeploymentDescriptor(BaseModel):
     vessel: VesselDescriptorSection = Field(
         default_factory=VesselDescriptorSection
     )
+
+    @model_validator(mode="after")
+    def _check_temporal_range(self) -> Self:
+        validate_temporal_range(
+            self.deployment_start_datetime, self.deployment_end_datetime
+        )
+        return self

--- a/src/afft/deployment/loader.py
+++ b/src/afft/deployment/loader.py
@@ -98,7 +98,12 @@ def read_deployment_info(path: Path) -> list[DeploymentInfo]:
             DeploymentInfo.model_validate(
                 {
                     "deployment_label": entry["deployment_label"],
-                    "deployment_datetime": entry["deployment_datetime"],
+                    "deployment_start_datetime": entry[
+                        "deployment_start_datetime"
+                    ],
+                    "deployment_end_datetime": entry.get(
+                        "deployment_end_datetime"
+                    ),
                     "deployment_platform": entry.get("deployment_platform", ""),
                     "metadata": {
                         "acfr_deployment_label": metadata[

--- a/src/afft/deployment/types.py
+++ b/src/afft/deployment/types.py
@@ -1,10 +1,11 @@
 """Data types for AUV deployment configuration and metadata."""
 
 from datetime import datetime
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
-from .common_types import DeploymentMetadata
+from .common_types import DeploymentMetadata, validate_temporal_range
 
 
 class UsblUncertaintyProfile(BaseModel):
@@ -94,7 +95,9 @@ class DeploymentInfo(BaseModel):
     Attributes
     ----------
     deployment_label: Deployment identifier in ``<GEOHASH>_<DATETIME>`` format.
-    deployment_datetime: Deployment datetime.
+    deployment_start_datetime: Start datetime of the deployment.
+    deployment_end_datetime: End datetime of the deployment; ``None`` when the
+        deployment covers its own full temporal range and no end was recorded.
     deployment_platform: Squidle+ platform name for this deployment.
     metadata: Collected deployment metadata.
     """
@@ -102,6 +105,14 @@ class DeploymentInfo(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     deployment_label: str
-    deployment_datetime: datetime
+    deployment_start_datetime: datetime
+    deployment_end_datetime: datetime | None = None
     deployment_platform: str
     metadata: DeploymentMetadata
+
+    @model_validator(mode="after")
+    def _check_temporal_range(self) -> Self:
+        validate_temporal_range(
+            self.deployment_start_datetime, self.deployment_end_datetime
+        )
+        return self

--- a/src/afft/tasks/build_deployment_bundle/__init__.py
+++ b/src/afft/tasks/build_deployment_bundle/__init__.py
@@ -4,6 +4,7 @@ logs."""
 from .frame_builders import (
     build_deployment_files_frame as build_deployment_files_frame,
     build_raw_telemetry_frame as build_raw_telemetry_frame,
+    record_to_frame as record_to_frame,
 )
 from .section_builders import (
     build_deployment_bundle as build_deployment_bundle,

--- a/src/afft/tasks/build_deployment_bundle/frame_builders.py
+++ b/src/afft/tasks/build_deployment_bundle/frame_builders.py
@@ -4,7 +4,8 @@ dtype normalization it needs before it can be passed to `write_frame`."""
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from typing import Any
+from types import NoneType, UnionType
+from typing import Any, get_args, get_origin
 
 import pandas as pd
 
@@ -66,6 +67,10 @@ def record_to_frame(value: BaseModel) -> pd.DataFrame:
     since `HDFStore`'s `format="table"` cannot write a naive/mixed-tz object
     column.
 
+    Optional datetime fields are normalized too, with a `None` becoming
+    `NaT`. The column is written whether or not a value was recorded, so
+    consumers see one shape either way.
+
     Arguments
     ---------
     value: Model instance to encode.
@@ -76,9 +81,23 @@ def record_to_frame(value: BaseModel) -> pd.DataFrame:
     """
     frame = pd.DataFrame([value.model_dump()])
     for name, field in type(value).model_fields.items():
-        if field.annotation is datetime:
+        if _is_datetime_annotation(field.annotation):
             frame[name] = pd.to_datetime(frame[name], utc=True)
     return frame
+
+
+def _is_datetime_annotation(annotation: Any) -> bool:
+    """Whether a field annotation is `datetime` or `datetime | None`.
+
+    The optional case needs unwrapping because `datetime | None` is not
+    `datetime`, so an identity check alone leaves an optional timestamp as an
+    object column -- the one `HDFStore`'s `format="table"` cannot write.
+    """
+    if annotation is datetime:
+        return True
+    if get_origin(annotation) is UnionType:
+        return set(get_args(annotation)) == {datetime, NoneType}
+    return False
 
 
 def message_topics_to_frame(topics: list[str]) -> pd.DataFrame:

--- a/src/afft/tasks/build_deployment_bundle/section_builders.py
+++ b/src/afft/tasks/build_deployment_bundle/section_builders.py
@@ -39,7 +39,8 @@ def build_deployment_section(
         frame_builders.record_to_frame(
             DeploymentIdentity(
                 deployment_label=descriptor.deployment_label,
-                deployment_datetime=descriptor.deployment_datetime,
+                deployment_start_datetime=descriptor.deployment_start_datetime,
+                deployment_end_datetime=descriptor.deployment_end_datetime,
             )
         ),
         if_exists="fail",

--- a/src/afft/tasks/deployment_catalog/builders.py
+++ b/src/afft/tasks/deployment_catalog/builders.py
@@ -37,7 +37,7 @@ def map_platform_profile_keys(
     """
     return {
         descriptor.deployment_label: (
-            f"{descriptor.deployment_datetime.year}_"
+            f"{descriptor.deployment_start_datetime.year}_"
             f"{_snake_case(descriptor.system.vehicle_name)}"
         )
         for descriptor in descriptors
@@ -78,12 +78,12 @@ def map_vessel_profile_keys(
 
     campaign_keys: dict[str, str] = {}
     for descriptor in sorted(
-        tracked, key=lambda item: item.deployment_datetime
+        tracked, key=lambda item: item.deployment_start_datetime
     ):
         campaign: str = descriptor.metadata.acfr_campaign_label
         if campaign not in campaign_keys:
             campaign_keys[campaign] = (
-                f"{descriptor.deployment_datetime:%Y%m}_"
+                f"{descriptor.deployment_start_datetime:%Y%m}_"
                 f"{_snake_case(campaign) or 'unknown_campaign'}"
             )
 

--- a/src/afft/tasks/deployment_descriptor/__init__.py
+++ b/src/afft/tasks/deployment_descriptor/__init__.py
@@ -7,7 +7,7 @@ from .builders import (
     build_telemetry_section as build_telemetry_section,
 )
 from .runner import (
-    create_deployment_datetime_finder as create_deployment_datetime_finder,
+    create_deployment_start_datetime_finder as create_deployment_start_datetime_finder,
     create_deployment_finder as create_deployment_finder,
     create_deployment_labeller as create_deployment_labeller,
     describe_deployment as describe_deployment,

--- a/src/afft/tasks/deployment_descriptor/runner.py
+++ b/src/afft/tasks/deployment_descriptor/runner.py
@@ -32,7 +32,7 @@ from .types import (
     DescribeDeploymentResult,
 )
 
-type DeploymentDatetimeFinder = Callable[[Path], datetime]
+type DeploymentStartDatetimeFinder = Callable[[Path], datetime]
 type DeploymentFinder = Callable[[Path], list[Path]]
 type DeploymentLabeller = Callable[[Path], str]
 
@@ -86,9 +86,9 @@ def create_deployment_labeller(
     return labeller
 
 
-def create_deployment_datetime_finder(
+def create_deployment_start_datetime_finder(
     command: DescribeDeploymentCommand,
-) -> DeploymentDatetimeFinder:
+) -> DeploymentStartDatetimeFinder:
     """
     Create a strategy that parses the start datetime from a deployment
     directory name.
@@ -121,7 +121,7 @@ def create_deployment_datetime_finder(
 def describe_deployment(
     directory: Path,
     deployment_label: str,
-    deployment_datetime: datetime,
+    deployment_start_datetime: datetime,
     diagnostics: DescribeDeploymentDiagnostics,
 ) -> DeploymentDescriptor:
     """
@@ -139,7 +139,7 @@ def describe_deployment(
     ---------
     directory: Deployment root directory.
     deployment_label: Label of the deployment.
-    deployment_datetime: Start datetime of the deployment.
+    deployment_start_datetime: Start datetime of the deployment.
     diagnostics: Accumulator for non-fatal issues.
 
     Returns
@@ -169,7 +169,7 @@ def describe_deployment(
 
     return DeploymentDescriptor(
         deployment_label=deployment_label,
-        deployment_datetime=deployment_datetime,
+        deployment_start_datetime=deployment_start_datetime,
         metadata=build_deployment_metadata(
             files, deployment_label, diagnostics
         ),
@@ -217,8 +217,8 @@ def run_describe_deployment(
 
     find_deployments: DeploymentFinder = create_deployment_finder(command)
     label_deployment: DeploymentLabeller = create_deployment_labeller(command)
-    find_start_datetime: DeploymentDatetimeFinder = (
-        create_deployment_datetime_finder(command)
+    find_start_datetime: DeploymentStartDatetimeFinder = (
+        create_deployment_start_datetime_finder(command)
     )
 
     deployment_dirs: list[Path] = find_deployments(command.root_dir)

--- a/tests/test_build_deployment_bundle.py
+++ b/tests/test_build_deployment_bundle.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pandas as pd
 import pytest
 
 from click.testing import CliRunner, Result
@@ -10,6 +11,7 @@ from click.testing import CliRunner, Result
 from afft.cli.entrypoint import cli
 from afft.deployment import (
     DeploymentDescriptor,
+    DeploymentIdentity,
     DeploymentMetadata,
     FileDescriptorSection,
     PlatformDescriptorSection,
@@ -25,6 +27,7 @@ from afft.deployment import (
 from afft.tasks.build_deployment_bundle import (
     BuildDeploymentBundleCommand,
     BuildDeploymentBundleConfig,
+    record_to_frame,
     run_build_deployment_bundle,
 )
 
@@ -63,7 +66,9 @@ def _build_descriptor(
     )
     return DeploymentDescriptor(
         deployment_label=label,
-        deployment_datetime=datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+        deployment_start_datetime=datetime(
+            2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc
+        ),
         metadata=DeploymentMetadata(
             acfr_deployment_label="geebank_16_15m_out",
             acfr_campaign_label="WA201004",
@@ -151,6 +156,16 @@ def test_run_builds_a_readable_bundle(tmp_path: Path) -> None:
         deployment_identity = reader.read_frame("deployment/identity")
         assert deployment_identity["deployment_label"].iloc[0] == (
             DEPLOYMENT_LABEL
+        )
+        # A descriptor without an end still writes the column, as NaT rather
+        # than omitting it, so consumers see one shape either way.
+        assert "deployment_end_datetime" in deployment_identity.columns
+        assert pd.isna(deployment_identity["deployment_end_datetime"].iloc[0])
+        assert deployment_identity["deployment_start_datetime"].dtype == (
+            pd.DatetimeTZDtype(unit="ns", tz="UTC")
+        )
+        assert deployment_identity["deployment_end_datetime"].dtype == (
+            pd.DatetimeTZDtype(unit="ns", tz="UTC")
         )
         platform_identity = reader.read_frame("platform/identity")
         assert platform_identity["platform_label"].iloc[0] == "AUV Sirius"
@@ -246,3 +261,44 @@ def test_cli_builds_a_deployment_bundle(tmp_path: Path) -> None:
             "telemetry/raw/pressure_parosci/PAROSCI/messages"
             in reader.list_frames()
         )
+
+
+def test_record_to_frame_normalizes_an_optional_datetime() -> None:
+    """`datetime | None` is normalized like a plain `datetime`.
+
+    `datetime | None` is not `datetime`, so an identity check on the
+    annotation would leave the column as objects -- the one case
+    `HDFStore`'s `format="table"` cannot write.
+    """
+    frame = record_to_frame(
+        DeploymentIdentity(
+            deployment_label=DEPLOYMENT_LABEL,
+            deployment_start_datetime=datetime(
+                2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc
+            ),
+            deployment_end_datetime=datetime(
+                2010, 4, 28, 3, 2, 2, tzinfo=timezone.utc
+            ),
+        )
+    )
+
+    utc = pd.DatetimeTZDtype(unit="ns", tz="UTC")
+    assert frame["deployment_start_datetime"].dtype == utc
+    assert frame["deployment_end_datetime"].dtype == utc
+
+
+def test_record_to_frame_encodes_an_absent_datetime_as_nat() -> None:
+    """An unrecorded end becomes `NaT` in a UTC column, not an object."""
+    frame = record_to_frame(
+        DeploymentIdentity(
+            deployment_label=DEPLOYMENT_LABEL,
+            deployment_start_datetime=datetime(
+                2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc
+            ),
+        )
+    )
+
+    assert frame["deployment_end_datetime"].dtype == (
+        pd.DatetimeTZDtype(unit="ns", tz="UTC")
+    )
+    assert pd.isna(frame["deployment_end_datetime"].iloc[0])

--- a/tests/test_deployment_bundle_io.py
+++ b/tests/test_deployment_bundle_io.py
@@ -14,10 +14,12 @@ import pandas as pd
 import pytest
 
 from afft.deployment import (
+    DeploymentIdentity,
     open_deployment_bundle,
     open_deployment_bundle_reader,
     open_deployment_bundle_writer,
 )
+from afft.tasks.build_deployment_bundle import record_to_frame
 
 SUFFIXES: tuple[str, ...] = (".h5", ".sqlite")
 
@@ -247,3 +249,48 @@ def test_unsupported_suffix_raises(tmp_path: Path) -> None:
     with pytest.raises(NotImplementedError):
         with open_deployment_bundle(tmp_path / "bundle.parquet"):
             pass
+
+
+@pytest.mark.parametrize(
+    "end",
+    [
+        datetime(2023, 10, 21, 4, 0, 0, tzinfo=timezone.utc),
+        None,
+    ],
+    ids=["clipped", "full-range"],
+)
+def test_deployment_identity_temporal_range_round_trip(
+    bundle_path: Path, end: datetime | None
+) -> None:
+    """A deployment identity's temporal range survives a round trip.
+
+    Covers both a clipped deployment, which records both bounds, and a
+    full-range one, whose absent end is stored as `NaT` in a UTC column
+    rather than as a missing column.
+    """
+    identity = record_to_frame(
+        DeploymentIdentity(
+            deployment_label="qdch0ftq_20231021_030000",
+            deployment_start_datetime=datetime(
+                2023, 10, 21, 3, 0, 0, tzinfo=timezone.utc
+            ),
+            deployment_end_datetime=end,
+        )
+    )
+
+    with open_deployment_bundle_writer(bundle_path) as writer:
+        writer.write_frame("deployment/identity", identity)
+
+    with open_deployment_bundle_reader(bundle_path) as reader:
+        read_back = reader.read_frame("deployment/identity")
+
+    utc = pd.DatetimeTZDtype(unit="ns", tz="UTC")
+    assert read_back["deployment_start_datetime"].dtype == utc
+    assert read_back["deployment_end_datetime"].dtype == utc
+    assert read_back["deployment_start_datetime"].iloc[0] == pd.Timestamp(
+        "2023-10-21 03:00:00", tz="UTC"
+    )
+    if end is None:
+        assert pd.isna(read_back["deployment_end_datetime"].iloc[0])
+    else:
+        assert read_back["deployment_end_datetime"].iloc[0] == pd.Timestamp(end)

--- a/tests/test_deployment_bundle_types.py
+++ b/tests/test_deployment_bundle_types.py
@@ -2,6 +2,10 @@
 
 from datetime import datetime
 
+import pytest
+
+from pydantic import ValidationError
+
 from afft.deployment import (
     DeploymentBundleHeader,
     DeploymentIdentity,
@@ -14,11 +18,50 @@ def test_deployment_identity() -> None:
     """Constructs a deployment identity."""
     identity: DeploymentIdentity = DeploymentIdentity(
         deployment_label="r20101003_054452_alligator_creek_south_02",
-        deployment_datetime=datetime(2010, 10, 3, 5, 44, 52),
+        deployment_start_datetime=datetime(2010, 10, 3, 5, 44, 52),
     )
     assert identity.deployment_label == (
         "r20101003_054452_alligator_creek_south_02"
     )
+
+
+def test_deployment_identity_end_defaults_to_none() -> None:
+    """A deployment covering its full temporal range records no end."""
+    identity: DeploymentIdentity = DeploymentIdentity(
+        deployment_label="r20101003_054452_alligator_creek_south_02",
+        deployment_start_datetime=datetime(2010, 10, 3, 5, 44, 52),
+    )
+    assert identity.deployment_end_datetime is None
+
+
+def test_deployment_identity_accepts_a_temporal_range() -> None:
+    """A clipped deployment records both bounds."""
+    identity: DeploymentIdentity = DeploymentIdentity(
+        deployment_label="r20101003_054452_alligator_creek_south_02_dense01",
+        deployment_start_datetime=datetime(2010, 10, 3, 5, 44, 52),
+        deployment_end_datetime=datetime(2010, 10, 3, 6, 14, 52),
+    )
+    assert identity.deployment_end_datetime == datetime(2010, 10, 3, 6, 14, 52)
+
+
+@pytest.mark.parametrize(
+    "end",
+    [
+        datetime(2010, 10, 3, 5, 44, 52),
+        datetime(2010, 10, 3, 4, 0, 0),
+    ],
+    ids=["equal-to-start", "before-start"],
+)
+def test_deployment_identity_rejects_an_end_not_after_its_start(
+    end: datetime,
+) -> None:
+    """An end at or before the start is not a temporal range."""
+    with pytest.raises(ValidationError, match="must be after its start"):
+        DeploymentIdentity(
+            deployment_label="r20101003_054452_alligator_creek_south_02",
+            deployment_start_datetime=datetime(2010, 10, 3, 5, 44, 52),
+            deployment_end_datetime=end,
+        )
 
 
 def test_deployment_bundle_header() -> None:

--- a/tests/test_deployment_descriptor.py
+++ b/tests/test_deployment_descriptor.py
@@ -57,7 +57,7 @@ def _build_descriptor() -> DeploymentDescriptor:
     """Builds a descriptor with every curated slot left unfilled."""
     return DeploymentDescriptor(
         deployment_label="qd66hv_20170525_234600",
-        deployment_datetime=datetime(
+        deployment_start_datetime=datetime(
             2017, 5, 25, 23, 46, 0, tzinfo=timezone.utc
         ),
         metadata=DeploymentMetadata(
@@ -100,9 +100,13 @@ def test_descriptor_datetime_is_native_toml_datetime(tmp_path: Path) -> None:
     write_deployment_descriptors(path, [_build_descriptor()])
 
     # Unquoted, so TOML decodes it back to a datetime rather than a string.
-    assert "deployment_datetime = 2017-05-25 23:46:00+00:00" in path.read_text()
+    assert (
+        "deployment_start_datetime = 2017-05-25 23:46:00+00:00"
+        in path.read_text()
+    )
     assert isinstance(
-        read_config(path)["deployments"][0]["deployment_datetime"], datetime
+        read_config(path)["deployments"][0]["deployment_start_datetime"],
+        datetime,
     )
 
 

--- a/tests/test_deployment_enrichment.py
+++ b/tests/test_deployment_enrichment.py
@@ -48,7 +48,9 @@ def _build_descriptor(
     """Builds a descriptor carrying only the fields enrichment reads."""
     return DeploymentDescriptor(
         deployment_label=label,
-        deployment_datetime=datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+        deployment_start_datetime=datetime(
+            2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc
+        ),
         metadata=DeploymentMetadata(
             acfr_deployment_label=label,
             acfr_campaign_label="WA201004",

--- a/tests/test_describe_deployment.py
+++ b/tests/test_describe_deployment.py
@@ -286,7 +286,7 @@ def test_run_writes_descriptor_toml(tmp_path: Path) -> None:
     descriptor = descriptors[0]
     assert descriptor == result.descriptors[0]
     assert descriptor.deployment_label == DEPLOYMENT_LABEL
-    assert descriptor.deployment_datetime.isoformat() == (
+    assert descriptor.deployment_start_datetime.isoformat() == (
         "2017-05-25T23:46:00+00:00"
     )
     assert descriptor.telemetry.topics == ["GPS_RMC", "RDI", "VIS"]

--- a/tests/test_scaffold_catalog.py
+++ b/tests/test_scaffold_catalog.py
@@ -37,7 +37,7 @@ def _build_descriptor(
     """Builds a descriptor carrying only the fields the scaffolder reads."""
     return DeploymentDescriptor(
         deployment_label=label,
-        deployment_datetime=moment,
+        deployment_start_datetime=moment,
         metadata=DeploymentMetadata(
             acfr_deployment_label=label,
             acfr_campaign_label=campaign,

--- a/tests/test_summarize_descriptors.py
+++ b/tests/test_summarize_descriptors.py
@@ -65,7 +65,7 @@ def _build_descriptor(
     """Builds a descriptor carrying only the fields the summarizer reads."""
     return DeploymentDescriptor(
         deployment_label=label,
-        deployment_datetime=moment,
+        deployment_start_datetime=moment,
         metadata=DeploymentMetadata(
             acfr_deployment_label=label,
             acfr_campaign_label=campaign,

--- a/tests/test_transform_camera_poses.py
+++ b/tests/test_transform_camera_poses.py
@@ -78,7 +78,9 @@ def _build_descriptor(
     """Builds a descriptor carrying only the fields the extrinsics lookup reads."""
     return DeploymentDescriptor(
         deployment_label=label,
-        deployment_datetime=datetime(2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc),
+        deployment_start_datetime=datetime(
+            2010, 4, 28, 2, 2, 2, tzinfo=timezone.utc
+        ),
         metadata=DeploymentMetadata(
             acfr_deployment_label=label,
             acfr_campaign_label="WA201004",


### PR DESCRIPTION
## Summary

Renames `deployment_datetime` to `deployment_start_datetime` and adds an optional `deployment_end_datetime` across the four models carrying it: `DeploymentDescriptor`, `DeploymentInfo`, `DeploymentSummary`, and `DeploymentIdentity`. The renamed field never changed meaning -- it was already the start, parsed from the deployment directory name -- but nothing said so, and there was no end to pair it with.

The end is optional and defaults to `None`. An end cannot be derived from a directory name, so every existing deployment carries `None`, and the clip task in #265 is the first producer that knows one. A shared `validate_temporal_range` backs a `model_validator` on each model, rejecting an end at or before its start.

`record_to_frame` now unwraps optional datetime annotations. `datetime | None` is not `datetime`, so the previous identity check left the column as objects -- the one case `HDFStore`'s `format="table"` cannot write. A `None` becomes `NaT` in a `datetime64[ns, UTC]` column, so the column is present whether or not an end was recorded.

Consumers updated: the catalog profile-key builders, the descriptor summary, the loader, the section builders, and the descriptor runner, where `create_deployment_datetime_finder` and `DeploymentDatetimeFinder` become `..._start_datetime_...`. The summary export now emits separate `Start` and `End` lines, with `not recorded` for an absent end.

The five tracked descriptor TOMLs are migrated by rewriting the key in place rather than regenerating them, which would discard the curated sections that enrichment fills.

Two things worth a reviewer's attention:

- `record_to_frame` is now exported from `afft.tasks.build_deployment_bundle`, so the tests import it from the package rather than the module. A small public-surface addition the issue did not call for.
- No compatibility alias accepts the old TOML key, so a descriptor file outside this repository will fail to load until its key is renamed. This was left open in the issue.

Every pydantic model in `afft.deployment` was swept for other `datetime | None` fields flowing through `record_to_frame`; the four added here are the only matches, so nothing was silently broken beforehand.

Closes #267