### PR TITLE
Add deployment bundle clipping task and CLI command

### DIFF
--- a/scripts/shell/bundle_batch_clip_desktop.sh
+++ b/scripts/shell/bundle_batch_clip_desktop.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/bash
+
+# Exit on the first failing command, on any unset variable, and on a failure
+# anywhere in a pipeline rather than only in its last command.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+INPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
+OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset_dense_grids"
+
+# Appended to each source deployment label to name the clipped deployment.
+# One dense grid is cut per full-grid deployment, so the suffix is the same
+# for every row; a second segment from the same parent would need its own.
+LABEL_SUFFIX="dense01"
+
+# Metocean series are sampled far coarser than telemetry -- often hourly --
+# so a dense-grid window would clip a forcing series to one row or none.
+# Metocean describes conditions rather than the vehicle's track, so the
+# dense-grid bundle keeps the full series.
+NO_CLIP_PATTERN="metocean/*"
+
+# Dense-grid temporal ranges, one row per deployment, as recorded in #266.
+# Each range is a subset of the full-grid deployment carrying the same label,
+# bracketed 10 seconds around the first and last dense-grid image.
+#
+# The clip window is closed, so both bounds are kept and the ranges transfer
+# exactly as #266 states them.
+#
+# Fields: deployment_label|start_time|end_time
+DENSE_GRID_RANGES=(
+  "qdch0ftq_20100428_020202|2010-04-28T03:54:39Z|2010-04-28T04:33:41Z"
+  "qdch0ftq_20110415_020103|2011-04-15T03:42:40Z|2011-04-15T04:20:34Z"
+  "qdch0ftq_20120430_002423|2012-04-30T02:07:21Z|2012-04-30T02:44:19Z"
+  "qdch0ftq_20130406_023610|2013-04-06T05:03:44Z|2013-04-06T05:39:38Z"
+  "qdchdmy1_20110416_005411|2011-04-16T00:58:13Z|2011-04-16T01:37:09Z"
+  "qdchdmy1_20120501_071203|2012-05-01T07:15:14Z|2012-05-01T07:52:50Z"
+  "qdchdmy1_20130406_081713|2013-04-06T08:24:09Z|2013-04-06T09:00:32Z"
+  "qdchdmy1_20170525_234624|2017-05-25T23:59:45Z|2017-05-26T00:38:37Z"
+  "r23685bc_20100605_021022|2010-06-05T03:00:40Z|2010-06-05T03:46:29Z"
+  "r23685bc_20120530_233021|2012-05-31T00:14:54Z|2012-05-31T00:58:44Z"
+  "r23685bc_20140616_225022|2014-06-16T22:54:31Z|2014-06-16T23:32:19Z"
+  "r29mrd5h_20090612_225306|2009-06-12T23:00:54Z|2009-06-13T00:45:53Z"
+  "r29mrd5h_20110612_033752|2011-06-12T03:45:37Z|2011-06-12T04:23:43Z"
+  "r29mrd5h_20130611_002419|2013-06-11T00:32:46Z|2013-06-11T01:08:39Z"
+  "r7jjskxq_20101023_210332|2010-10-23T21:06:23Z|2010-10-23T21:51:50Z"
+  "r7jjskxq_20121013_060425|2012-10-13T06:21:17Z|2012-10-13T07:02:50Z"
+  "r7jjskxq_20131022_004934|2013-10-22T00:55:47Z|2013-10-22T01:32:58Z"
+)
+
+mkdir -p "${OUTPUT_DIR}"
+
+cd "${REPO_ROOT}"
+
+for range in "${DENSE_GRID_RANGES[@]}"; do
+  IFS="|" read -r deployment_label start_time end_time <<< "${range}"
+
+  input_file="${INPUT_DIR}/${deployment_label}_deployment_bundle.sqlite"
+  output_file="${OUTPUT_DIR}/${deployment_label}_${LABEL_SUFFIX}_deployment_bundle.sqlite"
+
+  uv run afft bundle clip \
+    --input "${input_file}" \
+    --output "${output_file}" \
+    --start "${start_time}" \
+    --end "${end_time}" \
+    --label-suffix "${LABEL_SUFFIX}" \
+    --no-clip "${NO_CLIP_PATTERN}" \
+    --overwrite
+done

--- a/src/afft/cli/bundle/actions.py
+++ b/src/afft/cli/bundle/actions.py
@@ -1,5 +1,6 @@
 """Actions for deployment bundle CLI commands."""
 
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -16,8 +17,10 @@ from afft.tasks.build_deployment_bundle import (
     run_build_deployment_bundle,
 )
 from afft.tasks.deployment_bundle_common import (
+    ClipDeploymentBundleCommand,
     ExportBundleFrameCommand,
     IngestBundleFrameCommand,
+    run_clip_deployment_bundle,
     run_export_bundle_frame,
     run_ingest_bundle_frame,
 )
@@ -132,3 +135,27 @@ def invoke_process_deployment_bundle(
         verbose=verbose,
     )
     run_process_deployment_bundle(command)
+
+
+def invoke_clip_deployment_bundle(
+    input_file: str | Path,
+    output_file: str | Path,
+    start: datetime,
+    end: datetime,
+    label_suffix: str,
+    datetime_column: str = "timestamp",
+    no_clip_patterns: tuple[str, ...] = (),
+    overwrite: bool = False,
+) -> None:
+    """Clip a deployment bundle's tables to a temporal window."""
+    command = ClipDeploymentBundleCommand(
+        input_file=Path(input_file),
+        output_file=Path(output_file),
+        start=start,
+        end=end,
+        label_suffix=label_suffix,
+        datetime_column=datetime_column,
+        no_clip_patterns=no_clip_patterns,
+        overwrite=overwrite,
+    )
+    run_clip_deployment_bundle(command)

