### PR TITLE
Ingest renav prior trajectories into deployment bundles

### DIFF
--- a/scripts/python/compare_camera_vehicle_poses.py
+++ b/scripts/python/compare_camera_vehicle_poses.py
@@ -27,7 +27,7 @@ from pyproj import CRS
 
 
 _CAMERA_SUFFIX: str = "_renav_stereo_poses.csv"
-_VEHICLE_SUFFIX: str = "_vehicle_poses.csv"
+_VEHICLE_SUFFIX: str = "_platform_poses.csv"
 
 _CAMERA_COLOR: str = "#1f77b4"
 _VEHICLE_COLOR: str = "#ff7f0e"

--- a/scripts/shell/bundle_batch_workflow_desktop.sh
+++ b/scripts/shell/bundle_batch_workflow_desktop.sh
@@ -12,10 +12,14 @@ CONFIG_FILE="${REPO_ROOT}/config/default.toml"
 
 DEPLOYMENT_DATA_DIR="/data/exos_01/acfr_deployments_v1_subset_fixed"
 SEALEVEL_DATA_DIR="/data/exos_01/metocean_sea_level_hourly"
+RENAV_PRIOR_TRAJECTORY_DATA_DIR="/data/exos_01/acfr_sirius_poses_v1_renav_priors"
 OUTPUT_DIR="/data/exos_01/acfr_deployment_bundles_v1_subset"
 
 SEALEVEL_KEY="metocean/worldtides/sealevel"
-SEALEVEL_DATETIME_COLUMN="datetime"
+SEALEVEL_DATETIME_COLUMN="timestamp"
+
+RENAV_PRIOR_TRAJECTORY_KEY="trajectory/renav_prior/platform_poses"
+RENAV_PRIOR_TRAJECTORY_DATETIME_COLUMN="timestamp"
 
 # Sea level file per deployment. The series are per site rather than per
 # deployment, so the deployments sharing a site share a file.
@@ -39,6 +43,27 @@ declare -A SEALEVEL_FILES=(
   ["r7jjskxq_20131022_004934"]="r7jjskxq_20090101_20211231_sea_level.csv"
 )
 
+# Renav prior trajectory file per deployment.
+declare -A RENAV_PRIOR_TRAJECTORY_FILES=(
+  ["qdch0ftq_20100428_020202"]="qdch0ftq_20100428_020202_platform_poses.csv"
+  ["qdch0ftq_20110415_020103"]="qdch0ftq_20110415_020103_platform_poses.csv"
+  ["qdch0ftq_20120430_002423"]="qdch0ftq_20120430_002423_platform_poses.csv"
+  ["qdch0ftq_20130406_023610"]="qdch0ftq_20130406_023610_platform_poses.csv"
+  ["qdchdmy1_20110416_005411"]="qdchdmy1_20110416_005411_platform_poses.csv"
+  ["qdchdmy1_20120501_071203"]="qdchdmy1_20120501_071203_platform_poses.csv"
+  ["qdchdmy1_20130406_081713"]="qdchdmy1_20130406_081713_platform_poses.csv"
+  ["qdchdmy1_20170525_234624"]="qdchdmy1_20170525_234624_platform_poses.csv"
+  ["r23685bc_20100605_021022"]="r23685bc_20100605_021022_platform_poses.csv"
+  ["r23685bc_20120530_233021"]="r23685bc_20120530_233021_platform_poses.csv"
+  ["r23685bc_20140616_225022"]="r23685bc_20140616_225022_platform_poses.csv"
+  ["r29mrd5h_20090612_225306"]="r29mrd5h_20090612_225306_platform_poses.csv"
+  ["r29mrd5h_20110612_033752"]="r29mrd5h_20110612_033752_platform_poses.csv"
+  ["r29mrd5h_20130611_002419"]="r29mrd5h_20130611_002419_platform_poses.csv"
+  ["r7jjskxq_20101023_210332"]="r7jjskxq_20101023_210332_platform_poses.csv"
+  ["r7jjskxq_20121013_060425"]="r7jjskxq_20121013_060425_platform_poses.csv"
+  ["r7jjskxq_20131022_004934"]="r7jjskxq_20131022_004934_platform_poses.csv"
+)
+
 # Building overwrites the bundle, so the sea level ingestion has to follow the
 # build of the same deployment rather than run as a second pass over all of
 # them -- a rebuild would otherwise discard a frame ingested earlier.
