### PR TITLE
Rename apply_sensor_extrinsics to apply_mounting_offset

### DIFF
--- a/src/afft/bundle_processing/__init__.py
+++ b/src/afft/bundle_processing/__init__.py
@@ -32,6 +32,6 @@ from .common_processors import (
     SelectColumnsConfig as SelectColumnsConfig,
 )
 from .pose_processors import (
-    ApplySensorExtrinsicsConfig as ApplySensorExtrinsicsConfig,
-    apply_sensor_extrinsics as apply_sensor_extrinsics,
+    ApplyMountingOffsetConfig as ApplyMountingOffsetConfig,
+    apply_mounting_offset as apply_mounting_offset,
 )

--- a/src/afft/bundle_processing/pose_processors.py
+++ b/src/afft/bundle_processing/pose_processors.py
@@ -19,9 +19,9 @@ from .processor_registry import register_processor
 Model = TypeVar("Model", bound=BaseModel)
 
 
-class ApplySensorExtrinsicsConfig(BaseModel):
+class ApplyMountingOffsetConfig(BaseModel):
     """
-    Column configuration for the apply sensor extrinsics pipeline step.
+    Column configuration for the apply mounting offset pipeline step.
 
     Attributes
     ----------
@@ -55,7 +55,7 @@ def _decode_single_row(
     Decode a one-row frame into `model_type`.
 
     Unlike `sensor_processors._decode_extrinsics`, absence is not a valid
-    outcome here: `apply_sensor_extrinsics` has no uncorrected mode, so a
+    outcome here: `apply_mounting_offset` has no uncorrected mode, so a
     missing or malformed extrinsics frame is always an error.
 
     Arguments
@@ -96,10 +96,10 @@ def _decode_single_row(
         ) from error
 
 
-def apply_sensor_extrinsics(
+def apply_mounting_offset(
     poses: pd.DataFrame,
     extrinsics: SensorExtrinsics,
-    config: ApplySensorExtrinsicsConfig,
+    config: ApplyMountingOffsetConfig,
 ) -> pd.DataFrame:
     """
     Apply a sensor's body-frame extrinsics to shift a geodetic pose frame by