--- a/src/afft/cli/bundle/commands.py
+++ b/src/afft/cli/bundle/commands.py
@@ -1,14 +1,42 @@
 """CLI commands for working with deployment bundles."""
 
+from datetime import datetime
+
 import click
 
 from .actions import (
     invoke_build_deployment_bundle,
+    invoke_clip_deployment_bundle,
     invoke_export_bundle_frame,
     invoke_ingest_bundle_frame,
     invoke_list_deployment_bundle,
     invoke_process_deployment_bundle,
 )
+
+
+class IsoDateTime(click.ParamType[datetime]):
+    """A datetime parsed from ISO8601, rather than from a fixed format list.
+
+    `click.DateTime` matches against a list of formats and none of its
+    defaults carries a UTC offset, so an offset-bearing bound would be
+    rejected. Whether the parsed value is naive is left to the task, which
+    takes a naive bound as UTC.
+    """
+
+    name: str = "iso8601"
+
+    def convert(
+        self,
+        value: object,
+        param: click.Parameter | None,
+        context: click.Context | None,
+    ) -> datetime:
+        if isinstance(value, datetime):
+            return value
+        try:
+            return datetime.fromisoformat(str(value))
+        except ValueError:
+            self.fail(f"{value!r} is not an ISO8601 datetime", param, context)
 
 
 @click.group()
@@ -243,5 +271,78 @@ def export_frame(
         bundle_file,
         key,
         output_file,
+        overwrite,
+    )
+
+
+@bundle_group.command("clip")
+@click.option(
+    "--input",
+    "input_file",
+    type=click.Path(exists=True, dir_okay=False),
+    required=True,
+    help="path to the deployment bundle to clip, never written",
+)
+@click.option(
+    "--output",
+    "output_file",
+    type=click.Path(dir_okay=False),
+    required=True,
+    help="path to write the clipped bundle to",
+)
+@click.option(
+    "--start",
+    type=IsoDateTime(),
+    required=True,
+    help="start of the clip window, inclusive; naive values are taken as UTC",
+)
+@click.option(
+    "--end",
+    type=IsoDateTime(),
+    required=True,
+    help="end of the clip window, inclusive; naive values are taken as UTC",
+)
+@click.option(
+    "--label-suffix",
+    required=True,
+    help="suffix joined onto the source deployment label with an underscore",
+)
+@click.option(
+    "--datetime-column",
+    default="timestamp",
+    show_default=True,
+    help="column to clip on; frames without it are copied whole",
+)
+@click.option(
+    "--no-clip",
+    "no_clip_patterns",
+    multiple=True,
+    help="key pattern whose frames are copied whole; repeatable",
+)
+@click.option(
+    "--overwrite",
+    is_flag=True,
+    default=False,
+    help="overwrite the output file if it already exists",
+)
+def clip(
+    input_file: str,
+    output_file: str,
+    start: datetime,
+    end: datetime,
+    label_suffix: str,
+    datetime_column: str,
+    no_clip_patterns: tuple[str, ...],
+    overwrite: bool,
+) -> None:
+    """Clip a deployment bundle's tables to a temporal window."""
+    invoke_clip_deployment_bundle(
+        input_file,
+        output_file,
+        start,
+        end,
+        label_suffix,
+        datetime_column,
+        no_clip_patterns,
         overwrite,
     )

--- a/src/afft/deployment/bundle_hdf_common.py
+++ b/src/afft/deployment/bundle_hdf_common.py
@@ -1,6 +1,8 @@
 """Helpers shared by the `pandas.HDFStore` deployment bundle reader, writer,
 and read-write implementations."""
 
+from typing import Literal
+
 import pandas as pd
 
 from .bundle_common import CONTENTS_KEY, empty_contents
