### PR TITLE
Add generic apply_sensor_extrinsics bundle pipeline processor

### DIFF
--- a/src/afft/bundle_processing/__init__.py
+++ b/src/afft/bundle_processing/__init__.py
@@ -23,10 +23,15 @@ from .pipeline_runners import (
 # Imported for their registration side effects: a processor in an unimported
 # module is silently absent from the registry rather than an error.
 from . import common_processors as common_processors
+from . import pose_processors as pose_processors
 from . import sensor_processors as sensor_processors
 
 from .common_processors import (
     DropColumnsConfig as DropColumnsConfig,
     RenameColumnsConfig as RenameColumnsConfig,
     SelectColumnsConfig as SelectColumnsConfig,
+)
+from .pose_processors import (
+    ApplySensorExtrinsicsConfig as ApplySensorExtrinsicsConfig,
+    apply_sensor_extrinsics as apply_sensor_extrinsics,
 )

--- a/src/afft/bundle_processing/pose_processors.py
+++ b/src/afft/bundle_processing/pose_processors.py
@@ -1,0 +1,194 @@
+"""Generic geometric transforms over geodetic pose frames, as distinct from
+`sensor_processors`, which holds sensor-family-specific processing."""
+
+from collections.abc import Mapping
+from typing import TypeVar
+
+import numpy as np
+import pandas as pd
+import pymap3d
+from numpy.typing import NDArray
+from scipy.spatial.transform import Rotation
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from afft.deployment import SensorExtrinsics
+
+from .processor_registry import register_processor
+
+Model = TypeVar("Model", bound=BaseModel)
+
+
+class ApplySensorExtrinsicsConfig(BaseModel):
+    """
+    Column configuration for the apply sensor extrinsics pipeline step.
+
+    Attributes
+    ----------
+    latitude_column: Latitude column in the pose frame.
+    longitude_column: Longitude column in the pose frame.
+    height_column: Height column in the pose frame, in metres, positive up.
+    heading_column: Heading column in degrees, clockwise from North.
+    pitch_column: Pitch column in degrees.
+    roll_column: Roll column in degrees.
+    invert: Apply the extrinsics in the reverse direction (platform -> sensor
+        rather than sensor -> platform).
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    latitude_column: str = "latitude"
+    longitude_column: str = "longitude"
+    height_column: str = "height"
+    heading_column: str = "heading"
+    pitch_column: str = "pitch"
+    roll_column: str = "roll"
+    invert: bool = False
+
+
+def _decode_single_row(
+    frame: pd.DataFrame,
+    model_type: type[Model],
+    processor_key: str,
+) -> Model:
+    """
+    Decode a one-row frame into `model_type`.
+
+    Unlike `sensor_processors._decode_extrinsics`, absence is not a valid
+    outcome here: `apply_sensor_extrinsics` has no uncorrected mode, so a
+    missing or malformed extrinsics frame is always an error.
+
+    Arguments
+    ---------
+    frame: The one-row frame to decode.
+    model_type: The model the frame's single row must match.
+    processor_key: Registered processor name, for the error messages.
+
+    Returns
+    -------
+    The decoded model.
+
+    Raises
+    ------
+    ValueError: If the frame does not hold exactly one row, or its columns do
+        not match `model_type`.
+    """
+    if len(frame) != 1:
+        raise ValueError(
+            f"{processor_key}: frame holds {len(frame)} rows, expected"
+            f" exactly 1"
+        )
+
+    expected: set[str] = set(model_type.model_fields)
+    if set(frame.columns) != expected:
+        raise ValueError(
+            f"{processor_key}: frame does not match {model_type.__name__}:"
+            f" columns are {sorted(frame.columns)}, expected"
+            f" {sorted(expected)}"
+        )
+
+    try:
+        return model_type(**frame.iloc[0].to_dict())
+    except ValidationError as error:
+        raise ValueError(
+            f"{processor_key}: frame does not match {model_type.__name__}:"
+            f" {error}"
+        ) from error
+
+
+def apply_sensor_extrinsics(
+    poses: pd.DataFrame,
+    extrinsics: SensorExtrinsics,
+    config: ApplySensorExtrinsicsConfig,
+) -> pd.DataFrame:
+    """
+    Apply a sensor's body-frame extrinsics to shift a geodetic pose frame by
+    the full 3D lever arm.
+
+    Reads latitude, longitude, height, and attitude from `poses`, offsets the
+    position by the extrinsics translation rotated into the local NED frame
+    by the pose's attitude, and writes the shifted latitude, longitude, and
+    height back. All other columns are passed through unchanged.
+
+    Arguments
+    ---------
+    poses: Pose frame in the sensor's reference frame (or the body's
+        reference frame, when `config.invert` is set).
+    extrinsics: The sensor's mounting pose in the body frame.
+    config: Column configuration and transform direction.
+
+    Returns
+    -------
+    Pose frame shifted to the body reference frame (or the reverse, when
+    `config.invert` is set).
+    """
+    headings: NDArray[np.float64] = poses[config.heading_column].to_numpy(
+        dtype=np.float64
+    )
+    pitches: NDArray[np.float64] = poses[config.pitch_column].to_numpy(
+        dtype=np.float64
+    )
+    rolls: NDArray[np.float64] = poses[config.roll_column].to_numpy(
+        dtype=np.float64
+    )
+
+    rotation: Rotation = Rotation.from_euler(
+        "ZYX",
+        np.column_stack([headings, pitches, rolls]),
+        degrees=True,
+    )
+
+    # Extrinsics translation is in the body frame (SNAME: x=forward,
+    # y=starboard, z=down), which is aligned with NED, so no sign conversion
+    # is needed beyond the translation direction itself.
+    sensor_in_body: NDArray[np.float64] = np.array(
+        [extrinsics.locx, extrinsics.locy, extrinsics.locz],
+        dtype=np.float64,
+    )
+    offset: NDArray[np.float64] = (
+        sensor_in_body if config.invert else -sensor_in_body
+    )
+    delta_ned: NDArray[np.float64] = rotation.apply(offset)
+
+    source_latitude: NDArray[np.float64] = poses[
+        config.latitude_column
+    ].to_numpy(dtype=np.float64)
+    source_longitude: NDArray[np.float64] = poses[
+        config.longitude_column
+    ].to_numpy(dtype=np.float64)
+    source_height: NDArray[np.float64] = poses[config.height_column].to_numpy(
+        dtype=np.float64
+    )
+
+    target_latitude: NDArray[np.float64]
+    target_longitude: NDArray[np.float64]
+    target_up: NDArray[np.float64]
+    target_latitude, target_longitude, target_up = pymap3d.ned2geodetic(
+        delta_ned[:, 0],
+        delta_ned[:, 1],
+        delta_ned[:, 2],
+        source_latitude,
+        source_longitude,
+        source_height,
+    )
+
+    shifted: pd.DataFrame = poses.copy()
+    shifted[config.latitude_column] = target_latitude
+    shifted[config.longitude_column] = target_longitude
+    shifted[config.height_column] = target_up
+    return shifted
+
+
+@register_processor(
+    "apply_sensor_extrinsics", config_type=ApplySensorExtrinsicsConfig
+)
+def step_apply_sensor_extrinsics(
+    frames: Mapping[str, pd.DataFrame],
+    config: ApplySensorExtrinsicsConfig,
+) -> pd.DataFrame:
+    """Apply a sensor's body-frame extrinsics to shift a geodetic pose frame
+    by the full 3D lever arm, in either direction."""
+    extrinsics: SensorExtrinsics = _decode_single_row(
+        frames["extrinsics"], SensorExtrinsics, "apply_sensor_extrinsics"
+    )
+    return apply_sensor_extrinsics(frames["poses"], extrinsics, config)

--- a/tests/test_bundle_processing_pose_processors.py
+++ b/tests/test_bundle_processing_pose_processors.py
@@ -1,0 +1,161 @@
+"""Tests for the generic pose-frame extrinsics processor."""
+
+import pandas as pd
+import pymap3d
+import pytest
+
+from afft.bundle_processing import default_registry
+from afft.bundle_processing.pose_processors import (
+    ApplySensorExtrinsicsConfig,
+    apply_sensor_extrinsics,
+    step_apply_sensor_extrinsics,
+)
+from afft.deployment import SensorExtrinsics
+
+_ORIGIN_LATITUDE: float = -32.035152
+_ORIGIN_LONGITUDE: float = 115.459240
+_ORIGIN_HEIGHT: float = 10.0
+
+
+def _pose_frame(heading: float = 0.0) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "latitude": [_ORIGIN_LATITUDE],
+            "longitude": [_ORIGIN_LONGITUDE],
+            "height": [_ORIGIN_HEIGHT],
+            "heading": [heading],
+            "pitch": [0.0],
+            "roll": [0.0],
+            "label": ["pose-0"],
+        }
+    )
+
+
+def _extrinsics(
+    locx: float = 0.0,
+    locy: float = 0.0,
+    locz: float = 0.0,
+) -> SensorExtrinsics:
+    return SensorExtrinsics(
+        locx=locx, locy=locy, locz=locz, rotx=0.0, roty=0.0, rotz=0.0
+    )
+
+
+def _extrinsics_frame(extrinsics: SensorExtrinsics) -> pd.DataFrame:
+    return pd.DataFrame([extrinsics.model_dump()])
+
+
+def _displacement(
+    source: pd.DataFrame, target: pd.DataFrame
+) -> tuple[float, float]:
+    """North and east displacement from `source` to `target`, in metres."""
+    north: float
+    east: float
+    north, east, _ = pymap3d.geodetic2ned(
+        target["latitude"].iloc[0],
+        target["longitude"].iloc[0],
+        0.0,
+        source["latitude"].iloc[0],
+        source["longitude"].iloc[0],
+        0.0,
+    )
+    return float(north), float(east)
+
+
+def test_apply_sensor_extrinsics_shifts_horizontally() -> None:
+    poses: pd.DataFrame = _pose_frame(heading=0.0)
+    extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5)
+
+    shifted: pd.DataFrame = apply_sensor_extrinsics(
+        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    )
+
+    north, east = _displacement(poses, shifted)
+    assert north == pytest.approx(-1.0, abs=1e-3)
+    assert east == pytest.approx(-0.5, abs=1e-3)
+
+
+def test_apply_sensor_extrinsics_shifts_vertically() -> None:
+    poses: pd.DataFrame = _pose_frame()
+    extrinsics: SensorExtrinsics = _extrinsics(locz=2.0)
+
+    shifted: pd.DataFrame = apply_sensor_extrinsics(
+        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    )
+
+    assert shifted["height"].iloc[0] == pytest.approx(
+        _ORIGIN_HEIGHT + 2.0, abs=1e-6
+    )
+
+
+def test_apply_sensor_extrinsics_passes_other_columns_through() -> None:
+    poses: pd.DataFrame = _pose_frame()
+    extrinsics: SensorExtrinsics = _extrinsics(locx=1.0)
+
+    shifted: pd.DataFrame = apply_sensor_extrinsics(
+        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    )
+
+    assert shifted["label"].iloc[0] == "pose-0"
+
+
+def test_apply_sensor_extrinsics_invert_reverses_the_shift() -> None:
+    poses: pd.DataFrame = _pose_frame()
+    extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5, locz=2.0)
+
+    forward: pd.DataFrame = apply_sensor_extrinsics(
+        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    )
+    round_tripped: pd.DataFrame = apply_sensor_extrinsics(
+        forward, extrinsics, ApplySensorExtrinsicsConfig(invert=True)
+    )
+
+    assert round_tripped["latitude"].iloc[0] == pytest.approx(
+        poses["latitude"].iloc[0], abs=1e-9
+    )
+    assert round_tripped["longitude"].iloc[0] == pytest.approx(
+        poses["longitude"].iloc[0], abs=1e-9
+    )
+    assert round_tripped["height"].iloc[0] == pytest.approx(
+        poses["height"].iloc[0], abs=1e-6
+    )
+
+
+def test_step_apply_sensor_extrinsics_requires_extrinsics_input() -> None:
+    frames = {"poses": _pose_frame()}
+
+    with pytest.raises(KeyError):
+        step_apply_sensor_extrinsics(frames, ApplySensorExtrinsicsConfig())
+
+
+def test_step_apply_sensor_extrinsics_rejects_multi_row_extrinsics() -> None:
+    extrinsics_frame: pd.DataFrame = pd.concat(
+        [_extrinsics_frame(_extrinsics(locx=1.0))] * 2, ignore_index=True
+    )
+    frames = {"poses": _pose_frame(), "extrinsics": extrinsics_frame}
+
+    with pytest.raises(ValueError, match="expected exactly 1"):
+        step_apply_sensor_extrinsics(frames, ApplySensorExtrinsicsConfig())
+
+
+def test_step_apply_sensor_extrinsics_matches_direct_call() -> None:
+    extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5, locz=2.0)
+    frames = {
+        "poses": _pose_frame(),
+        "extrinsics": _extrinsics_frame(extrinsics),
+    }
+
+    from_step: pd.DataFrame = step_apply_sensor_extrinsics(
+        frames, ApplySensorExtrinsicsConfig()
+    )
+    direct: pd.DataFrame = apply_sensor_extrinsics(
+        frames["poses"], extrinsics, ApplySensorExtrinsicsConfig()
+    )
+
+    pd.testing.assert_frame_equal(from_step, direct)
+
+
+def test_apply_sensor_extrinsics_is_registered() -> None:
+    registered = default_registry().get("apply_sensor_extrinsics")
+    assert registered.processor is step_apply_sensor_extrinsics
+    assert registered.config_type is ApplySensorExtrinsicsConfig

--- a/tests/test_bundle_processing_processor_registry.py
+++ b/tests/test_bundle_processing_processor_registry.py
@@ -82,6 +82,7 @@ def test_a_local_registry_does_not_leak_into_the_default_one() -> None:
 def test_default_registry_holds_every_shipped_processor() -> None:
     """Importing the package registers all processors it defines."""
     assert default_registry().names() == [
+        "apply_sensor_extrinsics",
         "correct_pressure_for_sea_level",
         "drop_columns",
         "estimate_dvl_uncertainty",


### PR DESCRIPTION
## Summary
- Adds `apply_sensor_extrinsics`, a standalone pipeline processor in a new `pose_processors.py` module, applying a sensor's body-frame extrinsics to shift a geodetic pose frame by the full 3D lever arm (horizontal + vertical, plus an `invert` direction), read from an explicit `extrinsics` bundle-key input.
- Missing/malformed extrinsics is a hard failure; deployments without a usable extrinsics frame are skipped via the pipeline's existing `optional: true` step mechanism rather than a passthrough mode.
- Registers the processor with the shared registry and updates the registry manifest test.

## Test plan
- [x] `uv run pytest` (435 passed)
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy src`

Closes #271