@@ -180,15 +180,15 @@ def apply_sensor_extrinsics(
 
 
 @register_processor(
-    "apply_sensor_extrinsics", config_type=ApplySensorExtrinsicsConfig
+    "apply_mounting_offset", config_type=ApplyMountingOffsetConfig
 )
-def step_apply_sensor_extrinsics(
+def step_apply_mounting_offset(
     frames: Mapping[str, pd.DataFrame],
-    config: ApplySensorExtrinsicsConfig,
+    config: ApplyMountingOffsetConfig,
 ) -> pd.DataFrame:
     """Apply a sensor's body-frame extrinsics to shift a geodetic pose frame
     by the full 3D lever arm, in either direction."""
     extrinsics: SensorExtrinsics = _decode_single_row(
-        frames["extrinsics"], SensorExtrinsics, "apply_sensor_extrinsics"
+        frames["extrinsics"], SensorExtrinsics, "apply_mounting_offset"
     )
-    return apply_sensor_extrinsics(frames["poses"], extrinsics, config)
+    return apply_mounting_offset(frames["poses"], extrinsics, config)

--- a/tests/test_bundle_processing_pose_processors.py
+++ b/tests/test_bundle_processing_pose_processors.py
@@ -6,9 +6,9 @@ import pytest
 
 from afft.bundle_processing import default_registry
 from afft.bundle_processing.pose_processors import (
-    ApplySensorExtrinsicsConfig,
-    apply_sensor_extrinsics,
-    step_apply_sensor_extrinsics,
+    ApplyMountingOffsetConfig,
+    apply_mounting_offset,
+    step_apply_mounting_offset,
 )
 from afft.deployment import SensorExtrinsics
 
@@ -62,12 +62,12 @@ def _displacement(
     return float(north), float(east)
 
 
-def test_apply_sensor_extrinsics_shifts_horizontally() -> None:
+def test_apply_mounting_offset_shifts_horizontally() -> None:
     poses: pd.DataFrame = _pose_frame(heading=0.0)
     extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5)
 
-    shifted: pd.DataFrame = apply_sensor_extrinsics(
-        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    shifted: pd.DataFrame = apply_mounting_offset(
+        poses, extrinsics, ApplyMountingOffsetConfig()
     )
 
     north, east = _displacement(poses, shifted)
@@ -75,12 +75,12 @@ def test_apply_sensor_extrinsics_shifts_horizontally() -> None:
     assert east == pytest.approx(-0.5, abs=1e-3)
 
 
-def test_apply_sensor_extrinsics_shifts_vertically() -> None:
+def test_apply_mounting_offset_shifts_vertically() -> None:
     poses: pd.DataFrame = _pose_frame()
     extrinsics: SensorExtrinsics = _extrinsics(locz=2.0)
 
-    shifted: pd.DataFrame = apply_sensor_extrinsics(
-        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    shifted: pd.DataFrame = apply_mounting_offset(
+        poses, extrinsics, ApplyMountingOffsetConfig()
     )
 
     assert shifted["height"].iloc[0] == pytest.approx(
@@ -88,26 +88,26 @@ def test_apply_sensor_extrinsics_shifts_vertically() -> None:
     )
 
 
-def test_apply_sensor_extrinsics_passes_other_columns_through() -> None:
+def test_apply_mounting_offset_passes_other_columns_through() -> None:
     poses: pd.DataFrame = _pose_frame()
     extrinsics: SensorExtrinsics = _extrinsics(locx=1.0)
 
-    shifted: pd.DataFrame = apply_sensor_extrinsics(
-        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    shifted: pd.DataFrame = apply_mounting_offset(
+        poses, extrinsics, ApplyMountingOffsetConfig()
     )
 
     assert shifted["label"].iloc[0] == "pose-0"
 
 
-def test_apply_sensor_extrinsics_invert_reverses_the_shift() -> None:
+def test_apply_mounting_offset_invert_reverses_the_shift() -> None:
     poses: pd.DataFrame = _pose_frame()
     extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5, locz=2.0)
 
-    forward: pd.DataFrame = apply_sensor_extrinsics(
-        poses, extrinsics, ApplySensorExtrinsicsConfig()
+    forward: pd.DataFrame = apply_mounting_offset(
+        poses, extrinsics, ApplyMountingOffsetConfig()
     )
-    round_tripped: pd.DataFrame = apply_sensor_extrinsics(
-        forward, extrinsics, ApplySensorExtrinsicsConfig(invert=True)
+    round_tripped: pd.DataFrame = apply_mounting_offset(
+        forward, extrinsics, ApplyMountingOffsetConfig(invert=True)
     )
 
     assert round_tripped["latitude"].iloc[0] == pytest.approx(
@@ -121,41 +121,41 @@ def test_apply_sensor_extrinsics_invert_reverses_the_shift() -> None:
     )
 
 
-def test_step_apply_sensor_extrinsics_requires_extrinsics_input() -> None:
+def test_step_apply_mounting_offset_requires_extrinsics_input() -> None:
     frames = {"poses": _pose_frame()}
 
     with pytest.raises(KeyError):
-        step_apply_sensor_extrinsics(frames, ApplySensorExtrinsicsConfig())
+        step_apply_mounting_offset(frames, ApplyMountingOffsetConfig())
 
 
-def test_step_apply_sensor_extrinsics_rejects_multi_row_extrinsics() -> None:
+def test_step_apply_mounting_offset_rejects_multi_row_extrinsics() -> None:
     extrinsics_frame: pd.DataFrame = pd.concat(
         [_extrinsics_frame(_extrinsics(locx=1.0))] * 2, ignore_index=True
     )
     frames = {"poses": _pose_frame(), "extrinsics": extrinsics_frame}
 
     with pytest.raises(ValueError, match="expected exactly 1"):
-        step_apply_sensor_extrinsics(frames, ApplySensorExtrinsicsConfig())
+        step_apply_mounting_offset(frames, ApplyMountingOffsetConfig())
 
 
-def test_step_apply_sensor_extrinsics_matches_direct_call() -> None:
+def test_step_apply_mounting_offset_matches_direct_call() -> None:
     extrinsics: SensorExtrinsics = _extrinsics(locx=1.0, locy=0.5, locz=2.0)
     frames = {
         "poses": _pose_frame(),
         "extrinsics": _extrinsics_frame(extrinsics),
     }
 
-    from_step: pd.DataFrame = step_apply_sensor_extrinsics(
-        frames, ApplySensorExtrinsicsConfig()
+    from_step: pd.DataFrame = step_apply_mounting_offset(
+        frames, ApplyMountingOffsetConfig()
     )
-    direct: pd.DataFrame = apply_sensor_extrinsics(
-        frames["poses"], extrinsics, ApplySensorExtrinsicsConfig()
+    direct: pd.DataFrame = apply_mounting_offset(
+        frames["poses"], extrinsics, ApplyMountingOffsetConfig()
     )
 
     pd.testing.assert_frame_equal(from_step, direct)
 
 
-def test_apply_sensor_extrinsics_is_registered() -> None:
-    registered = default_registry().get("apply_sensor_extrinsics")
-    assert registered.processor is step_apply_sensor_extrinsics
-    assert registered.config_type is ApplySensorExtrinsicsConfig
+def test_apply_mounting_offset_is_registered() -> None:
+    registered = default_registry().get("apply_mounting_offset")
+    assert registered.processor is step_apply_mounting_offset
+    assert registered.config_type is ApplyMountingOffsetConfig

--- a/tests/test_bundle_processing_processor_registry.py
+++ b/tests/test_bundle_processing_processor_registry.py
@@ -82,7 +82,7 @@ def test_a_local_registry_does_not_leak_into_the_default_one() -> None:
 def test_default_registry_holds_every_shipped_processor() -> None:
     """Importing the package registers all processors it defines."""
     assert default_registry().names() == [
-        "apply_sensor_extrinsics",
+        "apply_mounting_offset",
         "correct_pressure_for_sea_level",
         "drop_columns",
         "estimate_dvl_uncertainty",


### PR DESCRIPTION
## Summary
- Rename the `apply_sensor_extrinsics` bundle pipeline processor (#271) to `apply_mounting_offset`, along with its config class (`ApplySensorExtrinsicsConfig` -> `ApplyMountingOffsetConfig`) and step function (`step_apply_sensor_extrinsics` -> `step_apply_mounting_offset`).
- The processor only ever compensated for the extrinsics' translation (lever arm) — it never reads or applies the extrinsics' mounting rotation, and pose attitude passes through unchanged — so `apply_sensor_extrinsics` overclaimed what it does. `apply_mounting_offset` names it accurately, and is the name settled on for #273, which was closed as already covered by this processor.

## Test plan
- `ruff check` / `ruff format --check` — pass
- `mypy src/afft` — pass
- `pytest` — 414 passed