@@ -100,3 +102,26 @@ def upsert_contents_row(
     if CONTENTS_KEY in store:
         store.remove(CONTENTS_KEY)
     store.put(CONTENTS_KEY, updated, format="table")
+
+
+def put_frame(store: pd.HDFStore, table_name: str, frame: pd.DataFrame) -> None:
+    """
+    Write a frame to the store, choosing the layout its row count allows.
+
+    A row-less frame is written as ``"fixed"`` rather than ``"table"``:
+    ``format="table"`` writes nothing at all for one, which would leave a
+    ``bundle_contents`` row pointing at an object the store does not hold --
+    ``has_frame`` would answer yes and ``read_frame`` would then raise. Both
+    layouts read back through ``select``, and the query support ``"table"``
+    buys is meaningless for a frame with no rows to query.
+
+    Arguments
+    ---------
+    store: Open store to write to.
+    table_name: Name to write the frame under.
+    frame: Frame to write, already coerced to storable dtypes.
+    """
+    table_format: Literal["fixed", "table"] = (
+        "fixed" if frame.empty else "table"
+    )
+    store.put(table_name, frame, format=table_format)

--- a/src/afft/deployment/bundle_hdf_io.py
+++ b/src/afft/deployment/bundle_hdf_io.py
@@ -11,6 +11,7 @@ import pandas as pd
 from .bundle_common import RESERVED_KEYS, encode_frame_dtypes
 from .bundle_hdf_common import (
     coerce_storable_dtypes,
+    put_frame,
     read_contents,
     resolve_table_name,
     upsert_contents_row,
@@ -64,7 +65,7 @@ class HDFDeploymentBundleIO:
         frame = coerce_storable_dtypes(frame)
         if exists:
             self.store.remove(table_name)
-        self.store.put(table_name, frame, format="table")
+        put_frame(self.store, table_name, frame)
 
         upsert_contents_row(self.store, key, table_name, dtypes)
 

--- a/src/afft/deployment/bundle_hdf_writers.py
+++ b/src/afft/deployment/bundle_hdf_writers.py
@@ -11,6 +11,7 @@ import pandas as pd
 from .bundle_common import RESERVED_KEYS, encode_frame_dtypes
 from .bundle_hdf_common import (
     coerce_storable_dtypes,
+    put_frame,
     read_contents,
     upsert_contents_row,
 )
@@ -51,7 +52,7 @@ class HDFDeploymentBundleWriter:
         frame = coerce_storable_dtypes(frame)
         if exists:
             self.store.remove(table_name)
-        self.store.put(table_name, frame, format="table")
+        put_frame(self.store, table_name, frame)
 
         upsert_contents_row(self.store, key, table_name, dtypes)
 

--- a/src/afft/deployment/bundle_types.py
+++ b/src/afft/deployment/bundle_types.py
@@ -66,11 +66,20 @@ class DeploymentProvenance(BaseModel):
     Attributes
     ----------
     deployment_key: Identifier of the deployment the bundle was built from.
+    source_bundle: Path to the bundle this one was cut from; ``None`` for a
+        bundle built from raw message logs rather than derived from another.
+    clip_start_datetime: Start of the window the source bundle was clipped to,
+        inclusive; ``None`` when the bundle is not a clip.
+    clip_end_datetime: End of the window the source bundle was clipped to,
+        inclusive; ``None`` when the bundle is not a clip.
     """
 
     model_config = ConfigDict(frozen=True)
 
     deployment_key: str
+    source_bundle: str | None = None
+    clip_start_datetime: datetime | None = None
+    clip_end_datetime: datetime | None = None
 
 
 class ProcessedProvenance(BaseModel):

--- a/src/afft/tasks/deployment_bundle_common/__init__.py
+++ b/src/afft/tasks/deployment_bundle_common/__init__.py
@@ -1,21 +1,30 @@
 """Common tasks for working with existing deployment bundles."""
 
 from .task_helpers import (
+    clip_frame_to_window as clip_frame_to_window,
+    key_matches_no_clip as key_matches_no_clip,
     read_frame_file as read_frame_file,
     validate_bundle_frame_key as validate_bundle_frame_key,
+    validate_clip_deployment_bundle_input,
     validate_export_bundle_frame_input as validate_export_bundle_frame_input,
     validate_ingest_bundle_frame_input as validate_ingest_bundle_frame_input,
     write_frame_file as write_frame_file,
 )
 from .task_runners import (
+    run_clip_deployment_bundle as run_clip_deployment_bundle,
     run_export_bundle_frame as run_export_bundle_frame,
     run_ingest_bundle_frame as run_ingest_bundle_frame,
 )
 from .task_types import (
+    ClipDeploymentBundleCommand as ClipDeploymentBundleCommand,
+    ClipDeploymentBundleResult as ClipDeploymentBundleResult,
+    ClippedFrame as ClippedFrame,
     ExportBundleFrameCommand as ExportBundleFrameCommand,
     ExportBundleFrameResult as ExportBundleFrameResult,
     IngestBundleFrameCommand as IngestBundleFrameCommand,
     IngestBundleFrameResult as IngestBundleFrameResult,
 )
 
-__all__ = []
+# Re-exported by name rather than the `X as X` form the others use: the
+# redundant-alias spelling runs past the line limit and cannot be wrapped.
+__all__ = ["validate_clip_deployment_bundle_input"]

--- a/src/afft/tasks/deployment_bundle_common/task_helpers.py
+++ b/src/afft/tasks/deployment_bundle_common/task_helpers.py
@@ -1,6 +1,7 @@
 """Supporting functions for the common deployment bundle tasks: key
 validation, frame reading and writing, and input validation."""
 
+import fnmatch
 import re
 
 from collections.abc import Callable
@@ -8,7 +9,11 @@ from pathlib import Path
 
 import pandas as pd
 
-from .task_types import ExportBundleFrameCommand, IngestBundleFrameCommand
+from .task_types import (
+    ClipDeploymentBundleCommand,
+    ExportBundleFrameCommand,
+    IngestBundleFrameCommand,
+)
 
 type BundleFrameKey = str
 type FrameWriter = Callable[[pd.DataFrame, Path], None]
@@ -190,6 +195,117 @@ def validate_ingest_bundle_frame_input(
     if not command.input_file.is_file():
         raise FileNotFoundError(
             f"input file does not exist: {command.input_file}"
+        )
+
+
+def key_matches_no_clip(key: BundleFrameKey, patterns: tuple[str, ...]) -> bool:
+    """
+    Whether a key matches any of the no-clip patterns.
+
+    Patterns are `fnmatch` globs matched against the whole key. ``*`` crosses
+    slash boundaries there, so ``metocean/*`` matches
+    ``metocean/stormglass/wave_height`` as intended.
+
+    Arguments
+    ---------
+    key: Bundle key to test.
+    patterns: Key patterns whose frames are copied whole.
+
+    Returns
+    -------
+    Whether the frame at `key` should keep every row.
+    """
+    return any(fnmatch.fnmatch(key, pattern) for pattern in patterns)
+
+
+def clip_frame_to_window(
+    key: BundleFrameKey,
+    frame: pd.DataFrame,
+    datetime_column: str,
+    start: pd.Timestamp,
+    end: pd.Timestamp,
+) -> pd.DataFrame:
+    """
+    Clip a frame's rows to a closed window on its datetime column.
+
+    The window is ``start <= t <= end``, so a range quoted as covering both
+    of its bounds keeps the rows sitting on them. Consecutive windows sharing
+    a bound therefore both keep the row on it -- cutting a source into
+    adjacent clips duplicates that row rather than partitioning cleanly.
+
+    The result is taken by boolean mask rather than rebuilt, which is what
+    keeps a window matching no rows an empty frame with the source's dtypes
+    intact rather than an empty frame of objects.
+
+    Arguments
+    ---------
+    key: Bundle key the frame was read from, named in any error.
+    frame: Frame to clip; not mutated.
+    datetime_column: Column to clip on.
+    start: Start of the window, inclusive.
+    end: End of the window, inclusive.
+
+    Returns
+    -------
+    The rows of `frame` inside the window.
+
+    Raises
+    ------
+    ValueError: If `datetime_column` is not a datetime column. A frame
+        carrying the name on a non-temporal column cannot be clipped, and
+        copying it whole instead would silently keep rows outside the window.
+    """
+    column: pd.Series = frame[datetime_column]
+    if not pd.api.types.is_datetime64_any_dtype(column):
+        raise ValueError(
+            f"{key}: column {datetime_column!r} is not a datetime column, "
+            f"got {column.dtype}"
+        )
+
+    return frame[(column >= start) & (column <= end)].reset_index(drop=True)
+
+
+def validate_clip_deployment_bundle_input(
+    command: ClipDeploymentBundleCommand,
+) -> None:
+    """
+    Validate the task's inputs before the bundle is opened.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Raises
+    ------
+    FileNotFoundError: If the input bundle does not exist.
+    ValueError: If the output file is the input file, if it exists and
+        ``overwrite`` is not set, if ``start`` is not before ``end``, or if
+        ``label_suffix`` is empty.
+    """
+    if not command.label_suffix:
+        raise ValueError("label suffix is empty")
+
+    if command.start >= command.end:
+        raise ValueError(
+            f"clip window start must be before its end: "
+            f"{command.start.isoformat()} >= {command.end.isoformat()}"
+        )
+
+    if not command.input_file.is_file():
+        raise FileNotFoundError(
+            f"deployment bundle does not exist: {command.input_file}"
+        )
+
+    if command.output_file == command.input_file:
+        raise ValueError(
+            f"output file is the input bundle: {command.output_file}; "
+            f"a clip is written to a new bundle"
+        )
+
+    if command.output_file.exists() and not command.overwrite:
+        raise ValueError(
+            f"output file already exists: {command.output_file}: "
+            f"pass overwrite to replace it"
         )
 
 

--- a/src/afft/tasks/deployment_bundle_common/task_runners.py
+++ b/src/afft/tasks/deployment_bundle_common/task_runners.py
@@ -1,5 +1,9 @@
 """Runners for the common deployment bundle tasks."""
 
+import os
+
+from datetime import datetime
+from pathlib import Path
 from typing import Literal
 
 import pandas as pd
@@ -7,23 +11,35 @@ import pandas as pd
 from afft.deployment import (
     DeploymentBundleIO,
     DeploymentBundleReader,
+    DeploymentIdentity,
+    DeploymentProvenance,
     open_deployment_bundle,
     open_deployment_bundle_reader,
 )
+from afft.tasks.build_deployment_bundle import record_to_frame
 from afft.utils.log import logger
 
 from .task_helpers import (
+    clip_frame_to_window,
+    key_matches_no_clip,
     read_frame_file,
+    validate_clip_deployment_bundle_input,
     validate_export_bundle_frame_input,
     validate_ingest_bundle_frame_input,
     write_frame_file,
 )
 from .task_types import (
+    ClipDeploymentBundleCommand,
+    ClipDeploymentBundleResult,
+    ClippedFrame,
     ExportBundleFrameCommand,
     ExportBundleFrameResult,
     IngestBundleFrameCommand,
     IngestBundleFrameResult,
 )
+
+_IDENTITY_KEY: str = "deployment/identity"
+_PROVENANCE_KEY: str = "deployment/provenance"
 
 
 def run_export_bundle_frame(
@@ -153,3 +169,170 @@ def run_ingest_bundle_frame(
         rows=len(frame),
         columns=tuple(frame.columns),
     )
+
+
+def run_clip_deployment_bundle(
+    command: ClipDeploymentBundleCommand,
+) -> ClipDeploymentBundleResult:
+    """
+    Clip a deployment bundle's tables to a temporal window, writing a new
+    bundle.
+
+    The input is opened through the reader interface and is never written, so
+    a clip cannot damage the bundle it reads.
+
+    The window is closed, ``start <= t <= end``. Cutting one source into
+    adjacent windows therefore repeats the row on a shared bound in both
+    clips, so windows meant to partition a deployment have to be stated so
+    they do not touch.
+
+    Every key the source holds is present in the output, including one the
+    window clipped to zero rows. An empty telemetry table is an honest
+    statement that the sensor produced nothing in the window, and keeping the
+    key means a consumer's ``has_frame`` answers the same against both
+    bundles.
+
+    Arguments
+    ---------
+    command: Task command.
+
+    Returns
+    -------
+    The run's result, naming the clipped deployment and what happened to each
+    key.
+
+    Raises
+    ------
+    FileNotFoundError: If the input bundle does not exist.
+    ValueError: If the output file is the input file, if it exists and
+        ``overwrite`` is not set, if ``start`` is not before ``end``, or if
+        ``label_suffix`` is empty.
+    """
+    validate_clip_deployment_bundle_input(command)
+
+    start: pd.Timestamp = _to_utc_timestamp(command.start)
+    end: pd.Timestamp = _to_utc_timestamp(command.end)
+
+    logger.info("-------------------------------------")
+    logger.info("Clip Deployment Bundle")
+    logger.info(f"  input file:  {command.input_file}")
+    logger.info(f"  output file: {command.output_file}")
+    logger.info(f"  window:      [{start.isoformat()}, {end.isoformat()}]")
+    logger.info("-------------------------------------")
+
+    clipped: list[ClippedFrame] = []
+    copied: list[str] = []
+    empty: list[str] = []
+    deployment_label: str
+
+    output_file: Path = command.output_file
+    staged: Path = output_file.with_suffix(".partial" + output_file.suffix)
+    try:
+        reader: DeploymentBundleReader
+        target: DeploymentBundleIO
+        with open_deployment_bundle_reader(command.input_file) as reader:
+            deployment_label = _clipped_deployment_label(
+                reader, command.label_suffix
+            )
+            with open_deployment_bundle(staged) as target:
+                for key in sorted(reader.list_frames()):
+                    if key == _IDENTITY_KEY:
+                        target.write_frame(
+                            key,
+                            record_to_frame(
+                                DeploymentIdentity(
+                                    deployment_label=deployment_label,
+                                    deployment_start_datetime=command.start,
+                                    deployment_end_datetime=command.end,
+                                )
+                            ),
+                            if_exists="fail",
+                        )
+                        copied.append(key)
+                        continue
+
+                    if key == _PROVENANCE_KEY:
+                        target.write_frame(
+                            key,
+                            record_to_frame(
+                                DeploymentProvenance(
+                                    deployment_key=deployment_label,
+                                    source_bundle=str(command.input_file),
+                                    clip_start_datetime=command.start,
+                                    clip_end_datetime=command.end,
+                                )
+                            ),
+                            if_exists="fail",
+                        )
+                        copied.append(key)
+                        continue
+
+                    frame: pd.DataFrame = reader.read_frame(key)
+                    if (
+                        key_matches_no_clip(key, command.no_clip_patterns)
+                        or command.datetime_column not in frame.columns
+                    ):
+                        target.write_frame(key, frame, if_exists="fail")
+                        copied.append(key)
+                        continue
+
+                    result: pd.DataFrame = clip_frame_to_window(
+                        key, frame, command.datetime_column, start, end
+                    )
+                    target.write_frame(key, result, if_exists="fail")
+                    clipped.append(
+                        ClippedFrame(
+                            key=key,
+                            rows_before=len(frame),
+                            rows_after=len(result),
+                        )
+                    )
+                    if result.empty:
+                        empty.append(key)
+                        logger.warning(f"{key}: no rows inside the clip window")
+        os.replace(staged, output_file)
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+
+    logger.info(f"wrote clipped deployment bundle to {output_file}")
+
+    return ClipDeploymentBundleResult(
+        input_file=command.input_file,
+        output_file=output_file,
+        deployment_label=deployment_label,
+        clipped_keys=tuple(clipped),
+        copied_keys=tuple(copied),
+        empty_keys=tuple(empty),
+    )
+
+
+def _to_utc_timestamp(value: datetime) -> pd.Timestamp:
+    """Coerce a window bound to a UTC timestamp, taking a naive value as UTC.
+
+    Every timestamp in a bundle is ``datetime64[ns, UTC]``, so a naive bound
+    has to be given a zone before it can be compared against one at all.
+    """
+    timestamp: pd.Timestamp = pd.Timestamp(value)
+    if timestamp.tzinfo is None:
+        return timestamp.tz_localize("UTC")
+    return timestamp.tz_convert("UTC")
+
+
+def _clipped_deployment_label(
+    reader: DeploymentBundleReader, label_suffix: str
+) -> str:
+    """Read the source deployment's label and join the suffix onto it.
+
+    Every bundle is written onto the identity field names the descriptor
+    models use, so the label is read unconditionally rather than probed for.
+    """
+    if not reader.has_frame(_IDENTITY_KEY):
+        raise ValueError(
+            f"bundle holds no frame at {_IDENTITY_KEY!r}: "
+            f"a clip needs the source deployment's identity"
+        )
+
+    identity: pd.DataFrame = reader.read_frame(_IDENTITY_KEY)
+    source_label: str = str(identity["deployment_label"].iloc[0])
+    return f"{source_label}_{label_suffix}"

--- a/src/afft/tasks/deployment_bundle_common/task_types.py
+++ b/src/afft/tasks/deployment_bundle_common/task_types.py
@@ -1,5 +1,6 @@
 """Data types for the common deployment bundle tasks."""
 
+from datetime import datetime
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict
@@ -47,6 +48,51 @@ class ExportBundleFrameCommand(BaseModel):
     overwrite: bool = False
 
 
+class ClipDeploymentBundleCommand(BaseModel):
+    """
+    Attributes
+    ----------
+    input_file: Path to the deployment bundle to clip. Read only; never
+        written.
+    output_file: Path to write the clipped bundle to.
+    start: Start of the clip window, inclusive.
+    end: End of the clip window, inclusive.
+    label_suffix: Appended to the source deployment label, joined with an
+        underscore, to name the clipped deployment.
+    datetime_column: Column to clip on. Frames without it are copied whole.
+    no_clip_patterns: Key patterns whose frames are copied whole even if they
+        carry ``datetime_column``.
+    overwrite: Overwrite an existing output file.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    output_file: Path
+    start: datetime
+    end: datetime
+    label_suffix: str
+    datetime_column: str = "timestamp"
+    no_clip_patterns: tuple[str, ...] = ()
+    overwrite: bool = False
+
+
+class ClippedFrame(BaseModel):
+    """
+    Attributes
+    ----------
+    key: Bundle key of the frame that was clipped.
+    rows_before: Row count in the source frame.
+    rows_after: Row count inside the clip window.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    key: str
+    rows_before: int
+    rows_after: int
+
+
 class IngestBundleFrameResult(BaseModel):
     """
     Attributes
@@ -81,3 +127,28 @@ class ExportBundleFrameResult(BaseModel):
     key: str
     rows: int
     columns: tuple[str, ...]
+
+
+class ClipDeploymentBundleResult(BaseModel):
+    """
+    Attributes
+    ----------
+    input_file: Path to the bundle that was clipped.
+    output_file: Path the clipped bundle was written to.
+    deployment_label: Label of the clipped deployment.
+    clipped_keys: Keys whose frames were clipped, with their row counts before
+        and after.
+    copied_keys: Keys whose frames were copied whole.
+    empty_keys: Keys the window clipped to zero rows. Reported separately
+        rather than read off ``clipped_keys``, since it is the field a caller
+        checks to find out whether the window was wrong.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    input_file: Path
+    output_file: Path
+    deployment_label: str
+    clipped_keys: tuple[ClippedFrame, ...]
+    copied_keys: tuple[str, ...]
+    empty_keys: tuple[str, ...]

--- a/tests/test_tasks_deployment_bundle_common.py
+++ b/tests/test_tasks_deployment_bundle_common.py
@@ -1,5 +1,6 @@
 """Tests for the common deployment bundle tasks."""
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pandas as pd
@@ -9,15 +10,20 @@ from click.testing import CliRunner, Result
 
 from afft.cli.entrypoint import cli
 from afft.deployment import (
+    DeploymentIdentity,
+    DeploymentProvenance,
     open_deployment_bundle,
     open_deployment_bundle_reader,
 )
+from afft.tasks.build_deployment_bundle import record_to_frame
 from afft.tasks.deployment_bundle_common import (
+    ClipDeploymentBundleCommand,
     ExportBundleFrameCommand,
     ExportBundleFrameResult,
     IngestBundleFrameCommand,
     IngestBundleFrameResult,
     read_frame_file,
+    run_clip_deployment_bundle,
     run_export_bundle_frame,
     run_ingest_bundle_frame,
     validate_bundle_frame_key,
@@ -502,3 +508,402 @@ def test_cli_export_frame_exits_non_zero_on_a_missing_bundle(
     )
 
     assert result.exit_code != 0
+
+
+CLIP_LABEL: str = "u4rmk_20231107_043022"
+
+
+def _clip_source_bundle(path: Path) -> Path:
+    """A bundle shaped like a full-grid deployment: identity, provenance, a
+    telemetry frame on `timestamp`, a coarse metocean series, and two frames
+    with no time axis at all."""
+    timestamps = pd.to_datetime(
+        [
+            "2023-11-07T05:00:00Z",
+            "2023-11-07T05:10:00Z",
+            "2023-11-07T05:20:00Z",
+            "2023-11-07T05:40:00Z",
+            "2023-11-07T05:50:00Z",
+        ],
+        utc=True,
+    )
+    with open_deployment_bundle(path) as bundle:
+        bundle.write_frame(
+            "deployment/identity",
+            record_to_frame(
+                DeploymentIdentity(
+                    deployment_label=CLIP_LABEL,
+                    deployment_start_datetime=datetime(
+                        2023, 11, 7, 5, 0, tzinfo=timezone.utc
+                    ),
+                )
+            ),
+        )
+        bundle.write_frame(
+            "deployment/provenance",
+            record_to_frame(DeploymentProvenance(deployment_key=CLIP_LABEL)),
+        )
+        bundle.write_frame(
+            "telemetry/raw/depth/PAROSCI/messages",
+            pd.DataFrame(
+                {"timestamp": timestamps, "depth": [1.0, 2.0, 3.0, 4.0, 5.0]}
+            ),
+        )
+        bundle.write_frame(
+            "metocean/stormglass/wave_height",
+            pd.DataFrame(
+                {
+                    "timestamp": pd.to_datetime(
+                        ["2023-11-07T00:00:00Z", "2023-11-07T06:00:00Z"],
+                        utc=True,
+                    ),
+                    "wave_height": [1.5, 1.7],
+                }
+            ),
+        )
+        bundle.write_frame(
+            "platform/sensors/depth/calibration",
+            pd.DataFrame({"name": ["scale"], "value": [1.0]}),
+        )
+        bundle.write_frame(
+            "platform/sensors/depth/message_topics",
+            pd.DataFrame({"topic": ["PAROSCI"]}),
+        )
+    return path
+
+
+@pytest.fixture
+def clip_source_file(tmp_path: Path) -> Path:
+    return _clip_source_bundle(tmp_path / "full_grid.sqlite")
+
+
+def _clip_command(
+    input_file: Path,
+    output_file: Path,
+    *,
+    start: str = "2023-11-07T05:10:00Z",
+    end: str = "2023-11-07T05:40:00Z",
+    label_suffix: str = "dense01",
+    datetime_column: str = "timestamp",
+    no_clip_patterns: tuple[str, ...] = (),
+    overwrite: bool = False,
+) -> ClipDeploymentBundleCommand:
+    return ClipDeploymentBundleCommand(
+        input_file=input_file,
+        output_file=output_file,
+        start=datetime.fromisoformat(start),
+        end=datetime.fromisoformat(end),
+        label_suffix=label_suffix,
+        datetime_column=datetime_column,
+        no_clip_patterns=no_clip_patterns,
+        overwrite=overwrite,
+    )
+
+
+def test_clip_keeps_only_the_rows_inside_the_window(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """The window is closed: a row at `start` and a row at `end` are both in,
+    and the rows outside on either side are not."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    run_clip_deployment_bundle(_clip_command(clip_source_file, output_file))
+
+    with open_deployment_bundle_reader(output_file) as reader:
+        frame = reader.read_frame("telemetry/raw/depth/PAROSCI/messages")
+
+    assert frame["depth"].tolist() == [2.0, 3.0, 4.0]
+
+
+def test_clip_copies_frames_without_the_datetime_column(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """A frame with no time axis is copied whole, without the task needing to
+    know the key exists."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    result = run_clip_deployment_bundle(
+        _clip_command(clip_source_file, output_file)
+    )
+
+    with open_deployment_bundle_reader(clip_source_file) as reader:
+        expected = reader.read_frame("platform/sensors/depth/calibration")
+    with open_deployment_bundle_reader(output_file) as reader:
+        actual = reader.read_frame("platform/sensors/depth/calibration")
+
+    pd.testing.assert_frame_equal(actual, expected)
+    assert "platform/sensors/depth/calibration" in result.copied_keys
+    assert "platform/sensors/depth/message_topics" in result.copied_keys
+
+
+def test_clip_keeps_every_row_of_a_no_clip_frame(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """A metocean series carries `timestamp` but is sampled far coarser than
+    telemetry, so a dense-grid window would leave nothing to interpolate."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    result = run_clip_deployment_bundle(
+        _clip_command(
+            clip_source_file,
+            output_file,
+            no_clip_patterns=("metocean/*",),
+        )
+    )
+
+    with open_deployment_bundle_reader(output_file) as reader:
+        frame = reader.read_frame("metocean/stormglass/wave_height")
+
+    assert len(frame) == 2
+    assert "metocean/stormglass/wave_height" in result.copied_keys
+
+
+def test_clip_copies_a_frame_whose_time_column_is_named_otherwise(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """Rule 2 keys off the column, so naming another one leaves the telemetry
+    frame copied whole rather than clipped on a column it does not carry."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    result = run_clip_deployment_bundle(
+        _clip_command(
+            clip_source_file, output_file, datetime_column="acquired_at"
+        )
+    )
+
+    with open_deployment_bundle_reader(output_file) as reader:
+        frame = reader.read_frame("telemetry/raw/depth/PAROSCI/messages")
+
+    assert len(frame) == 5
+    assert result.clipped_keys == ()
+
+
+def test_clip_rewrites_the_deployment_identity(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """The clipped bundle is a new deployment and says so."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    result = run_clip_deployment_bundle(
+        _clip_command(clip_source_file, output_file)
+    )
+
+    assert result.deployment_label == f"{CLIP_LABEL}_dense01"
+    with open_deployment_bundle_reader(output_file) as reader:
+        identity = reader.read_frame("deployment/identity")
+
+    assert identity["deployment_label"].iloc[0] == f"{CLIP_LABEL}_dense01"
+    assert identity["deployment_start_datetime"].iloc[0] == pd.Timestamp(
+        "2023-11-07T05:10:00Z"
+    )
+    assert identity["deployment_end_datetime"].iloc[0] == pd.Timestamp(
+        "2023-11-07T05:40:00Z"
+    )
+
+
+def test_clip_records_its_source_and_window_in_provenance(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """A dense-grid bundle traces back to its full-grid parent without
+    external bookkeeping."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    run_clip_deployment_bundle(_clip_command(clip_source_file, output_file))
+
+    with open_deployment_bundle_reader(output_file) as reader:
+        provenance = reader.read_frame("deployment/provenance")
+
+    assert provenance["source_bundle"].iloc[0] == str(clip_source_file)
+    assert provenance["clip_start_datetime"].iloc[0] == pd.Timestamp(
+        "2023-11-07T05:10:00Z"
+    )
+    assert provenance["clip_end_datetime"].iloc[0] == pd.Timestamp(
+        "2023-11-07T05:40:00Z"
+    )
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".sqlite"])
+def test_clip_writes_an_empty_frame_when_the_window_matches_nothing(
+    tmp_path: Path, suffix: str
+) -> None:
+    """Every key in the source is present in the clip, so a consumer's
+    `has_frame` answers the same against both."""
+    clip_source_file = _clip_source_bundle(tmp_path / f"full_grid{suffix}")
+    output_file = tmp_path / f"dense_grid{suffix}"
+
+    result = run_clip_deployment_bundle(
+        _clip_command(
+            clip_source_file,
+            output_file,
+            start="2023-11-07T12:00:00Z",
+            end="2023-11-07T13:00:00Z",
+        )
+    )
+
+    key = "telemetry/raw/depth/PAROSCI/messages"
+    assert key in result.empty_keys
+    with open_deployment_bundle_reader(output_file) as reader:
+        assert reader.has_frame(key)
+        frame = reader.read_frame(key)
+
+    assert frame.empty
+    assert list(frame.columns) == ["timestamp", "depth"]
+
+
+def test_clip_leaves_the_source_bundle_unchanged(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """A clip cannot damage the bundle it reads."""
+    before = clip_source_file.read_bytes()
+
+    run_clip_deployment_bundle(
+        _clip_command(clip_source_file, tmp_path / "dense_grid.sqlite")
+    )
+
+    assert clip_source_file.read_bytes() == before
+
+
+def test_clip_repeats_the_row_on_a_shared_bound(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """Adjacent closed windows both keep the row on the bound they share, so
+    cutting a source into touching windows does not partition it."""
+    key = "telemetry/raw/depth/PAROSCI/messages"
+    first = tmp_path / "first.sqlite"
+    second = tmp_path / "second.sqlite"
+
+    run_clip_deployment_bundle(
+        _clip_command(
+            clip_source_file,
+            first,
+            start="2023-11-07T05:00:00Z",
+            end="2023-11-07T05:20:00Z",
+        )
+    )
+    run_clip_deployment_bundle(
+        _clip_command(
+            clip_source_file,
+            second,
+            start="2023-11-07T05:20:00Z",
+            end="2023-11-07T06:00:00Z",
+            label_suffix="dense02",
+        )
+    )
+
+    with open_deployment_bundle_reader(first) as reader:
+        first_depths = reader.read_frame(key)["depth"].tolist()
+    with open_deployment_bundle_reader(second) as reader:
+        second_depths = reader.read_frame(key)["depth"].tolist()
+
+    assert first_depths == [1.0, 2.0, 3.0]
+    assert second_depths == [3.0, 4.0, 5.0]
+    assert set(first_depths) & set(second_depths) == {3.0}
+
+
+def test_clip_rejects_a_start_not_before_its_end(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="must be before its end"):
+        run_clip_deployment_bundle(
+            _clip_command(
+                clip_source_file,
+                tmp_path / "dense_grid.sqlite",
+                start="2023-11-07T05:40:00Z",
+                end="2023-11-07T05:10:00Z",
+            )
+        )
+
+
+def test_clip_rejects_an_empty_label_suffix(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    with pytest.raises(ValueError, match="label suffix is empty"):
+        run_clip_deployment_bundle(
+            _clip_command(
+                clip_source_file,
+                tmp_path / "dense_grid.sqlite",
+                label_suffix="",
+            )
+        )
+
+
+def test_clip_rejects_an_existing_output_without_overwrite(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    output_file = tmp_path / "dense_grid.sqlite"
+    output_file.write_bytes(b"")
+
+    with pytest.raises(ValueError, match="already exists"):
+        run_clip_deployment_bundle(_clip_command(clip_source_file, output_file))
+
+
+def test_clip_rejects_writing_over_its_input(clip_source_file: Path) -> None:
+    with pytest.raises(ValueError, match="is the input bundle"):
+        run_clip_deployment_bundle(
+            _clip_command(clip_source_file, clip_source_file, overwrite=True)
+        )
+
+
+def test_clip_leaves_no_output_when_it_fails(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    """A clip that fails halfway leaves no bundle rather than a partial one."""
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    with pytest.raises(ValueError, match="not a datetime column"):
+        run_clip_deployment_bundle(
+            _clip_command(
+                clip_source_file, output_file, datetime_column="depth"
+            )
+        )
+
+    assert not output_file.exists()
+    assert list(tmp_path.glob("*.partial*")) == []
+
+
+@pytest.mark.parametrize("suffix", [".h5", ".sqlite"])
+def test_clip_round_trips_through_both_backends(
+    tmp_path: Path, suffix: str
+) -> None:
+    source_file = _clip_source_bundle(tmp_path / f"full_grid{suffix}")
+    output_file = tmp_path / f"dense_grid{suffix}"
+
+    run_clip_deployment_bundle(_clip_command(source_file, output_file))
+
+    with open_deployment_bundle_reader(output_file) as reader:
+        frame = reader.read_frame("telemetry/raw/depth/PAROSCI/messages")
+
+    assert frame["depth"].tolist() == [2.0, 3.0, 4.0]
+
+
+def test_cli_clips_a_deployment_bundle(
+    clip_source_file: Path, tmp_path: Path
+) -> None:
+    output_file = tmp_path / "dense_grid.sqlite"
+
+    result: Result = CliRunner().invoke(
+        cli,
+        [
+            "bundle",
+            "clip",
+            "--input",
+            str(clip_source_file),
+            "--output",
+            str(output_file),
+            "--start",
+            "2023-11-07T05:10:00",
+            "--end",
+            "2023-11-07T05:40:00",
+            "--label-suffix",
+            "dense01",
+            "--no-clip",
+            "metocean/*",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    with open_deployment_bundle_reader(output_file) as reader:
+        assert len(reader.read_frame("metocean/stormglass/wave_height")) == 2
+        assert (
+            len(reader.read_frame("telemetry/raw/depth/PAROSCI/messages")) == 3
+        )


### PR DESCRIPTION
## Summary

Adds `afft bundle clip`, which cuts a dense-grid deployment bundle from a full-grid one by clipping its tables to a temporal window.

The task lives in `afft.tasks.deployment_bundle_common` alongside ingest and export. It reads one bundle and writes another, following `process` rather than `ingest-frame`, and stages the output through a `.partial` file so a failed clip leaves no bundle behind.

Which frames get clipped is decided per key from the frame itself: a key matching `--no-clip` is copied whole, otherwise a frame carrying `--datetime-column` is clipped and everything else is copied. The frames with no time axis need no enumerating, and `metocean/*` is passed rather than hardcoded.

The clipped bundle is a new deployment. Its identity carries the source label plus `--label-suffix` and the window as its start and end -- the first producer of a non-null `deployment_end_datetime` -- and its provenance names the source bundle and the window.

Also adds `scripts/shell/bundle_batch_clip_desktop.sh`, carrying the seventeen dense-grid ranges from #266.

### Two things worth review

**The window is closed, `start <= t <= end`, not half-open as the issue specifies.** Changed on request after the issue was written. The consequence is that adjacent windows sharing a bound both keep the row on it, so cutting one deployment into touching windows duplicates that row rather than partitioning cleanly. That does not affect the single-segment clips in #266. The issue body still argues for half-open and needs updating.

**Empty frames were silently dropped on the HDF5 backend** (first commit, separate from the feature). `HDFStore.put(..., format="table")` writes no object at all for a row-less frame, but the `bundle_contents` row was still upserted -- so `has_frame` answered yes for a key `read_frame` then raised on. Clip is the first task to produce empty frames, which is what surfaced it. Row-less frames now go in as `"fixed"`, which stores them with dtypes intact and reads back through the same `select`. This touches the HDF5 write path for every task, not just clip.

### Notes

- `--start`/`--end` are parsed by a small `click.ParamType` over `datetime.fromisoformat`, since none of `click.DateTime`'s default formats carries a UTC offset. A naive bound is taken as UTC.
- A frame carrying `--datetime-column` on a non-temporal column raises rather than being copied whole; copying would silently keep rows outside the stated window.
- `DeploymentProvenance` gains three optional fields (`source_bundle`, `clip_start_datetime`, `clip_end_datetime`), all `None` for a bundle built from raw logs.
- Nothing writes `DeploymentBundleHeader` anywhere in `src/`, so the issue's `created_datetime` bullet had no producer to act on.

17 new tests; 427 pass, ruff and mypy clean.

Closes #265