@@ -48,6 +73,7 @@ declare -A SEALEVEL_FILES=(
 for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
   bundle_file="${OUTPUT_DIR}/${deployment}_deployment_bundle.sqlite"
   sealevel_file="${SEALEVEL_DATA_DIR}/${SEALEVEL_FILES[${deployment}]}"
+  renav_prior_trajectory_file="${RENAV_PRIOR_TRAJECTORY_DATA_DIR}/${RENAV_PRIOR_TRAJECTORY_FILES[${deployment}]}"
 
   uv run afft bundle build \
     --descriptor-file "${DESCRIPTOR_FILE}" \
@@ -62,5 +88,12 @@ for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
     --key "${SEALEVEL_KEY}" \
     --file "${sealevel_file}" \
     --datetime-column "${SEALEVEL_DATETIME_COLUMN}" \
+    --overwrite
+
+  uv run afft bundle ingest-frame \
+    --bundle "${bundle_file}" \
+    --key "${RENAV_PRIOR_TRAJECTORY_KEY}" \
+    --file "${renav_prior_trajectory_file}" \
+    --datetime-column "${RENAV_PRIOR_TRAJECTORY_DATETIME_COLUMN}" \
     --overwrite
 done

--- a/scripts/shell/bundle_batch_workflow_laptop.sh
+++ b/scripts/shell/bundle_batch_workflow_laptop.sh
@@ -12,10 +12,14 @@ CONFIG_FILE="${REPO_ROOT}/config/default.toml"
 
 DEPLOYMENT_DATA_DIR="${HOME}/data/acfr_deployments_v1_subset_fixed"
 SEALEVEL_DATA_DIR="${HOME}/data/metocean_sea_level_hourly"
+RENAV_PRIOR_TRAJECTORY_DATA_DIR="${HOME}/data/acfr_sirius_poses_v1_renav_priors"
 OUTPUT_DIR="${HOME}/data/acfr_deployment_bundles_v1_subset"
 
 SEALEVEL_KEY="metocean/worldtides/sealevel"
-SEALEVEL_DATETIME_COLUMN="datetime"
+SEALEVEL_DATETIME_COLUMN="timestamp"
+
+RENAV_PRIOR_TRAJECTORY_KEY="trajectory/renav_prior/platform_poses"
+RENAV_PRIOR_TRAJECTORY_DATETIME_COLUMN="timestamp"
 
 # Sea level file per deployment. The series are per site rather than per
 # deployment, so the deployments sharing a site share a file.
@@ -39,6 +43,27 @@ declare -A SEALEVEL_FILES=(
   ["r7jjskxq_20131022_004934"]="r7jjskxq_20090101_20211231_sea_level.csv"
 )
 
+# Renav prior trajectory file per deployment.
+declare -A RENAV_PRIOR_TRAJECTORY_FILES=(
+  ["qdch0ftq_20100428_020202"]="qdch0ftq_20100428_020202_platform_poses.csv"
+  ["qdch0ftq_20110415_020103"]="qdch0ftq_20110415_020103_platform_poses.csv"
+  ["qdch0ftq_20120430_002423"]="qdch0ftq_20120430_002423_platform_poses.csv"
+  ["qdch0ftq_20130406_023610"]="qdch0ftq_20130406_023610_platform_poses.csv"
+  ["qdchdmy1_20110416_005411"]="qdchdmy1_20110416_005411_platform_poses.csv"
+  ["qdchdmy1_20120501_071203"]="qdchdmy1_20120501_071203_platform_poses.csv"
+  ["qdchdmy1_20130406_081713"]="qdchdmy1_20130406_081713_platform_poses.csv"
+  ["qdchdmy1_20170525_234624"]="qdchdmy1_20170525_234624_platform_poses.csv"
+  ["r23685bc_20100605_021022"]="r23685bc_20100605_021022_platform_poses.csv"
+  ["r23685bc_20120530_233021"]="r23685bc_20120530_233021_platform_poses.csv"
+  ["r23685bc_20140616_225022"]="r23685bc_20140616_225022_platform_poses.csv"
+  ["r29mrd5h_20090612_225306"]="r29mrd5h_20090612_225306_platform_poses.csv"
+  ["r29mrd5h_20110612_033752"]="r29mrd5h_20110612_033752_platform_poses.csv"
+  ["r29mrd5h_20130611_002419"]="r29mrd5h_20130611_002419_platform_poses.csv"
+  ["r7jjskxq_20101023_210332"]="r7jjskxq_20101023_210332_platform_poses.csv"
+  ["r7jjskxq_20121013_060425"]="r7jjskxq_20121013_060425_platform_poses.csv"
+  ["r7jjskxq_20131022_004934"]="r7jjskxq_20131022_004934_platform_poses.csv"
+)
+
 # Building overwrites the bundle, so the sea level ingestion has to follow the
 # build of the same deployment rather than run as a second pass over all of
 # them -- a rebuild would otherwise discard a frame ingested earlier.
@@ -48,6 +73,7 @@ declare -A SEALEVEL_FILES=(
 for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
   bundle_file="${OUTPUT_DIR}/${deployment}_deployment_bundle.sqlite"
   sealevel_file="${SEALEVEL_DATA_DIR}/${SEALEVEL_FILES[${deployment}]}"
+  renav_prior_trajectory_file="${RENAV_PRIOR_TRAJECTORY_DATA_DIR}/${RENAV_PRIOR_TRAJECTORY_FILES[${deployment}]}"
 
   uv run afft bundle build \
     --descriptor-file "${DESCRIPTOR_FILE}" \
@@ -62,5 +88,12 @@ for deployment in $(printf "%s\n" "${!SEALEVEL_FILES[@]}" | sort); do
     --key "${SEALEVEL_KEY}" \
     --file "${sealevel_file}" \
     --datetime-column "${SEALEVEL_DATETIME_COLUMN}" \
+    --overwrite
+
+  uv run afft bundle ingest-frame \
+    --bundle "${bundle_file}" \
+    --key "${RENAV_PRIOR_TRAJECTORY_KEY}" \
+    --file "${renav_prior_trajectory_file}" \
+    --datetime-column "${RENAV_PRIOR_TRAJECTORY_DATETIME_COLUMN}" \
     --overwrite
 done

--- a/src/afft/cli/renav/actions.py
+++ b/src/afft/cli/renav/actions.py
@@ -133,7 +133,7 @@ def invoke_transform_camera_poses_batch(
     output_dir: str | Path,
     descriptor_file: str | Path,
     input_suffix: str = "_renav_stereo_poses.csv",
-    output_suffix: str = "_vehicle_poses.csv",
+    output_suffix: str = "_platform_poses.csv",
 ) -> None:
     """Batch-transform camera poses to vehicle reference-point poses."""
     extrinsics: dict[str, CameraVehicleExtrinsics] = (

--- a/src/afft/cli/renav/commands.py
+++ b/src/afft/cli/renav/commands.py
@@ -228,7 +228,7 @@ def transform_poses(
     "--output-suffix",
     "output_suffix",
     type=str,
-    default="_vehicle_poses.csv",
+    default="_platform_poses.csv",
     show_default=True,
     help="suffix appended to the deployment label to form the output filename",
 )

--- a/src/afft/sensors/pressure_parosci/types.py
+++ b/src/afft/sensors/pressure_parosci/types.py
@@ -17,5 +17,5 @@ class SeaLevelCorrectionConfig(BaseModel):
     depth_col: str = "depth"
     timestamp_col: str = "timestamp"
     sea_level_col: str = "sea_level"
-    sea_level_timestamp_col: str = "datetime"
+    sea_level_timestamp_col: str = "timestamp"
     max_gap_seconds: float = 3600.0

--- a/src/afft/tasks/transform_camera_poses/types.py
+++ b/src/afft/tasks/transform_camera_poses/types.py
@@ -80,13 +80,13 @@ class TransformCameraPosesBatchCommand:
     input_suffix: Suffix stripped from input filenames to derive the
         deployment label (e.g. ``"_renav_stereo_poses.csv"``).
     output_suffix: Suffix appended to the deployment label to form the
-        output filename (e.g. ``"_vehicle_poses.csv"``).
+        output filename (e.g. ``"_platform_poses.csv"``).
     """
 
     input_dir: Path
     output_dir: Path
     input_suffix: str = "_renav_stereo_poses.csv"
-    output_suffix: str = "_vehicle_poses.csv"
+    output_suffix: str = "_platform_poses.csv"
 
 
 @dataclass(slots=True, frozen=True)

--- a/tests/telemetry_processing/test_pressure_parosci.py
+++ b/tests/telemetry_processing/test_pressure_parosci.py
@@ -36,7 +36,7 @@ def _sea_level_frame(
     """A tide frame typed as the WorldTides ingestion stores it."""
     return pd.DataFrame(
         {
-            "datetime": pd.to_datetime(timestamps, utc=True),
+            "timestamp": pd.to_datetime(timestamps, utc=True),
             "sea_level": levels,
         }
     )

--- a/tests/test_bundle_processing_sensor_processors.py
+++ b/tests/test_bundle_processing_sensor_processors.py
@@ -159,7 +159,7 @@ def test_sea_level_step_maps_its_two_inputs() -> None:
         ),
         "sea_level": pd.DataFrame(
             {
-                "datetime": pd.to_datetime(["2010-04-28T00:00:00Z"], utc=True),
+                "timestamp": pd.to_datetime(["2010-04-28T00:00:00Z"], utc=True),
                 "sea_level": [0.5],
             }
         ),

--- a/tests/test_transform_camera_poses.py
+++ b/tests/test_transform_camera_poses.py
@@ -429,11 +429,11 @@ def test_batch_applies_extrinsics_per_deployment(tmp_path: Path) -> None:
 
     first_north, _ = _displacement(
         pd.read_csv(input_dir / "first_renav_stereo_poses.csv"),
-        pd.read_csv(output_dir / "first_vehicle_poses.csv"),
+        pd.read_csv(output_dir / "first_platform_poses.csv"),
     )
     second_north, _ = _displacement(
         pd.read_csv(input_dir / "second_renav_stereo_poses.csv"),
-        pd.read_csv(output_dir / "second_vehicle_poses.csv"),
+        pd.read_csv(output_dir / "second_platform_poses.csv"),
     )
     assert first_north == pytest.approx(-10.0, abs=1e-6)
     assert second_north == pytest.approx(-20.0, abs=1e-6)
@@ -596,6 +596,6 @@ def test_cli_batch_transform_poses_uses_descriptor_extrinsics(
     assert result.exit_code == 0, result.output
     north, _ = _displacement(
         pd.read_csv(input_dir / "first_renav_stereo_poses.csv"),
-        pd.read_csv(output_dir / "first_vehicle_poses.csv"),
+        pd.read_csv(output_dir / "first_platform_poses.csv"),
     )
     assert north == pytest.approx(-10.0, abs=1e-6)


### PR DESCRIPTION
## Summary
- Add `RENAV_PRIOR_TRAJECTORY_FILES` and a second `ingest-frame` step to both `bundle_batch_workflow_desktop.sh` and `bundle_batch_workflow_laptop.sh`, ingesting the renav prior trajectory in place at `trajectory/renav_prior/platform_poses`, alongside the existing sealevel frame ingestion.
- Rename `*_vehicle_poses.csv` to `*_platform_poses.csv` throughout (data files and code references) for consistency with the `platform` terminology used elsewhere for the robot.
- Standardize the sealevel frame's datetime column to `timestamp` (was `datetime`), matching the convention used by every other frame with time information; updates `SeaLevelCorrectionConfig.sea_level_timestamp_col`'s default and affected test fixtures accordingly.

## Test plan
- [x] `uv run pytest` (427 passed)